### PR TITLE
fix: alpha sender ID has no thread key

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,11 @@ make install
 - [ ] Implement TOTP/OTP vault with Safari autofill
 - [ ] Explore macOS support
 
-## Contributing
+## Acknowledgements
+[ancs4linux](https://github.com/pzmarzly/ancs4linux) for pioneering the ANCS notifications technique.
+[iphonebridge](https://github.com/gabrielmeir53/iphonebridge) for the research on MAP Messages.
+@orychalk for many many feature ideas, bug reports, beta testing
+
 
 Contributions are welcome!
 

--- a/src/core/include/tether/bluetooth/messages.hpp
+++ b/src/core/include/tether/bluetooth/messages.hpp
@@ -23,6 +23,10 @@ namespace tether::bluetooth {
     // True for a MAP folder holding messages the phone sent.
     bool is_outgoing_folder(const std::string& folder);
 
+    // The other party's address as the UI should show it: a normalized number or
+    // email, or the raw sender ID when it is neither.
+    std::string display_address(const VCardParty& party);
+
     struct Message {
         std::string handle;
         std::string object_path;

--- a/src/core/src/bluetooth/bmessage.cpp
+++ b/src/core/src/bluetooth/bmessage.cpp
@@ -232,13 +232,34 @@ namespace tether::bluetooth {
         return out;
     }
 
+    namespace {
+        bool has_letter(const std::string& text) {
+            return std::any_of(text.begin(), text.end(), [](unsigned char c) { return std::isalpha(c) != 0; });
+        }
+
+        // sender ID -> one spelling: printable, no spaces, lowercase.
+        std::string sender_key(const std::string& raw) {
+            std::string out;
+            for (unsigned char c : raw) {
+                if (c <= 0x20 || c == 0x7f)
+                    continue;
+                out += static_cast<char>(std::tolower(c));
+            }
+            return out.empty() ? std::string{} : "sender:" + out;
+        }
+    } // namespace
+
     std::string thread_key_for(const VCardParty& party) {
         // A phone number wins when both are present: it is what the phone routes
         // SMS on, and it is the more stable of the two.
         if (!party.tel.empty()) {
-            std::string tel = normalize_phone(party.tel);
-            if (!tel.empty())
+            // Providers send OTP SMS from an alphanumeric sender ID, identity, not a number
+            if (has_letter(party.tel)) {
+                if (std::string sender = sender_key(party.tel); !sender.empty())
+                    return sender;
+            } else if (std::string tel = normalize_phone(party.tel); !tel.empty()) {
                 return "tel:" + tel;
+            }
         }
         if (!party.email.empty()) {
             std::string email = normalize_email(party.email);

--- a/src/core/src/bluetooth/connection.cpp
+++ b/src/core/src/bluetooth/connection.cpp
@@ -794,8 +794,16 @@ namespace tether::bluetooth {
             std::lock_guard<std::mutex> lock(g_messages_mutex);
             for (const auto& listing : listings) {
                 Message message = message_from_listing(listing);
-                if (message.thread_key.empty())
+                if (message.thread_key.empty()) {
+                    debug::log(WARN,
+                               "bluetooth: dropping message {} from folder '{}': no usable address "
+                               "(sender='{}' address='{}')",
+                               listing.handle,
+                               listing.folder,
+                               listing.sender_name,
+                               listing.sender_address);
                     continue;
+                }
                 if (!g_messages.find(message.handle)) {
                     unseen.push_back({std::move(message), &listing});
                     continue;

--- a/src/core/src/bluetooth/map_session.cpp
+++ b/src/core/src/bluetooth/map_session.cpp
@@ -398,7 +398,7 @@ namespace tether::bluetooth {
         // Empty when the phone gave no usable address for the other end. The
         // caller drops those rather than filing them under a guess.
         message.thread_key = thread_key_for(peer);
-        message.peer_address = peer.tel.empty() ? normalize_email(peer.email) : normalize_phone(peer.tel);
+        message.peer_address = display_address(peer);
         message.peer_name = peer.name;
         return message;
     }

--- a/src/core/src/bluetooth/messages.cpp
+++ b/src/core/src/bluetooth/messages.cpp
@@ -12,12 +12,6 @@ namespace tether::bluetooth {
 
     namespace {
 
-        std::string display_address(const VCardParty& party) {
-            if (!party.tel.empty())
-                return normalize_phone(party.tel);
-            return normalize_email(party.email);
-        }
-
         // Every run of whitespace becomes one space, and the ends are dropped.
         std::string collapse_whitespace(const std::string& text) {
             std::string out;
@@ -50,6 +44,13 @@ namespace tether::bluetooth {
         }
 
     } // namespace
+
+    std::string display_address(const VCardParty& party) {
+        if (party.tel.empty())
+            return normalize_email(party.email);
+        std::string tel = normalize_phone(party.tel);
+        return tel.empty() ? collapse_whitespace(party.tel) : tel;
+    }
 
     MessageStore::MessageStore(size_t max_messages) : max_messages_(max_messages) {}
 

--- a/src/core/src/net.cpp
+++ b/src/core/src/net.cpp
@@ -474,7 +474,15 @@ namespace tether {
         // guards, and std::mutex is not recursive.
         for (auto& entry : threads) {
             if (!entry.value("group", false)) {
-                entry["repliable"] = true;
+                // An alphanumeric sender ID has no route back, so the composer must not accept text the phone would
+                // bounce.
+                bluetooth::Recipient recipient;
+                std::string reason;
+                const bool repliable =
+                    bluetooth::recipient_from_thread_key(entry.value("thread", ""), recipient, reason);
+                entry["repliable"] = repliable;
+                if (!repliable)
+                    entry["reply_reason"] = reason;
                 continue;
             }
             std::string reason;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -205,12 +205,17 @@ int main(int argc, char** argv) {
                 who = message.peer_name.empty() ? message.peer_address : message.peer_name;
             tether::bluetooth::ancs::Notification as_notification;
             as_notification.app_id = tether::bluetooth::ancs::APP_ID_MESSAGES;
+            // The reply action is only offered for a thread that has a route back.
+            tether::bluetooth::Recipient recipient;
+            std::string reply_error;
+            const bool repliable =
+                tether::bluetooth::recipient_from_thread_key(message.thread_key, recipient, reply_error);
             notifier.notify({_("Messages"),
                              who.empty() ? "iPhone" : who,
                              message.body,
                              tether::bluetooth::ancs::icon_candidates(as_notification),
                              false,
-                             message.thread_key,
+                             repliable ? message.thread_key : std::string{},
                              otp});
         });
     if (bluez.start()) {

--- a/test/test_bmessage.cpp
+++ b/test/test_bmessage.cpp
@@ -165,6 +165,37 @@ TEST(AddressIdentity, ThreadKeyPrefersTelAndNamespacesTypes) {
     EXPECT_TRUE(thread_key_for(VCardParty{}).empty());
 }
 
+// Providers send OTP SMS from an alphanumeric sender ID. Keyed on the id itself:
+// normalizing it as a phone number leaves nothing, and the message is dropped.
+TEST(AddressIdentity, AlphanumericSenderKeepsItsOwnKey) {
+    VCardParty sender;
+    sender.tel = "MMA";
+    EXPECT_EQ(thread_key_for(sender), "sender:mma");
+
+    VCardParty spelled_differently;
+    spelled_differently.tel = "  mma ";
+    EXPECT_EQ(thread_key_for(spelled_differently), thread_key_for(sender));
+
+    // Digits inside a sender id are not a phone number, and must not be keyed as
+    // one: "tel:123" belongs to whoever really has that number.
+    VCardParty mixed;
+    mixed.tel = "MMA-123";
+    EXPECT_EQ(thread_key_for(mixed), "sender:mma-123");
+
+    VCardParty number;
+    number.tel = "+15551234567";
+    EXPECT_EQ(thread_key_for(number), "tel:+15551234567");
+
+    // Control characters never reach a key; the id around them survives.
+    VCardParty noisy;
+    noisy.tel = "M\x01MA";
+    EXPECT_EQ(thread_key_for(noisy), "sender:mma");
+
+    VCardParty junk;
+    junk.tel = "\x01\x02";
+    EXPECT_TRUE(thread_key_for(junk).empty());
+}
+
 // The display name is not identity; two contacts sharing a name must stay apart.
 TEST(AddressIdentity, NameDoesNotAffectThreadKey) {
     VCardParty a;


### PR DESCRIPTION
This causes tether to drop some SMS messages from the UI
Addresses https://github.com/zackb/tether/issues/60