### PR TITLE
feat: show "silent" notifications as low urgency in notification daemons

### DIFF
--- a/src/core/include/tether/bluetooth/ancs/notifications.hpp
+++ b/src/core/include/tether/bluetooth/ancs/notifications.hpp
@@ -73,6 +73,8 @@ namespace tether::bluetooth::ancs {
 
     // Messages arrive over MAP already, with read state that stays in sync. The
     // ANCS copy is kept for correlation but must never raise a second popup.
+    // Everything else is shown, silent included: iOS sets FlagSilent whenever the
+    // phone is muted or in a Focus mode, which means "make no noise", not "hide".
     bool should_show_desktop_popup(const Notification& notification);
 
     // Freedesktop icon names to try for a notification, best first: the app's

--- a/src/core/src/bluetooth/ancs/notifications.cpp
+++ b/src/core/src/bluetooth/ancs/notifications.cpp
@@ -115,11 +115,7 @@ namespace tether::bluetooth::ancs {
         return name;
     }
 
-    bool should_show_desktop_popup(const Notification& notification) {
-        if (notification.app_id == APP_ID_MESSAGES)
-            return false;
-        return !notification.silent;
-    }
+    bool should_show_desktop_popup(const Notification& notification) { return notification.app_id != APP_ID_MESSAGES; }
 
     std::vector<std::string> icon_candidates(const Notification& notification) {
         std::vector<std::string> out;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -205,7 +205,8 @@ int main(int argc, char** argv) {
                     notifier.notify({notification.app_name,
                                      title.empty() ? "iPhone" : title,
                                      body,
-                                     tether::bluetooth::ancs::icon_candidates(notification)});
+                                     tether::bluetooth::ancs::icon_candidates(notification),
+                                     notification.silent});
                 },
                 [](uint32_t uid) {
                     nlohmann::json event;

--- a/src/daemon/notification.cpp
+++ b/src/daemon/notification.cpp
@@ -190,6 +190,7 @@ namespace tether {
                 return G_SOURCE_REMOVE;
 
             set_identity(notification, spec->app_name);
+            notify_notification_set_urgency(notification, spec->quiet ? NOTIFY_URGENCY_LOW : NOTIFY_URGENCY_NORMAL);
 
             GError* error = nullptr;
             if (!notify_notification_show(notification, &error)) {

--- a/src/daemon/notification.hpp
+++ b/src/daemon/notification.hpp
@@ -15,6 +15,7 @@ namespace tether {
         std::string body;
         // Freedesktop icon names, best first.
         std::vector<std::string> icons;
+        bool quiet = false;
     };
 
     class DesktopNotifier {

--- a/test/test_ancs_sequencer.cpp
+++ b/test/test_ancs_sequencer.cpp
@@ -274,7 +274,7 @@ TEST(AncsNotifications, SuppressesDesktopPopupsForMessages) {
     Notification silent;
     silent.app_id = "com.example.chat";
     silent.silent = true;
-    EXPECT_FALSE(should_show_desktop_popup(silent)) << "the phone was told to stay quiet about this one";
+    EXPECT_TRUE(should_show_desktop_popup(silent)) << "a muted phone still wants the notification on screen";
 }
 
 TEST(AncsNotifications, KeepsRecentNotificationsNewestFirst) {


### PR DESCRIPTION
KDE hides notifications marked "silent". We now mark notifications with low urgency, but not silent. This maintains the noticiation in the NotifyDaemon's history but does not bug the user, which I think is the intent of the iPhone's "silent" flag

Additional Fix #17 