### PR TITLE
fix(gtk): message body should be from bmessage not MAP listing subject

### DIFF
--- a/src/core/src/bluetooth/bmessage.cpp
+++ b/src/core/src/bluetooth/bmessage.cpp
@@ -26,22 +26,19 @@ namespace tether::bluetooth {
             return text;
         }
 
-        // Splits on LF and drops a trailing CR, so CRLF and LF payloads parse the
-        // same way.
+        // Splits on CRLF, LF, or a bare CR, so a payload with any of the three
+        // parses the same way.
         std::vector<std::string> split_lines(const std::string& text) {
             std::vector<std::string> lines;
             size_t start = 0;
             while (start <= text.size()) {
-                size_t nl = text.find('\n', start);
+                size_t nl = text.find_first_of("\r\n", start);
                 if (nl == std::string::npos) {
                     lines.push_back(text.substr(start));
                     break;
                 }
-                std::string line = text.substr(start, nl - start);
-                if (!line.empty() && line.back() == '\r')
-                    line.pop_back();
-                lines.push_back(std::move(line));
-                start = nl + 1;
+                lines.push_back(text.substr(start, nl - start));
+                start = nl + (text[nl] == '\r' && nl + 1 < text.size() && text[nl + 1] == '\n' ? 2 : 1);
             }
             return lines;
         }
@@ -380,8 +377,8 @@ namespace tether::bluetooth {
             out += "\r\n";
         }
         // split_lines yields a trailing empty element for a body ending in a
-        // newline; drop the extra break it would introduce.
-        if (!body.empty() && body.back() != '\n' && out.size() >= 2)
+        // line break; drop the extra break it would introduce.
+        if (!body.empty() && body.back() != '\n' && body.back() != '\r' && out.size() >= 2)
             out.erase(out.size() - 2);
         return out;
     }

--- a/src/core/src/bluetooth/connection.cpp
+++ b/src/core/src/bluetooth/connection.cpp
@@ -10,6 +10,7 @@
 #include "tether/bluetooth/pbap_session.hpp"
 #include "tether/log.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -228,6 +229,10 @@ namespace tether::bluetooth {
         // notices. Consecutive listing failures are the cheapest liveness signal.
         constexpr int MAP_FAILURES_BEFORE_REOPEN = 3;
         constexpr int MESSAGE_LIST_MAX = 200;
+        // Bodies are fetched one OBEX Get at a time on the connection thread,
+        // which also has ANCS and the bearer supervisor. Needs cap to keep the
+        // first listing of a full mailbox from stalling all of it
+        constexpr size_t MESSAGE_BODY_FETCH_MAX = 20;
         constexpr int SUPERVISOR_TICK_SECONDS = 1;
 
         // Whether the controller can carry ANCS right now. Re-read rather than
@@ -736,22 +741,66 @@ namespace tether::bluetooth {
             }
         }
 
-        std::vector<Message> fresh;
+        // A listing reports the message text in Subject, which is a preview.
+        // Line breaks arrive flattened to spaces and a long one is cut. The
+        // bMessage is the only source of the real body, so every message not
+        // seen before costs one OBEX Get.
+        struct Pending {
+            Message message;
+            const MapListing* listing;
+        };
+
+        std::vector<Pending> unseen;
         {
             std::lock_guard<std::mutex> lock(g_messages_mutex);
             for (const auto& listing : listings) {
+                Message message = message_from_listing(listing);
+                if (message.thread_key.empty())
+                    continue;
+                if (!g_messages.find(message.handle)) {
+                    unseen.push_back({std::move(message), &listing});
+                    continue;
+                }
+                g_messages.add(message);
+                g_messages.set_read(message.handle, message.read);
+            }
+        }
+
+        // Newest first, so when the cap defers part of a backfill the messages
+        // the user is looking at are the ones that get their real body now.
+        std::sort(unseen.begin(), unseen.end(), [](const Pending& a, const Pending& b) {
+            return a.message.timestamp > b.message.timestamp;
+        });
+        if (unseen.size() > MESSAGE_BODY_FETCH_MAX)
+            unseen.resize(MESSAGE_BODY_FETCH_MAX);
+
+        for (auto& pending : unseen) {
+            BMessage parsed;
+            std::string body_err;
+            if (session->fetch_bmessage(pending.listing->handle, parsed, body_err))
+                pending.message.body = parsed.body;
+            else
+                debug::log(DEBUG,
+                           "bluetooth: no bMessage for {} ({}); keeping the listing preview",
+                           pending.message.handle,
+                           body_err);
+        }
+
+        std::vector<Message> fresh;
+        {
+            std::lock_guard<std::mutex> lock(g_messages_mutex);
+            for (auto& pending : unseen) {
+                const MapListing& listing = *pending.listing;
+                Message& message = pending.message;
+
                 // raw, before anything here can correct or discard it
-                if ((listing.sent || is_outgoing_folder(listing.folder)) && !g_messages.find(listing.handle))
+                if (listing.sent || is_outgoing_folder(listing.folder))
                     debug::log(DEBUG,
                                "bluetooth: phone lists sent msg folder='{}' recipient=[{}] sender=[{}] handle={}",
                                listing.folder,
                                listing.recipient_address,
                                listing.sender_address,
                                listing.handle);
-
-                Message message = message_from_listing(listing);
-                if (message.thread_key.empty())
-                    continue;
 
                 // MAP gives a group message one sender and no conversation
                 // identifier. The correlated Messages notification is the only

--- a/src/core/src/bluetooth/map_session.cpp
+++ b/src/core/src/bluetooth/map_session.cpp
@@ -2,9 +2,11 @@
 #include "tether/bluetooth/obex_transfer.hpp"
 #include "tether/log.hpp"
 
+#include <chrono>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <thread>
 #include <unistd.h>
 
 namespace tether::bluetooth {
@@ -20,6 +22,11 @@ namespace tether::bluetooth {
         constexpr int MAP_CALL_TIMEOUT_MS = 60000;
         constexpr int MAP_PUSH_CALL_TIMEOUT_MS = 15000;
         constexpr int MAP_PUSH_TIMEOUT_SECONDS = 30;
+        constexpr int MAP_GET_TIMEOUT_SECONDS = 15;
+        // obexd names the file before the transfer has written it, so it can
+        // still be a moment behind when the transfer settles.
+        constexpr int MAP_FILE_GRACE_SECONDS = 2;
+        constexpr int MAP_FILE_POLL_MS = 50;
 
         std::string variant_string(GVariant* value) {
             if (!value)
@@ -172,18 +179,43 @@ namespace tether::bluetooth {
         if (!reply)
             return take_error(error, err);
 
-        GVariant* props = g_variant_get_child_value(reply, 1);
-        GVariant* filename = g_variant_lookup_value(props, "Filename", G_VARIANT_TYPE_STRING);
+        const gchar* transfer_path = nullptr;
+        GVariant* props = nullptr;
+        g_variant_get(reply, "(&o@a{sv})", &transfer_path, &props);
+        const std::string transfer = transfer_path ? transfer_path : "";
+        GVariant* filename = props ? g_variant_lookup_value(props, "Filename", G_VARIANT_TYPE_STRING) : nullptr;
         const std::string path = filename ? g_variant_get_string(filename, nullptr) : "";
         if (filename)
             g_variant_unref(filename);
-        g_variant_unref(props);
+        if (props)
+            g_variant_unref(props);
         g_variant_unref(reply);
 
         if (path.empty()) {
             err = "transfer returned no filename";
             return false;
         }
+        if (transfer.empty()) {
+            err = "obexd returned no transfer object";
+            return false;
+        }
+
+        std::error_code ec;
+        const TransferState state = wait_for_transfer(state_->bus, transfer, MAP_GET_TIMEOUT_SECONDS);
+        if (state == TransferState::Error) {
+            err = "message transfer failed";
+            std::filesystem::remove(path, ec);
+            return false;
+        }
+        if (state == TransferState::Active) {
+            err = "message transfer timed out";
+            std::filesystem::remove(path, ec);
+            return false;
+        }
+
+        const auto grace = std::chrono::steady_clock::now() + std::chrono::seconds(MAP_FILE_GRACE_SECONDS);
+        while (!std::filesystem::exists(path, ec) && std::chrono::steady_clock::now() < grace)
+            std::this_thread::sleep_for(std::chrono::milliseconds(MAP_FILE_POLL_MS));
 
         std::ifstream in(path, std::ios::binary);
         if (!in.is_open()) {
@@ -191,6 +223,9 @@ namespace tether::bluetooth {
             return false;
         }
         std::string text((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        in.close();
+        std::filesystem::remove(path, ec);
+
         out = parse_bmessage(text);
         if (!out.valid) {
             err = "unparseable bMessage";

--- a/src/core/src/bluetooth/messages.cpp
+++ b/src/core/src/bluetooth/messages.cpp
@@ -1,6 +1,7 @@
 #include "tether/bluetooth/messages.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 
 namespace tether::bluetooth {
@@ -15,6 +16,24 @@ namespace tether::bluetooth {
             if (!party.tel.empty())
                 return normalize_phone(party.tel);
             return normalize_email(party.email);
+        }
+
+        // Every run of whitespace becomes one space, and the ends are dropped.
+        std::string collapse_whitespace(const std::string& text) {
+            std::string out;
+            bool pending = false;
+            for (unsigned char c : text) {
+                if (std::isspace(c)) {
+                    pending = !out.empty();
+                    continue;
+                }
+                if (pending) {
+                    out += ' ';
+                    pending = false;
+                }
+                out += static_cast<char>(c);
+            }
+            return out;
         }
 
     } // namespace
@@ -48,7 +67,11 @@ namespace tether::bluetooth {
             const Message& existing = it->second;
             if (!existing.outgoing || !is_local_handle(existing.handle))
                 continue;
-            if (existing.thread_key != arrived.thread_key || existing.body != arrived.body)
+            // The phone's copy is not byte-identical to what was typed. MAP
+            // listing reports the body with its line breaks flattened to
+            // spaces, so only the text itself can be compared.
+            if (existing.thread_key != arrived.thread_key ||
+                collapse_whitespace(existing.body) != collapse_whitespace(arrived.body))
                 continue;
             if (std::llabs(existing.timestamp - arrived.timestamp) > LOCAL_ECHO_WINDOW_SECONDS)
                 continue;
@@ -174,7 +197,7 @@ namespace tether::bluetooth {
             {"thread", thread.key},
             {"name", thread.display_name},
             {"address", thread.peer_address},
-            {"preview", thread.last_body},
+            {"preview", collapse_whitespace(thread.last_body)},
             {"timestamp", thread.last_timestamp},
             {"unread", thread.unread},
             {"count", thread.count},

--- a/test/test_bmessage.cpp
+++ b/test/test_bmessage.cpp
@@ -486,6 +486,20 @@ TEST(MessageStore, PhoneCopySupersedesTheLocalEcho) {
     EXPECT_EQ(messages[0].handle, "m9") << "the phone's copy is the one with a usable handle";
 }
 
+// A MAP listing reports the body with its line breaks flattened to spaces, so
+// the phone's copy of a multi-line reply never matches the local echo byte for
+// byte. Comparing the text alone is what keeps it from showing up twice.
+TEST(MessageStore, MultiLineEchoSurvivesAFlattenedPhoneCopy) {
+    MessageStore store;
+    ASSERT_TRUE(store.add(local_send("tel:+1111", "on my way\nsee you soon", 1000)));
+    ASSERT_TRUE(store.add(phone_copy("m9", "tel:+1111", "on my way see you soon", 1005)));
+
+    EXPECT_EQ(store.size(), 1u);
+    auto messages = store.messages("tel:+1111");
+    ASSERT_EQ(messages.size(), 1u);
+    EXPECT_EQ(messages[0].handle, "m9");
+}
+
 TEST(MessageStore, UnrelatedOutgoingMessagesAreNotCollapsed) {
     MessageStore store;
     store.add(local_send("tel:+1111", "on my way", 1000));
@@ -542,4 +556,46 @@ TEST(BMessageParse, LeavesAnUntaggedAddressAlone) {
                                       "END:BMSG\r\n");
     ASSERT_TRUE(m.valid);
     EXPECT_EQ(m.originator.email, "ab@icloud.com");
+}
+
+namespace {
+
+    // Same message in each of the three line endings a phone might use, with a
+    // two-line body.
+    std::string two_line_bmessage(const std::string& eol) {
+        const std::string lines[] = {"BEGIN:BMSG",
+                                     "VERSION:1.0",
+                                     "STATUS:UNREAD",
+                                     "TYPE:SMS_GSM",
+                                     "FOLDER:telecom/msg/inbox",
+                                     "BEGIN:VCARD",
+                                     "VERSION:2.1",
+                                     "TEL:+15551234567",
+                                     "END:VCARD",
+                                     "BEGIN:BENV",
+                                     "BEGIN:BBODY",
+                                     "CHARSET:UTF-8",
+                                     "BEGIN:MSG",
+                                     "first line",
+                                     "second line",
+                                     "END:MSG",
+                                     "END:BBODY",
+                                     "END:BENV",
+                                     "END:BMSG"};
+        std::string out;
+        for (const auto& line : lines)
+            out += line + eol;
+        return out;
+    }
+
+} // namespace
+
+// The body is what the conversation shows, so its line breaks have to survive
+// the parser whichever ending the phone wrote them with.
+TEST(BMessage, MultiLineBodyKeepsItsLineBreaks) {
+    for (const std::string& eol : {std::string("\r\n"), std::string("\n"), std::string("\r")}) {
+        const BMessage parsed = parse_bmessage(two_line_bmessage(eol));
+        ASSERT_TRUE(parsed.valid);
+        EXPECT_EQ(parsed.body, "first line\nsecond line");
+    }
 }


### PR DESCRIPTION
The GTK app showed messages from the MAP listings "subject", not the real bMessage body from OBEX. Basically a preview text vs the real message. MAP listing subject is, first of all the wrong body to be showing, and also normalizes CRLF to space. This means newlines get turned into spaces and look weird. 

Fixes #27 and #28 