### PR TITLE
feat(gtk): notification "reply" action and tab selector

### DIFF
--- a/docs/man/man1/tether-gtk.1.in
+++ b/docs/man/man1/tether-gtk.1.in
@@ -4,6 +4,8 @@ tether-gtk \- Graphical interface for Tether
 .SH SYNOPSIS
 .B tether-gtk
 [\fB\-\-tray\fR]
+[\fB\-\-devices\fR | \fB\-\-messages\fR | \fB\-\-notifications\fR]
+[\fB\-\-thread\fR=\fIKEY\fR]
 .SH DESCRIPTION
 .B tether-gtk
 is a GTK-based graphical application for managing Tether connections and devices.
@@ -24,6 +26,15 @@ start it automatically.
 .B \-\-tray
 Start without showing the window. The application is reachable only from its
 tray icon until \fBOpen Tether\fR is chosen.
+.TP
+.B \-\-devices\fR, \fB\-\-messages\fR, \fB\-\-notifications
+Open on that tab. When \fBtether-gtk\fR is already running the existing window
+is raised and switched instead of a second one being started.
+.TP
+.B \-\-thread=\fIKEY\fR
+Open the messages tab on the conversation with this thread key, for example
+\fBtel:+15551234567\fR. This is what the \fBReply\fR button on a message
+notification uses.
 .SH SEE ALSO
 .BR tether (1),
 .BR tetherd (8)

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -150,7 +150,9 @@ int main(int argc, char** argv) {
             notifier.notify({"Messages",
                              who.empty() ? "iPhone" : who,
                              message.body,
-                             tether::bluetooth::ancs::icon_candidates(as_notification)});
+                             tether::bluetooth::ancs::icon_candidates(as_notification),
+                             false,
+                             message.thread_key});
         });
     if (bluez.start()) {
         tether::bluetooth::g_bluez = &bluez;

--- a/src/daemon/notification.cpp
+++ b/src/daemon/notification.cpp
@@ -94,7 +94,7 @@ namespace tether {
         }
 
         struct NotificationActionData {
-            std::string uri;
+            std::string payload;
         };
 
         void free_request(gpointer data) { delete static_cast<NotificationRequest*>(data); }
@@ -117,13 +117,38 @@ namespace tether {
             return true;
         }
 
+        // Hitting an already-running GUI is GApplication's job. A second launch is routed to the primary instance
+        // rather than starting a new window.
+        void open_gui_thread(const std::string& thread_key) {
+            std::string argument = "--thread=" + thread_key;
+            char* argv[] = {const_cast<char*>("tether-gtk"), argument.data(), nullptr};
+            GError* error = nullptr;
+            if (!g_spawn_async(nullptr,
+                               argv,
+                               nullptr,
+                               static_cast<GSpawnFlags>(G_SPAWN_SEARCH_PATH | G_SPAWN_STDOUT_TO_DEV_NULL |
+                                                        G_SPAWN_STDERR_TO_DEV_NULL),
+                               nullptr,
+                               nullptr,
+                               nullptr,
+                               &error)) {
+                debug::log(ERR, "Failed to open tether-gtk: {}", error ? error->message : "unknown");
+                g_clear_error(&error);
+            }
+        }
+
+        void on_reply_action(NotifyNotification*, char*, gpointer user_data) {
+            if (auto* action = static_cast<NotificationActionData*>(user_data))
+                open_gui_thread(action->payload);
+        }
+
         void on_notification_action(NotifyNotification*, char*, gpointer user_data) {
             auto* action = static_cast<NotificationActionData*>(user_data);
             if (!action) {
                 return;
             }
 
-            launch_uri(action->uri);
+            launch_uri(action->payload);
         }
 
         void on_notification_closed(NotifyNotification* notification, gpointer) { g_object_unref(notification); }
@@ -192,12 +217,32 @@ namespace tether {
             set_identity(notification, spec->app_name);
             notify_notification_set_urgency(notification, spec->quiet ? NOTIFY_URGENCY_LOW : NOTIFY_URGENCY_NORMAL);
 
+            const bool has_actions = !spec->reply_thread.empty();
+            if (has_actions) {
+                g_signal_connect(notification, "closed", G_CALLBACK(on_notification_closed), nullptr);
+                notify_notification_add_action(notification,
+                                               "default",
+                                               "default",
+                                               on_reply_action,
+                                               new NotificationActionData{spec->reply_thread},
+                                               free_action_data);
+                notify_notification_add_action(notification,
+                                               "reply",
+                                               "Reply",
+                                               on_reply_action,
+                                               new NotificationActionData{spec->reply_thread},
+                                               free_action_data);
+            }
+
             GError* error = nullptr;
             if (!notify_notification_show(notification, &error)) {
                 debug::log(ERR, "Failed to show notification: {}", error ? error->message : "unknown");
                 g_clear_error(&error);
+                g_object_unref(notification);
+                return G_SOURCE_REMOVE;
             }
-            g_object_unref(notification);
+            if (!has_actions)
+                g_object_unref(notification);
             return G_SOURCE_REMOVE;
         }
 

--- a/src/daemon/notification.hpp
+++ b/src/daemon/notification.hpp
@@ -16,6 +16,7 @@ namespace tether {
         // Freedesktop icon names, best first.
         std::vector<std::string> icons;
         bool quiet = false;
+        std::string reply_thread;
     };
 
     class DesktopNotifier {
@@ -29,7 +30,6 @@ namespace tether {
         bool init();
         void notify_file_arrived(const std::filesystem::path& path);
 
-        // A plain notification with no actions.
         void notify(const NotificationSpec& spec);
 
     private:

--- a/src/gtk/main.cpp
+++ b/src/gtk/main.cpp
@@ -6,6 +6,7 @@
 #include "ui_util.hpp"
 
 #include <gtk/gtk.h>
+#include <string>
 #include <tether/crypto.hpp>
 
 namespace {
@@ -13,7 +14,25 @@ namespace {
     using namespace tether::ui;
 
     GtkWidget* g_refresh_button = nullptr;
+    GtkWidget* g_stack = nullptr;
     gboolean g_start_hidden = FALSE;
+
+    // what the current invocation asked to see
+    std::string g_requested_view;
+    std::string g_requested_thread;
+
+    void apply_requested_view() {
+        if (!g_stack)
+            return;
+        if (!g_requested_thread.empty())
+            g_requested_view = "messages";
+        if (!g_requested_view.empty())
+            gtk_stack_set_visible_child_name(GTK_STACK(g_stack), g_requested_view.c_str());
+        if (!g_requested_thread.empty())
+            messages_view_open_thread(g_requested_thread);
+        g_requested_view.clear();
+        g_requested_thread.clear();
+    }
 
     void on_visible_view_changed(GObject* stack, GParamSpec*, gpointer) {
         const gchar* name = gtk_stack_get_visible_child_name(GTK_STACK(stack));
@@ -100,6 +119,7 @@ namespace {
         gtk_header_bar_pack_start(GTK_HEADER_BAR(header_bar), g_refresh_button);
 
         GtkWidget* stack = gtk_stack_new();
+        g_stack = stack;
         gtk_stack_set_transition_type(GTK_STACK(stack), GTK_STACK_TRANSITION_TYPE_CROSSFADE);
         gtk_stack_add_titled(GTK_STACK(stack), devices_view_new(), "devices", "Devices");
         gtk_stack_add_titled(GTK_STACK(stack), messages_view_new(), "messages", "Messages");
@@ -142,7 +162,7 @@ namespace {
 } // namespace
 
 int main(int argc, char** argv) {
-    GtkApplication* app = gtk_application_new("com.tether.desktop", G_APPLICATION_DEFAULT_FLAGS);
+    GtkApplication* app = gtk_application_new("com.tether.desktop", G_APPLICATION_HANDLES_COMMAND_LINE);
     g_application_add_main_option(G_APPLICATION(app),
                                   "tray",
                                   0,
@@ -150,12 +170,35 @@ int main(int argc, char** argv) {
                                   G_OPTION_ARG_NONE,
                                   "Start hidden in the system tray",
                                   nullptr);
+    for (const char* view : {"devices", "messages", "notifications"}) {
+        g_application_add_main_option(
+            G_APPLICATION(app), view, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, "Open on this tab", nullptr);
+    }
+    g_application_add_main_option(G_APPLICATION(app),
+                                  "thread",
+                                  0,
+                                  G_OPTION_FLAG_NONE,
+                                  G_OPTION_ARG_STRING,
+                                  "Open the messages tab on this conversation",
+                                  "KEY");
+
     g_signal_connect(app,
-                     "handle-local-options",
-                     G_CALLBACK(+[](GApplication*, GVariantDict* options, gpointer) -> gint {
+                     "command-line",
+                     G_CALLBACK(+[](GApplication* app, GApplicationCommandLine* cmdline, gpointer) -> gint {
+                         GVariantDict* options = g_application_command_line_get_options_dict(cmdline);
                          if (g_variant_dict_contains(options, "tray"))
                              g_start_hidden = TRUE;
-                         return -1;
+                         for (const char* view : {"devices", "messages", "notifications"}) {
+                             if (g_variant_dict_contains(options, view))
+                                 g_requested_view = view;
+                         }
+                         const gchar* thread = nullptr;
+                         if (g_variant_dict_lookup(options, "thread", "&s", &thread) && thread)
+                             g_requested_thread = thread;
+
+                         g_application_activate(app);
+                         apply_requested_view();
+                         return 0;
                      }),
                      nullptr);
     g_signal_connect(app, "activate", G_CALLBACK(activate), nullptr);

--- a/src/gtk/messages_view.cpp
+++ b/src/gtk/messages_view.cpp
@@ -53,6 +53,8 @@ namespace tether::ui {
             // why not when it cannot.
             bool selected_repliable = false;
             std::string selected_block_reason;
+            // A conversation opened from outside the list is a reply that is already under way
+            bool focus_composer = false;
 
             // Addressing a message to someone with no conversation yet.
             bool composing = false;
@@ -266,6 +268,12 @@ namespace tether::ui {
 
             if (g_messages.thread_selected_handler)
                 g_signal_handler_unblock(g_messages.thread_list, g_messages.thread_selected_handler);
+
+            if (g_messages.focus_composer) {
+                g_messages.focus_composer = false;
+                if (gtk_widget_is_sensitive(g_messages.composer))
+                    gtk_widget_grab_focus(g_messages.composer);
+            }
         }
 
         void show_messages(const nlohmann::json& event) {
@@ -725,6 +733,21 @@ namespace tether::ui {
         g_messages.marked_read.clear();
         update_composer_sensitivity();
         set_banner("The Tether daemon is not running.");
+    }
+
+    void messages_view_open_thread(const std::string& thread_key) {
+        if (thread_key.empty())
+            return;
+        leave_compose();
+        g_messages.selected_thread = thread_key;
+        g_messages.selected_name.clear();
+        g_messages.selected_repliable = false;
+        g_messages.selected_block_reason.clear();
+        g_messages.focus_composer = true;
+        gtk_stack_set_visible_child_name(GTK_STACK(g_messages.placeholder_stack), "conversation");
+        update_composer_sensitivity();
+        request_threads();
+        request_messages(thread_key);
     }
 
     void messages_view_set_visible(bool visible) {

--- a/src/gtk/messages_view.hpp
+++ b/src/gtk/messages_view.hpp
@@ -2,6 +2,7 @@
 
 #include <gtk/gtk.h>
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace tether::ui {
 
@@ -11,6 +12,10 @@ namespace tether::ui {
 
     // Returns true when the event belonged to this view.
     bool messages_view_handle_event(const nlohmann::json& event);
+
+    // Selects a conversation by thread key, as the notification Reply action and
+    // the --thread option do. Switching to the messages view is the caller's job.
+    void messages_view_open_thread(const std::string& thread_key);
 
     // Threads are only pulled while someone is looking at them, so the view has
     // to be told when it comes and goes.


### PR DESCRIPTION
- Adds a "Reply" button (action) to notifications which opens the GUI app to the message thread it came from. Input is focused for quick reply.
- Adds flags `--devices` `--messages` `--notifications` to open the GUI app to the corresponding tab.

Fixes https://github.com/zackb/tether/issues/30 

Thanks to @orychalk for the idea!