### PR TITLE
Improve pairing reliability and Bluetooth status feedback

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -175,7 +175,9 @@ Instructs the daemon to asynchronously reach out to a specific host to initiate 
 ### `accept_device` (Local Client -> Daemon)
 Trusts a pending pair request by moving the target fingerprint into the daemon's internal secure `known_hosts.json`.
 **Payload**: `{"command": "accept_device", "fingerprint": "12:aa:bb:cc..."}`
-**Response**: The daemon synchronously broadcasts `pair_accepted` with the `fingerprint` and resolved `device_name`.
+**Response**: The daemon promotes any matching live TLS session, notifies the phone and local subscribers,
+then replies with `{"command":"accept_device_result","accepted":true,"connected":true}`. `connected` is false
+when the trust record was saved for a device that is no longer connected.
 
 ### `send_file` (Local Client -> Daemon)
 Offloads an entire file transfer to the daemon. The daemon spawns a thread to read the local filesystem and pushes the chunks sequence securely.

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -931,6 +931,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth není na tomto stroji dostupné."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Hledání zařízení v okolí..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Plný režim — zprávy, kontakty a oznámení."
 
@@ -1060,10 +1064,6 @@ msgid "Unknown Device"
 msgstr "Neznámé zařízení"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Hledání zařízení v okolí..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Připojeno"
 
@@ -1074,6 +1074,10 @@ msgstr "Offline"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "V okolí (klepnutím spárujete)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Částečně připojeno"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1291,6 +1295,14 @@ msgid "Today"
 msgstr "Dnes"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "Pro synchronizaci zpráv je potřeba připojení Bluetooth."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Vyberte konverzaci"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Odesílání…"
 
@@ -1325,10 +1337,6 @@ msgstr "Nová zpráva"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Hledat konverzace"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Vyberte konverzaci"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -951,6 +951,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth ist auf diesem Rechner nicht verfügbar."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Suche nach Geräten in der Nähe..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Vollmodus — Nachrichten, Kontakte und Mitteilungen."
 
@@ -1086,10 +1090,6 @@ msgid "Unknown Device"
 msgstr "Unbekanntes Gerät"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Suche nach Geräten in der Nähe..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Verbunden"
 
@@ -1100,6 +1100,10 @@ msgstr "Offline"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "In der Nähe (zum Koppeln tippen)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Teilweise verbunden"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1317,6 +1321,16 @@ msgid "Today"
 msgstr "Heute"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr ""
+"Zum Synchronisieren von Nachrichten ist eine Bluetooth-Verbindung "
+"erforderlich."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Wählen Sie eine Unterhaltung"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Wird gesendet…"
 
@@ -1354,10 +1368,6 @@ msgstr "Neue Nachricht"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Unterhaltungen durchsuchen"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Wählen Sie eine Unterhaltung"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -944,6 +944,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth no está disponible en este equipo."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Buscando dispositivos cercanos..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Modo completo — mensajes, contactos y notificaciones."
 
@@ -1077,10 +1081,6 @@ msgid "Unknown Device"
 msgstr "Dispositivo desconocido"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Buscando dispositivos cercanos..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Conectado"
 
@@ -1091,6 +1091,10 @@ msgstr "Desconectado"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "Cerca (toque para emparejar)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Parcialmente conectado"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1308,6 +1312,14 @@ msgid "Today"
 msgstr "Hoy"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "Se necesita una conexión Bluetooth para sincronizar los mensajes."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Seleccione una conversación"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Enviando…"
 
@@ -1343,10 +1355,6 @@ msgstr "Mensaje nuevo"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Buscar conversaciones"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Seleccione una conversación"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -949,6 +949,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth est indisponible sur cette machine."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Recherche d'appareils à proximité..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Mode complet — messages, contacts et notifications."
 
@@ -1083,10 +1087,6 @@ msgid "Unknown Device"
 msgstr "Appareil inconnu"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Recherche d'appareils à proximité..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Connecté"
 
@@ -1097,6 +1097,10 @@ msgstr "Hors ligne"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "À proximité (toucher pour appairer)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Partiellement connecté"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1314,6 +1318,14 @@ msgid "Today"
 msgstr "Aujourd'hui"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "Une connexion Bluetooth est nécessaire pour synchroniser les messages."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Sélectionnez une conversation"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Envoi…"
 
@@ -1349,10 +1361,6 @@ msgstr "Nouveau message"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Rechercher des conversations"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Sélectionnez une conversation"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -943,6 +943,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth non è disponibile su questa macchina."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Ricerca di dispositivi nelle vicinanze..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Modalità completa — messaggi, contatti e notifiche."
 
@@ -1074,10 +1078,6 @@ msgid "Unknown Device"
 msgstr "Dispositivo sconosciuto"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Ricerca di dispositivi nelle vicinanze..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Connesso"
 
@@ -1088,6 +1088,10 @@ msgstr "Offline"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "Nelle vicinanze (tocca per accoppiare)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Parzialmente connesso"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1304,6 +1308,14 @@ msgid "Today"
 msgstr "Oggi"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "È necessaria una connessione Bluetooth per sincronizzare i messaggi."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Seleziona una conversazione"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Invio…"
 
@@ -1341,10 +1353,6 @@ msgstr "Nuovo messaggio"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Cerca conversazioni"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Seleziona una conversazione"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -914,6 +914,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "このマシンでは Bluetooth を利用できません。"
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "近くのデバイスを検索しています..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "フルモード — メッセージ、連絡先、通知。"
 
@@ -1046,10 +1050,6 @@ msgid "Unknown Device"
 msgstr "不明なデバイス"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "近くのデバイスを検索しています..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "接続済み"
 
@@ -1060,6 +1060,10 @@ msgstr "オフライン"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "近くにあります (タップしてペアリング)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "部分的に接続"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1273,6 +1277,14 @@ msgid "Today"
 msgstr "今日"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "メッセージの同期にはBluetooth接続が必要です。"
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "会話を選択"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "送信中…"
 
@@ -1309,10 +1321,6 @@ msgstr "新規メッセージ"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "会話を検索"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "会話を選択"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -908,6 +908,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "이 컴퓨터에서는 Bluetooth를 사용할 수 없습니다."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "근처 기기를 검색하는 중..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "전체 모드 — 메시지, 연락처, 알림."
 
@@ -1036,10 +1040,6 @@ msgid "Unknown Device"
 msgstr "알 수 없는 기기"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "근처 기기를 검색하는 중..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "연결됨"
 
@@ -1050,6 +1050,10 @@ msgstr "오프라인"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "근처 (탭하여 페어링)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "부분적으로 연결됨"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1261,6 +1265,14 @@ msgid "Today"
 msgstr "오늘"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "메시지를 동기화하려면 Bluetooth 연결이 필요합니다."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "대화 선택"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "보내는 중…"
 
@@ -1295,10 +1307,6 @@ msgstr "새 메시지"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "대화 검색"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "대화 선택"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -938,6 +938,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth is niet beschikbaar op deze machine."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Zoeken naar apparaten in de buurt..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Volledige modus — berichten, contacten en meldingen."
 
@@ -1070,10 +1074,6 @@ msgid "Unknown Device"
 msgstr "Onbekend apparaat"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Zoeken naar apparaten in de buurt..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Verbonden"
 
@@ -1084,6 +1084,10 @@ msgstr "Offline"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "In de buurt (tik om te koppelen)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Gedeeltelijk verbonden"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1300,6 +1304,14 @@ msgid "Today"
 msgstr "Vandaag"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "Er is een Bluetooth-verbinding nodig om berichten te synchroniseren."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Selecteer een gesprek"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Versturen…"
 
@@ -1334,10 +1346,6 @@ msgstr "Nieuw bericht"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Gesprekken doorzoeken"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Selecteer een gesprek"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -941,6 +941,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth jest niedostępny na tej maszynie."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Wyszukiwanie urządzeń w pobliżu..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Tryb pełny — wiadomości, kontakty i powiadomienia."
 
@@ -1072,10 +1076,6 @@ msgid "Unknown Device"
 msgstr "Nieznane urządzenie"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Wyszukiwanie urządzeń w pobliżu..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Połączono"
 
@@ -1086,6 +1086,10 @@ msgstr "Offline"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "W pobliżu (dotknij, aby sparować)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Częściowo połączono"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1304,6 +1308,14 @@ msgid "Today"
 msgstr "Dzisiaj"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "Do synchronizacji wiadomości wymagane jest połączenie Bluetooth."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Wybierz rozmowę"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Wysyłanie…"
 
@@ -1340,10 +1352,6 @@ msgstr "Nowa wiadomość"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Szukaj rozmów"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Wybierz rozmowę"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -938,6 +938,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "O Bluetooth está indisponível nesta máquina."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Procurando dispositivos por perto..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Modo completo — mensagens, contatos e notificações."
 
@@ -1068,10 +1072,6 @@ msgid "Unknown Device"
 msgstr "Dispositivo desconhecido"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Procurando dispositivos por perto..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Conectado"
 
@@ -1082,6 +1082,10 @@ msgstr "Offline"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "Por perto (toque para parear)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Parcialmente conectado"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1298,6 +1302,14 @@ msgid "Today"
 msgstr "Hoje"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "É necessária uma conexão Bluetooth para sincronizar as mensagens."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Selecione uma conversa"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Enviando…"
 
@@ -1333,10 +1345,6 @@ msgstr "Nova mensagem"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Pesquisar conversas"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Selecione uma conversa"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -939,6 +939,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth недоступен на этой машине."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Поиск устройств поблизости..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Полный режим — сообщения, контакты и уведомления."
 
@@ -1072,10 +1076,6 @@ msgid "Unknown Device"
 msgstr "Неизвестное устройство"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Поиск устройств поблизости..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Подключено"
 
@@ -1086,6 +1086,10 @@ msgstr "Не в сети"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "Поблизости (нажмите, чтобы создать пару)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Подключено частично"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1304,6 +1308,14 @@ msgid "Today"
 msgstr "Сегодня"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "Для синхронизации сообщений требуется подключение Bluetooth."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Выберите переписку"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Отправка…"
 
@@ -1338,10 +1350,6 @@ msgstr "Новое сообщение"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Поиск переписок"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Выберите переписку"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -926,6 +926,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth är otillgängligt på den här maskinen."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Söker efter enheter i närheten..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Fullt läge — meddelanden, kontakter och aviseringar."
 
@@ -1055,10 +1059,6 @@ msgid "Unknown Device"
 msgstr "Okänd enhet"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Söker efter enheter i närheten..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Ansluten"
 
@@ -1069,6 +1069,10 @@ msgstr "Offline"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "I närheten (tryck för att parkoppla)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Delvis ansluten"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1286,6 +1290,14 @@ msgid "Today"
 msgstr "Idag"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "En Bluetooth-anslutning krävs för att synkronisera meddelanden."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Välj en konversation"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Skickar…"
 
@@ -1320,10 +1332,6 @@ msgstr "Nytt meddelande"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Sök konversationer"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Välj en konversation"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: tether 0.2.18\n"
+"Project-Id-Version: tether 0.2.19\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -838,6 +838,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr ""
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr ""
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr ""
 
@@ -961,10 +965,6 @@ msgid "Unknown Device"
 msgstr ""
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr ""
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr ""
 
@@ -974,6 +974,10 @@ msgstr ""
 
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
 msgstr ""
 
 #: src/gtk/devices_view.cpp
@@ -1167,6 +1171,14 @@ msgid "Today"
 msgstr ""
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr ""
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr ""
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr ""
 
@@ -1200,10 +1212,6 @@ msgstr ""
 
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
-msgstr ""
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
 msgstr ""
 
 #: src/gtk/messages_view.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -925,6 +925,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bu makinede Bluetooth kullanılamıyor."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Yakındaki aygıtlar taranıyor..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Tam kip — mesajlar, kişiler ve bildirimler."
 
@@ -1053,10 +1057,6 @@ msgid "Unknown Device"
 msgstr "Bilinmeyen aygıt"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Yakındaki aygıtlar taranıyor..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Bağlandı"
 
@@ -1067,6 +1067,10 @@ msgstr "Çevrimdışı"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "Yakında (eşleşmek için dokunun)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Kısmen bağlı"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1283,6 +1287,14 @@ msgid "Today"
 msgstr "Bugün"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "Mesajları eşitlemek için Bluetooth bağlantısı gerekli."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Bir konuşma seçin"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Gönderiliyor…"
 
@@ -1317,10 +1329,6 @@ msgstr "Yeni mesaj"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Konuşmalarda ara"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Bir konuşma seçin"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -936,6 +936,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "Bluetooth недоступний на цій машині."
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "Пошук пристроїв поблизу..."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Повний режим — повідомлення, контакти та сповіщення."
 
@@ -1068,10 +1072,6 @@ msgid "Unknown Device"
 msgstr "Невідомий пристрій"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "Пошук пристроїв поблизу..."
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "Під'єднано"
 
@@ -1082,6 +1082,10 @@ msgstr "Не в мережі"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "Поблизу (торкніться, щоб створити пару)"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "Під'єднано частково"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1300,6 +1304,14 @@ msgid "Today"
 msgstr "Сьогодні"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "Для синхронізації повідомлень потрібне з’єднання Bluetooth."
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "Виберіть розмову"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "Надсилання…"
 
@@ -1335,10 +1347,6 @@ msgstr "Нове повідомлення"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "Пошук розмов"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "Виберіть розмову"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-30 11:33-0700\n"
+"POT-Creation-Date: 2026-08-31 19:04-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -887,6 +887,10 @@ msgid "Bluetooth is unavailable on this machine."
 msgstr "这台机器上蓝牙不可用。"
 
 #: src/gtk/devices_view.cpp
+msgid "Scanning for nearby devices..."
+msgstr "正在搜索附近的设备……"
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "完整模式 —— 信息、通讯录和通知。"
 
@@ -1014,10 +1018,6 @@ msgid "Unknown Device"
 msgstr "未知设备"
 
 #: src/gtk/devices_view.cpp
-msgid "Scanning for nearby devices..."
-msgstr "正在搜索附近的设备……"
-
-#: src/gtk/devices_view.cpp
 msgid "Connected"
 msgstr "已连接"
 
@@ -1028,6 +1028,10 @@ msgstr "离线"
 #: src/gtk/devices_view.cpp
 msgid "Nearby (Tap to Pair)"
 msgstr "附近（轻点以配对）"
+
+#: src/gtk/devices_view.cpp
+msgid "Partially connected"
+msgstr "部分连接"
 
 #: src/gtk/devices_view.cpp
 msgid "Paired"
@@ -1237,6 +1241,14 @@ msgid "Today"
 msgstr "今天"
 
 #: src/gtk/messages_view.cpp
+msgid "Bluetooth connection needed to sync messages."
+msgstr "需要蓝牙连接才能同步消息。"
+
+#: src/gtk/messages_view.cpp
+msgid "Select a conversation"
+msgstr "选择一个会话"
+
+#: src/gtk/messages_view.cpp
 msgid "Sending…"
 msgstr "正在发送……"
 
@@ -1271,10 +1283,6 @@ msgstr "新信息"
 #: src/gtk/messages_view.cpp
 msgid "Search conversations"
 msgstr "搜索会话"
-
-#: src/gtk/messages_view.cpp
-msgid "Select a conversation"
-msgstr "选择一个会话"
 
 #: src/gtk/messages_view.cpp
 msgid "To:"

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -787,10 +787,6 @@ int main(int argc, char* argv[]) {
     if (action == "list") {
         debug::log(INFO, "{}", client.list_devices());
         return 0;
-    } else if (action == "accept") {
-        client.accept_device(arg_val);
-        debug::log(INFO, "Successfully paired device: {}", arg_val);
-        return 0;
     } else if (action == "discover") {
         debug::log(INFO, "Scanning for tetherd instances on the local network...\n\n");
 
@@ -840,7 +836,13 @@ int main(int argc, char* argv[]) {
     }
 
     std::string err;
-    if (action == "pair") {
+    if (action == "accept") {
+        if (arg_val.empty() || !client.accept_device(arg_val)) {
+            debug::log(ERR, _("Could not reach the daemon.\n"));
+            return 1;
+        }
+        debug::log(INFO, "Successfully paired device: {}", arg_val);
+    } else if (action == "pair") {
         char hostname[256] = {};
         gethostname(hostname, sizeof(hostname) - 1);
         std::string resp = client.pair(hostname, err);

--- a/src/core/include/tether/bluetooth/advert.hpp
+++ b/src/core/include/tether/bluetooth/advert.hpp
@@ -23,7 +23,7 @@ namespace tether::bluetooth {
 
         // Registration is two-phase, and the phases must run on different threads.
         bool export_object();
-        bool register_with_bluez();
+        bool register_with_bluez(std::string* error = nullptr);
         void unregister_with_bluez();
         void unexport_object();
 

--- a/src/core/include/tether/bluetooth/monitor.hpp
+++ b/src/core/include/tether/bluetooth/monitor.hpp
@@ -2,9 +2,11 @@
 
 #include "tether/bluetooth/objects.hpp"
 
+#include <chrono>
 #include <functional>
 #include <gio/gio.h>
 #include <memory>
+#include <optional>
 
 namespace tether::bluetooth {
 
@@ -19,8 +21,9 @@ namespace tether::bluetooth {
         BluezMonitor(const BluezMonitor&) = delete;
         BluezMonitor& operator=(const BluezMonitor&) = delete;
 
-        // Connects to the system bus and starts the watcher thread. Returns false
-        // if BlueZ is unreachable; the daemon runs on without Bluetooth support.
+        // Connects to the system bus and starts the watcher thread. BlueZ object
+        // and controller capability reads happen on that thread so daemon startup
+        // and the network event loop never wait for Bluetooth tooling.
         bool start();
         void stop();
         bool running() const;
@@ -44,5 +47,12 @@ namespace tether::bluetooth {
     };
 
     extern BluezMonitor* g_bluez;
+
+    // BlueZ exposes Secure Connections only through the management interface.
+    // Runs btmgmt without a shell and returns no value if it fails or exceeds the
+    // deadline. Public so the process boundary and timeout can be tested directly.
+    std::optional<bool> probe_secure_connections(
+        const std::string& adapter_id,
+        std::chrono::milliseconds timeout = std::chrono::seconds(1));
 
 } // namespace tether::bluetooth

--- a/src/core/include/tether/bluetooth/objects.hpp
+++ b/src/core/include/tether/bluetooth/objects.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <glib.h>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -131,7 +132,12 @@ namespace tether::bluetooth {
     // result for null or unexpected input rather than throwing.
     BluezObjects parse_managed_objects(GVariant* reply);
 
-    Capability resolve_capability(const BluezObjects& objects);
+    // Resolves the pure ObjectManager snapshot plus the optional controller
+    // setting read by BluezMonitor. Keeping the external btmgmt probe out of
+    // this function makes capability resolution deterministic and prevents a
+    // stalled controller query from blocking unrelated callers.
+    Capability resolve_capability(const BluezObjects& objects,
+                                  std::optional<bool> secure_connections = std::nullopt);
 
     nlohmann::json to_json(const Adapter& adapter);
     nlohmann::json to_json(const Device& device);

--- a/src/core/include/tether/net.hpp
+++ b/src/core/include/tether/net.hpp
@@ -48,7 +48,7 @@ namespace tether {
 
     class UnixServer {
     public:
-        UnixServer(EpollEventLoop& loop);
+        UnixServer(EpollEventLoop& loop, TcpServer& tcp_server);
         ~UnixServer();
 
         bool start();
@@ -59,6 +59,7 @@ namespace tether {
         void handle_client(int client_fd);
 
         EpollEventLoop& loop_;
+        TcpServer& tcp_server_;
         int server_fd_ = -1;
         std::string socket_path_;
         std::map<int, std::string> client_buffers_;
@@ -72,6 +73,10 @@ namespace tether {
 
         bool start();
         void stop();
+
+        // Trusts a fingerprint and promotes every matching live TLS session.
+        // Returns true when at least one connected client was promoted.
+        bool accept_device(const std::string& fingerprint, const std::string& fallback_name = "Paired Device");
 
     private:
         struct ConnectedClientInfo {

--- a/src/core/src/bluetooth/advert.cpp
+++ b/src/core/src/bluetooth/advert.cpp
@@ -18,8 +18,8 @@ namespace tether::bluetooth {
         constexpr const char* ADVERT_MANAGER = "org.bluez.LEAdvertisingManager1";
 
         // Private/test identifiers that claim no Apple or hardware-vendor
-        // identity, following the convention ancs4linux established. No meaning; they exist because the advert iOS
-        // responds to carries them.
+        // identity, following the convention ancs4linux established. No meaning;
+        // they exist because the advert iOS responds to carries them.
         constexpr guint16 INERT_MANUFACTURER_ID = 0xffff;
         constexpr const char* INERT_SERVICE_UUID = "00009999-0000-1000-8000-00805f9b34fb";
 
@@ -144,7 +144,7 @@ namespace tether::bluetooth {
         return true;
     }
 
-    bool AncsAdvertisement::register_with_bluez() {
+    bool AncsAdvertisement::register_with_bluez(std::string* failure) {
         if (state_->registered_with_bluez)
             return true;
         if (state_->registration_id == 0)
@@ -165,7 +165,10 @@ namespace tether::bluetooth {
                                                       nullptr,
                                                       &error);
         if (!reply) {
-            debug::log(ERR, "bluetooth: RegisterAdvertisement failed: {}", error ? error->message : "unknown");
+            const std::string message = error && error->message ? error->message : "unknown error";
+            debug::log(ERR, "bluetooth: RegisterAdvertisement failed: {}", message);
+            if (failure)
+                *failure = message;
             g_clear_error(&error);
             return false;
         }

--- a/src/core/src/bluetooth/monitor.cpp
+++ b/src/core/src/bluetooth/monitor.cpp
@@ -1,13 +1,21 @@
 #include "tether/bluetooth/monitor.hpp"
 #include "tether/log.hpp"
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cerrno>
+#include <csignal>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
 #include <gio/gio.h>
 #include <mutex>
+#include <optional>
+#include <poll.h>
+#include <sys/wait.h>
 #include <sys/eventfd.h>
 #include <thread>
 #include <unistd.h>
@@ -40,11 +48,15 @@ namespace tether::bluetooth {
         mutable std::mutex mutex;
         BluezObjects objects;
         Capability cap;
+        std::string secure_adapter;
+        std::optional<bool> secure_connections;
+        std::chrono::steady_clock::time_point secure_checked_at{};
 
         void run();
         void refresh();
         void schedule_refresh();
         void notify();
+        std::optional<bool> read_secure_connections(const std::string& adapter_id);
     };
 
     namespace {
@@ -129,6 +141,145 @@ namespace tether::bluetooth {
         return value;
     }
 
+    std::optional<bool> probe_secure_connections(const std::string& adapter_id,
+                                                 std::chrono::milliseconds timeout) {
+        if (adapter_id.empty())
+            return std::nullopt;
+
+        std::array<gchar*, 5> argv = {
+            const_cast<gchar*>("btmgmt"),
+            const_cast<gchar*>("--index"),
+            const_cast<gchar*>(adapter_id.c_str()),
+            const_cast<gchar*>("info"),
+            nullptr,
+        };
+
+        GPid child = 0;
+        gint output_fd = -1;
+        GError* error = nullptr;
+        const auto flags = static_cast<GSpawnFlags>(G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD |
+                                                    G_SPAWN_STDERR_TO_DEV_NULL | G_SPAWN_CLOEXEC_PIPES);
+        if (!g_spawn_async_with_pipes(nullptr,
+                                      argv.data(),
+                                      nullptr,
+                                      flags,
+                                      nullptr,
+                                      nullptr,
+                                      &child,
+                                      nullptr,
+                                      &output_fd,
+                                      nullptr,
+                                      &error)) {
+            debug::log(WARN,
+                       "bluetooth: cannot start btmgmt for {}: {}",
+                       adapter_id,
+                       error ? error->message : "unknown error");
+            g_clear_error(&error);
+            return std::nullopt;
+        }
+
+        const int old_flags = fcntl(output_fd, F_GETFL, 0);
+        if (old_flags >= 0)
+            fcntl(output_fd, F_SETFL, old_flags | O_NONBLOCK);
+
+        std::string output;
+        output.reserve(2048);
+        int status = 0;
+        bool exited = false;
+        const auto started = std::chrono::steady_clock::now();
+        const auto deadline = started + std::max(timeout, std::chrono::milliseconds::zero());
+
+        auto drain_output = [&] {
+            char buffer[1024];
+            for (;;) {
+                const ssize_t count = read(output_fd, buffer, sizeof(buffer));
+                if (count > 0) {
+                    if (output.size() < 64 * 1024)
+                        output.append(buffer, std::min<size_t>(static_cast<size_t>(count), 64 * 1024 - output.size()));
+                    continue;
+                }
+                if (count < 0 && errno == EINTR)
+                    continue;
+                break;
+            }
+        };
+
+        while (std::chrono::steady_clock::now() < deadline) {
+            drain_output();
+            const pid_t waited = waitpid(child, &status, WNOHANG);
+            if (waited == child) {
+                exited = true;
+                break;
+            }
+            if (waited < 0 && errno != EINTR)
+                break;
+
+            const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                deadline - std::chrono::steady_clock::now());
+            pollfd watched{output_fd, POLLIN | POLLHUP, 0};
+            poll(&watched, 1, static_cast<int>(std::clamp<int64_t>(remaining.count(), 1, 50)));
+        }
+
+        if (!exited) {
+            kill(child, SIGTERM);
+            const auto grace_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+            while (std::chrono::steady_clock::now() < grace_deadline) {
+                const pid_t waited = waitpid(child, &status, WNOHANG);
+                if (waited == child) {
+                    exited = true;
+                    break;
+                }
+                if (waited < 0 && errno != EINTR)
+                    break;
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            }
+            if (!exited) {
+                kill(child, SIGKILL);
+                while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+                }
+            }
+
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - started);
+            debug::log(WARN, "bluetooth: btmgmt info for {} timed out after {}ms", adapter_id, elapsed.count());
+            close(output_fd);
+            g_spawn_close_pid(child);
+            return std::nullopt;
+        }
+
+        drain_output();
+        close(output_fd);
+        g_spawn_close_pid(child);
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+            return std::nullopt;
+
+        const size_t settings = output.find("current settings:");
+        if (settings == std::string::npos)
+            return std::nullopt;
+        const size_t line_end = output.find('\n', settings);
+        const std::string line = output.substr(settings, line_end - settings);
+        return line.find("secure-conn") != std::string::npos;
+    }
+
+    std::optional<bool> MonitorState::read_secure_connections(const std::string& adapter_id) {
+        constexpr auto RECHECK_AFTER = std::chrono::seconds(30);
+        if (adapter_id.empty()) {
+            secure_adapter.clear();
+            secure_connections.reset();
+            secure_checked_at = {};
+            return std::nullopt;
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        if (adapter_id != secure_adapter || secure_checked_at == std::chrono::steady_clock::time_point{} ||
+            now - secure_checked_at >= RECHECK_AFTER) {
+            secure_adapter = adapter_id;
+            secure_connections = probe_secure_connections(adapter_id);
+            secure_checked_at = std::chrono::steady_clock::now();
+        }
+        return secure_connections;
+    }
+
     void MonitorState::refresh() {
         GError* error = nullptr;
         GVariant* reply = g_dbus_connection_call_sync(conn,
@@ -152,6 +303,7 @@ namespace tether::bluetooth {
         g_variant_unref(reply);
         parsed.experimental_api = bluetoothd_has_experimental();
         Capability resolved = resolve_capability(parsed);
+        resolved = resolve_capability(parsed, read_secure_connections(resolved.adapter_id));
 
         {
             std::lock_guard<std::mutex> lock(mutex);
@@ -222,29 +374,6 @@ namespace tether::bluetooth {
             g_clear_error(&error);
             return false;
         }
-
-        // fail fast when bluetoothd is not present
-        GVariant* probe = g_dbus_connection_call_sync(impl_->conn,
-                                                      BLUEZ_NAME,
-                                                      "/",
-                                                      OBJECT_MANAGER,
-                                                      "GetManagedObjects",
-                                                      nullptr,
-                                                      G_VARIANT_TYPE("(a{oa{sa{sv}}})"),
-                                                      G_DBUS_CALL_FLAGS_NONE,
-                                                      5000,
-                                                      nullptr,
-                                                      &error);
-        if (!probe) {
-            debug::log(WARN, "bluetooth: BlueZ unavailable: {}", error ? error->message : "unknown");
-            g_clear_error(&error);
-            g_clear_object(&impl_->conn);
-            return false;
-        }
-        impl_->objects = parse_managed_objects(probe);
-        impl_->objects.experimental_api = bluetoothd_has_experimental();
-        impl_->cap = resolve_capability(impl_->objects);
-        g_variant_unref(probe);
 
         impl_->efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
         if (impl_->efd < 0) {

--- a/src/core/src/bluetooth/objects.cpp
+++ b/src/core/src/bluetooth/objects.cpp
@@ -2,7 +2,6 @@
 #include <tether/i18n.hpp>
 
 #include <algorithm>
-#include <cstdio>
 #include <cstring>
 #include <filesystem>
 
@@ -284,35 +283,6 @@ namespace tether::bluetooth {
             return "/usr/lib/bluetooth/bluetoothd";
         }
 
-        // Reads the controller's current mgmt settings. BlueZ exposes Secure
-        // Connections nowhere on D-Bus, and it is the precondition for the
-        // cross-transport key derivation that gives a BR/EDR bond its LE half.
-        // without it the bond is Classic-only and ANCS is unreachable, which is
-        // otherwise indistinguishable from a dozen other failures.
-        //
-        // TODO: shelling out to btmgmt, which reads the mgmt socket
-        // unprivileged. Only worth opening an AF_BLUETOOTH mgmt socket here if
-        // this ever needs to run somewhere btmgmt is not installed.
-        bool read_secure_connections(const std::string& adapter_id, bool& enabled) {
-            const std::string cmd = "btmgmt --index " + adapter_id + " info 2>/dev/null";
-            FILE* pipe = popen(cmd.c_str(), "r");
-            if (!pipe)
-                return false;
-
-            bool found = false;
-            char line[1024];
-            while (std::fgets(line, sizeof(line), pipe)) {
-                const std::string text(line);
-                if (text.find("current settings:") == std::string::npos)
-                    continue;
-                enabled = text.find("secure-conn") != std::string::npos;
-                found = true;
-                break;
-            }
-            pclose(pipe);
-            return found;
-        }
-
         // The package ships the drop-in for the user to copy.
         std::string enable_experimental_command() {
             const std::string shipped = std::string(TETHER_DATADIR) + "/bluetooth-experimental.conf";
@@ -334,7 +304,7 @@ namespace tether::bluetooth {
 
     } // namespace
 
-    Capability resolve_capability(const BluezObjects& objects) {
+    Capability resolve_capability(const BluezObjects& objects, std::optional<bool> secure_connections) {
         Capability cap;
 
         // prefer powered adapter, fall back to the first so the reasons below
@@ -380,7 +350,10 @@ namespace tether::bluetooth {
         if (cap.bearer_api != BearerApi::Confirmed)
             cap.bearer_api = objects.experimental_api ? BearerApi::Unknown : BearerApi::Absent;
 
-        cap.secure_connections_known = read_secure_connections(cap.adapter_id, cap.secure_connections);
+        if (secure_connections.has_value()) {
+            cap.secure_connections_known = true;
+            cap.secure_connections = *secure_connections;
+        }
 
         if (!cap.powered) {
             cap.reasons.emplace_back(_("Bluetooth adapter is powered off."));

--- a/src/core/src/bluetooth/pairing.cpp
+++ b/src/core/src/bluetooth/pairing.cpp
@@ -330,14 +330,16 @@ namespace tether::bluetooth {
             monitor.invoke_sync([&] { exported = advert->export_object(); });
             // BlueZ reads the advertisement's properties back before returning, so
             // this call must stay off the thread that answers those reads.
-            if (exported && advert->register_with_bluez()) {
+            std::string registration_error;
+            if (exported && advert->register_with_bluez(&registration_error)) {
                 g_advert = advert;
                 return true;
             }
 
             monitor.invoke_sync([&] { advert->unexport_object(); });
             delete advert;
-            err = "Could not advertise for ANCS. The controller may have no free LE advertising instance.";
+            err = registration_error.empty() ? "Could not prepare the ANCS advertisement."
+                                             : "Could not advertise for ANCS: " + registration_error;
             return false;
         }
 

--- a/src/core/src/client.cpp
+++ b/src/core/src/client.cpp
@@ -240,32 +240,17 @@ namespace tether {
     }
 
     bool Client::accept_device(const std::string& fingerprint, const std::string& name) {
-        tether::Crypto::instance().init();
+        if (!is_connected() || ssl_ || fingerprint.empty())
+            return false;
 
-        // Check if the daemon stored a name from the pair_request
-        std::string resolved_name = name;
-        std::string pending_path = tether::get_runtime_dir() + "/pending_pairs.json";
-        nlohmann::json pending;
-
-        std::ifstream ifs(pending_path);
-        if (ifs.is_open()) {
-            try {
-                pending = nlohmann::json::parse(ifs);
-            } catch (...) {
-            }
-            ifs.close();
+        nlohmann::json request{{"command", "accept_device"}, {"fingerprint", fingerprint}, {"device_name", name}};
+        const std::string response = send_and_wait(request.dump() + "\n");
+        try {
+            const auto parsed = nlohmann::json::parse(response);
+            return parsed.value("command", "") == "accept_device_result" && parsed.value("accepted", false);
+        } catch (...) {
+            return false;
         }
-
-        if (pending.contains(fingerprint) && pending[fingerprint].is_string()) {
-            resolved_name = pending[fingerprint].get<std::string>();
-            // Remove the accepted entry
-            pending.erase(fingerprint);
-            std::ofstream ofs(pending_path);
-            ofs << pending.dump(4);
-        }
-
-        tether::Crypto::instance().add_known_host(resolved_name, fingerprint);
-        return true;
     }
 
     std::string Client::pair(const std::string& device_name, std::string& err_out) {

--- a/src/core/src/net.cpp
+++ b/src/core/src/net.cpp
@@ -258,6 +258,11 @@ namespace tether {
         return pending;
     }
 
+    static void save_pending_pairs(const nlohmann::json& pending) {
+        std::ofstream ofs(get_runtime_dir() + "/pending_pairs.json");
+        ofs << pending.dump(4);
+    }
+
     static std::string lookup_known_host_name(const std::string& fingerprint) {
         try {
             auto known = nlohmann::json::parse(Crypto::instance().get_known_hosts_dump());
@@ -671,7 +676,9 @@ namespace tether {
 
     // --- UnixServer ---
 
-    UnixServer::UnixServer(EpollEventLoop& loop) : loop_(loop) { socket_path_ = get_runtime_dir() + "/tetherd.sock"; }
+    UnixServer::UnixServer(EpollEventLoop& loop, TcpServer& tcp_server) : loop_(loop), tcp_server_(tcp_server) {
+        socket_path_ = get_runtime_dir() + "/tetherd.sock";
+    }
 
     UnixServer::~UnixServer() { stop(); }
 
@@ -1066,31 +1073,14 @@ namespace tether {
                         write_plain_packet(client_fd, payload);
                         continue;
                     } else if (j.contains("command") && j["command"] == "accept_device" && j.contains("fingerprint")) {
-                        std::string print = j["fingerprint"];
-                        std::string resolved_name = "Unknown Device";
-                        std::string pending_path = get_runtime_dir() + "/pending_pairs.json";
-                        nlohmann::json pending;
-                        std::ifstream ifs(pending_path);
-                        if (ifs.is_open()) {
-                            try {
-                                pending = nlohmann::json::parse(ifs);
-                            } catch (...) {
-                            }
-                            ifs.close();
-                        }
-                        if (pending.contains(print) && pending[print].is_string()) {
-                            resolved_name = pending[print].get<std::string>();
-                            pending.erase(print);
-                            std::ofstream ofs(pending_path);
-                            ofs << pending.dump(4);
-                        }
-                        Crypto::instance().add_known_host(resolved_name, print);
-
-                        nlohmann::json event;
-                        event["command"] = "pair_accepted";
-                        event["fingerprint"] = print;
-                        event["device_name"] = resolved_name;
-                        broadcast_local_event(event.dump());
+                        const std::string print = j.value("fingerprint", "");
+                        const std::string fallback_name = j.value("device_name", "Paired Device");
+                        const bool connected = !print.empty() && tcp_server_.accept_device(print, fallback_name);
+                        nlohmann::json response{{"command", "accept_device_result"},
+                                                {"accepted", !print.empty()},
+                                                {"connected", connected}};
+                        write_plain_packet(client_fd, response.dump() + "\n");
+                        continue;
                     } else if (j.contains("command") && j["command"] == "pair_request" && j.contains("host")) {
                         std::string target_host = j["host"];
                         int target_port = j.value("port", 5134);
@@ -1537,6 +1527,79 @@ namespace tether {
         }
     }
 
+    bool TcpServer::accept_device(const std::string& fingerprint, const std::string& fallback_name) {
+        if (fingerprint.empty())
+            return false;
+
+        auto pending = load_pending_pairs();
+        std::string device_name = lookup_known_host_name(fingerprint);
+        if (device_name.empty())
+            device_name = fallback_name.empty() ? "Paired Device" : fallback_name;
+        if (pending.contains(fingerprint) && pending[fingerprint].is_string()) {
+            device_name = pending[fingerprint].get<std::string>();
+            pending.erase(fingerprint);
+            save_pending_pairs(pending);
+        }
+
+        Crypto::instance().add_known_host(device_name, fingerprint);
+
+        bool promoted = false;
+        std::string address;
+        for (auto& [client_fd, remote] : connected_remote_clients) {
+            if (remote.fingerprint != fingerprint)
+                continue;
+
+            auto ssl_it = active_ssl_.find(client_fd);
+            auto paired_it = client_paired_.find(client_fd);
+            auto info_it = client_info_.find(client_fd);
+            if (ssl_it == active_ssl_.end() || paired_it == client_paired_.end() || info_it == client_info_.end())
+                continue;
+
+            paired_it->second = true;
+            info_it->second.paired = true;
+            info_it->second.device_name = device_name;
+            remote.paired = true;
+            remote.device_name = device_name;
+            address = remote.address;
+            register_client_ssl(client_fd, ssl_it->second);
+            promoted = true;
+
+            nlohmann::json connected_event{{"command", "client_connected"},
+                                            {"fingerprint", fingerprint},
+                                            {"device_name", device_name},
+                                            {"address", remote.address},
+                                            {"paired", true}};
+            broadcast_local_event(connected_event.dump());
+
+            nlohmann::json response{{"command", "pair_accepted"}};
+            const std::string payload = response.dump() + "\n";
+            robust_ssl_write(ssl_it->second, payload.c_str(), payload.size());
+        }
+
+        nlohmann::json event{{"command", "pair_accepted"},
+                             {"fingerprint", fingerprint},
+                             {"device_name", device_name},
+                             {"address", address},
+                             {"connected", promoted}};
+        broadcast_local_event(event.dump());
+
+        // An external acceptance supersedes any dialog for the same request.
+        // Its exit callback observes the promoted session and ignores the stale
+        // non-zero result rather than sending pair_rejected to the phone.
+        for (const auto& [read_fd, dialog] : pending_dialogs_) {
+            (void)read_fd;
+            if (dialog.fingerprint == fingerprint)
+                kill(dialog.pid, SIGTERM);
+        }
+
+        debug::log(INFO,
+                   promoted ? "[Pairing Accepted] {} ({}) and live session promoted"
+                            : "[Pairing Accepted] {} ({}) for the next connection",
+                   device_name,
+                   fingerprint);
+        return promoted;
+    }
+
     void TcpServer::spawn_pair_dialog(int client_fd,
                                       SSL* ssl,
                                       const std::string& fingerprint,
@@ -1645,70 +1708,9 @@ namespace tether {
             int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : 3;
 
             if (exit_code == 0) {
-                Crypto::instance().add_known_host(info.device_name, info.fingerprint);
-                debug::log(INFO, "[Pairing Accepted] {} ({})", info.device_name, info.fingerprint);
-
-                auto remote_it = connected_remote_clients.find(info.client_fd);
-                auto ssl_it = active_ssl_.find(info.client_fd);
-
-                if (client_paired_.find(info.client_fd) != client_paired_.end()) {
-                    client_paired_[info.client_fd] = true;
-                }
-                auto info_it = client_info_.find(info.client_fd);
-                if (info_it != client_info_.end()) {
-                    info_it->second.paired = true;
-                    info_it->second.device_name = info.device_name;
-                }
-                if (remote_it != connected_remote_clients.end()) {
-                    remote_it->second.paired = true;
-                    remote_it->second.device_name = info.device_name;
-                }
-
-                if (ssl_it != active_ssl_.end()) {
-                    register_client_ssl(info.client_fd, ssl_it->second);
-                }
-
-                nlohmann::json event;
-                event["command"] = "pair_accepted";
-                event["fingerprint"] = info.fingerprint;
-                event["device_name"] = info.device_name;
-                if (remote_it != connected_remote_clients.end()) {
-                    event["address"] = remote_it->second.address;
-                }
-                broadcast_local_event(event.dump());
-
-                nlohmann::json connected_event;
-                connected_event["command"] = "client_connected";
-                connected_event["fingerprint"] = info.fingerprint;
-                connected_event["device_name"] = info.device_name;
-                connected_event["paired"] = true;
-                if (remote_it != connected_remote_clients.end()) {
-                    connected_event["address"] = remote_it->second.address;
-                }
-                broadcast_local_event(connected_event.dump());
-
-                if (ssl_it != active_ssl_.end()) {
-                    nlohmann::json resp;
-                    resp["command"] = "pair_accepted";
-                    std::string payload = resp.dump() + "\n";
-                    robust_ssl_write(ssl_it->second, payload.c_str(), payload.size());
-                }
-
-                std::string pending_path = get_runtime_dir() + "/pending_pairs.json";
-                nlohmann::json pending;
-                std::ifstream ifs(pending_path);
-                if (ifs.is_open()) {
-                    try {
-                        pending = nlohmann::json::parse(ifs);
-                    } catch (...) {
-                    }
-                    ifs.close();
-                }
-                if (pending.contains(info.fingerprint)) {
-                    pending.erase(info.fingerprint);
-                    std::ofstream ofs(pending_path);
-                    ofs << pending.dump(4);
-                }
+                accept_device(info.fingerprint, info.device_name);
+            } else if (client_paired_.contains(info.client_fd) && client_paired_[info.client_fd]) {
+                debug::log(INFO, "Pairing dialog dismissed after {} was accepted elsewhere", info.device_name);
             } else {
 
                 if (!bluetooth::dialog_answered(status))

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -71,13 +71,13 @@ int main(int argc, char** argv) {
     tether::EpollEventLoop loop;
     g_loop = &loop;
 
-    tether::UnixServer unix_srv(loop);
+    tether::TcpServer tcp_srv(loop, 5134);
+    tether::UnixServer unix_srv(loop, tcp_srv);
     if (!unix_srv.start()) {
         debug::log(ERR, "Failed to start Unix server");
         return 1;
     }
 
-    tether::TcpServer tcp_srv(loop, 5134);
     if (!tcp_srv.start()) {
         debug::log(ERR, "Failed to start TCP server");
         return 1;

--- a/src/gtk/devices_view.cpp
+++ b/src/gtk/devices_view.cpp
@@ -41,6 +41,8 @@ namespace tether::ui {
             GtkWidget* lbl_action_name = nullptr;
             GtkWidget* lbl_action_status = nullptr;
             GtkWidget* btn_grid = nullptr;
+            GtkWidget* btn_action_bt_pair = nullptr;
+            bool select_bt_after_scan = false;
 
             GtkWidget* lbl_unpaired_name = nullptr;
             GtkWidget* lbl_unpaired_ip = nullptr;
@@ -134,6 +136,20 @@ namespace tether::ui {
         void on_bt_enabled_toggled(GtkWidget* widget, gpointer);
         void on_bt_ancs_toggled(GtkWidget* widget, gpointer);
         void on_bt_content_toggled(GtkWidget* widget, gpointer);
+
+        void update_action_bt_scan_controls() {
+            if (g_devices.btn_action_bt_pair)
+                gtk_widget_set_sensitive(g_devices.btn_action_bt_pair, !g_devices.select_bt_after_scan);
+        }
+
+        void on_action_bt_pair_clicked(GtkWidget*, gpointer) {
+            g_devices.select_bt_after_scan = true;
+            update_action_bt_scan_controls();
+            set_status_action(_("Scanning for nearby devices..."));
+            set_status_main(_("Scanning for nearby devices..."));
+            daemon_send({{"command", "bt_status"}});
+            daemon_send({{"command", "bt_scan"}});
+        }
 
         void update_bt_pane() {
             const std::string address = g_devices.selected_bt_address;
@@ -293,12 +309,20 @@ namespace tether::ui {
                 bool online = std::find(g_devices.connected_fps.begin(),
                                         g_devices.connected_fps.end(),
                                         g_devices.selected_device_fp) != g_devices.connected_fps.end();
-                set_status_action(
-                    online ? _("Connected and ready.")
-                           : _("Device is offline. Open the Tether app on iPhone while on the same network."));
+                if (g_devices.select_bt_after_scan)
+                    set_status_action(_("Scanning for nearby devices..."));
+                else
+                    set_status_action(
+                        online ? _("Connected and ready.")
+                               : _("Device is offline. Open the Tether app on iPhone while on the same network."));
                 if (g_devices.btn_grid) {
                     gtk_widget_set_visible(g_devices.btn_grid, online);
                 }
+                if (g_devices.btn_action_bt_pair) {
+                    const std::string supervised = g_devices.bt_status.value("device_address", "");
+                    gtk_widget_set_visible(g_devices.btn_action_bt_pair, supervised.empty());
+                }
+                update_action_bt_scan_controls();
             } else {
                 gtk_stack_set_visible_child_name(GTK_STACK(g_devices.right_pane_stack), "pair");
                 set_markup(g_devices.lbl_unpaired_name,
@@ -672,6 +696,9 @@ namespace tether::ui {
             const std::string name = device.value("name", "").empty() ? address : device.value("name", "");
             const bool paired = device.value("paired", false);
             const bool connected = device.value("connected", false);
+            const bool route_ready = is_supervised_bt_device(address) &&
+                                     (g_devices.bt_connection.value("map_open", false) ||
+                                      g_devices.bt_connection.value("ancs_ready", false));
 
             GtkWidget* row = gtk_list_box_row_new();
             g_object_set_data_full(G_OBJECT(row), "bt_address", g_strdup(address.c_str()), g_free);
@@ -690,8 +717,11 @@ namespace tether::ui {
             gtk_label_set_xalign(GTK_LABEL(title), 0.0);
             gtk_box_pack_start(GTK_BOX(labels), title, FALSE, FALSE, 0);
 
-            GtkWidget* subtitle =
-                gtk_label_new(connected ? _("Connected") : (paired ? _("Paired") : _("Nearby (Tap to Pair)")));
+            const char* subtitle_text = route_ready          ? _("Connected")
+                                        : connected          ? _("Partially connected")
+                                        : paired             ? _("Paired")
+                                                             : _("Nearby (Tap to Pair)");
+            GtkWidget* subtitle = gtk_label_new(subtitle_text);
             gtk_label_set_xalign(GTK_LABEL(subtitle), 0.0);
             gtk_style_context_add_class(gtk_widget_get_style_context(subtitle), "muted");
             gtk_box_pack_start(GTK_BOX(labels), subtitle, FALSE, FALSE, 0);
@@ -866,7 +896,10 @@ namespace tether::ui {
             std::string fp = event.value("fingerprint", "");
             std::string name = event.value("device_name", "");
             if (!fp.empty()) {
-                g_devices.connected_fps.push_back(fp);
+                if (event.value("connected", false) &&
+                    std::find(g_devices.connected_fps.begin(), g_devices.connected_fps.end(), fp) ==
+                        g_devices.connected_fps.end())
+                    g_devices.connected_fps.push_back(fp);
 
                 // Ensure it's in the paired devices list so the UI transitions
                 bool already_paired = false;
@@ -962,6 +995,20 @@ namespace tether::ui {
                 for (const auto& device : event["devices"])
                     g_devices.bt_devices.push_back(device);
             }
+
+            if (g_devices.select_bt_after_scan) {
+                const auto iphone = std::find_if(g_devices.bt_devices.begin(),
+                                                 g_devices.bt_devices.end(),
+                                                 [](const nlohmann::json& device) {
+                                                     return device.value("iphone", false);
+                                                 });
+                if (iphone != g_devices.bt_devices.end()) {
+                    g_devices.selected_bt_address = iphone->value("address", "");
+                    g_devices.selected_bt_name = iphone->value("name", "iPhone");
+                    g_devices.selected_device_fp.clear();
+                    g_devices.select_bt_after_scan = false;
+                }
+            }
             devices_view_refresh();
             update_right_pane();
             return true;
@@ -984,12 +1031,20 @@ namespace tether::ui {
             set_text(g_devices.lbl_bt_progress, message);
             // A failed scan already carries the reason; only a scan that really
             // ran and found nothing wants the "check the phone" advice.
-            if (event.value("success", false) && g_devices.bt_devices.empty())
-                set_text(g_devices.lbl_welcome_bt,
-                         _("No iPhone found. Unlock the phone and open Settings > Bluetooth so it advertises, "
-                           "then scan again."));
-            else if (!event.value("success", false))
+            if (event.value("success", false) && g_devices.select_bt_after_scan) {
+                const char* advice = _("No iPhone found. Unlock the phone and open Settings > Bluetooth so it "
+                                       "advertises, then scan again.");
+                set_text(g_devices.lbl_welcome_bt, advice);
+                set_status_action(advice);
+                g_devices.select_bt_after_scan = false;
+                update_action_bt_scan_controls();
+            } else if (!event.value("success", false)) {
                 set_text(g_devices.lbl_welcome_bt, message);
+                if (g_devices.select_bt_after_scan)
+                    set_status_action(message);
+                g_devices.select_bt_after_scan = false;
+                update_action_bt_scan_controls();
+            }
             return true;
         }
         if (command == "bt_solicit_result") {
@@ -1305,6 +1360,19 @@ namespace tether::ui {
         gtk_box_pack_start(GTK_BOX(btn_grid), btn_send_clip, FALSE, FALSE, 0);
 
         gtk_box_pack_start(GTK_BOX(action_box), btn_grid, FALSE, FALSE, 0);
+
+        g_devices.btn_action_bt_pair = gtk_button_new_with_label(_("Pair over Bluetooth"));
+        gtk_button_set_image(GTK_BUTTON(g_devices.btn_action_bt_pair),
+                             gtk_image_new_from_icon_name("bluetooth-symbolic", GTK_ICON_SIZE_BUTTON));
+        gtk_button_set_always_show_image(GTK_BUTTON(g_devices.btn_action_bt_pair), TRUE);
+        gtk_widget_set_halign(g_devices.btn_action_bt_pair, GTK_ALIGN_CENTER);
+        g_signal_connect(g_devices.btn_action_bt_pair, "clicked", G_CALLBACK(on_action_bt_pair_clicked), nullptr);
+        gtk_box_pack_start(GTK_BOX(action_box), g_devices.btn_action_bt_pair, FALSE, FALSE, 0);
+
+        GtkSizeGroup* action_button_sizes = gtk_size_group_new(GTK_SIZE_GROUP_BOTH);
+        gtk_size_group_add_widget(action_button_sizes, btn_send_clip);
+        gtk_size_group_add_widget(action_button_sizes, g_devices.btn_action_bt_pair);
+        g_object_unref(action_button_sizes);
 
         g_devices.lbl_action_status = gtk_label_new(_("Ready"));
         gtk_widget_set_halign(g_devices.lbl_action_status, GTK_ALIGN_CENTER);

--- a/src/gtk/messages_view.cpp
+++ b/src/gtk/messages_view.cpp
@@ -33,6 +33,8 @@ namespace tether::ui {
             GtkWidget* composer = nullptr;
             GtkWidget* send_button = nullptr;
             GtkWidget* placeholder_stack = nullptr;
+            GtkWidget* placeholder_icon = nullptr;
+            GtkWidget* placeholder_label = nullptr;
             GtkWidget* paned = nullptr;
             GtkWidget* thread_scroll = nullptr;
             GtkWidget* search_entry = nullptr;
@@ -43,6 +45,8 @@ namespace tether::ui {
             std::string selected_name;
             bool visible = false;
             bool map_open = false;
+            bool threads_known = false;
+            size_t thread_count = 0;
             bool sending = false;
             GtkWidget* composer_notice = nullptr;
             // Rebuilding the thread list destroys and recreates the selected row.
@@ -108,6 +112,7 @@ namespace tether::ui {
         enum ComposeColumn { COMPOSE_COL_DISPLAY, COMPOSE_COL_ADDRESS, COMPOSE_COL_SEARCH, COMPOSE_COL_COUNT };
 
         void update_composer_sensitivity();
+        void update_placeholder();
         void apply_row_selection(GtkWidget* row);
         void clear_selection();
         void switch_thread(const std::string& key);
@@ -413,6 +418,10 @@ namespace tether::ui {
 
             clear_list_box(g_messages.thread_list);
 
+            g_messages.threads_known = true;
+            g_messages.thread_count = event["threads"].size();
+            update_placeholder();
+
             GtkWidget* reselect = nullptr;
             for (const auto& thread : event["threads"]) {
                 GtkWidget* row = build_thread_row(thread);
@@ -556,6 +565,7 @@ namespace tether::ui {
         void update_connection(const nlohmann::json& event) {
             const bool map_open = event.value("map_open", false);
             g_messages.map_open = map_open;
+            update_placeholder();
             update_composer_sensitivity();
             if (map_open) {
                 set_banner("");
@@ -576,6 +586,20 @@ namespace tether::ui {
             // not when the link itself is down.
             const std::string map_error = event.value("map_error", "none");
             set_banner(reason, map_error == "forbidden" || map_error == "no_record");
+        }
+
+        void update_placeholder() {
+            if (!g_messages.placeholder_icon || !g_messages.placeholder_label)
+                return;
+
+            const bool bluetooth_needed =
+                g_messages.threads_known && g_messages.thread_count == 0 && !g_messages.map_open;
+            gtk_image_set_from_icon_name(GTK_IMAGE(g_messages.placeholder_icon),
+                                         bluetooth_needed ? "bluetooth-disabled-symbolic" : "mail-unread-symbolic",
+                                         GTK_ICON_SIZE_DIALOG);
+            set_text(g_messages.placeholder_label,
+                     bluetooth_needed ? _("Bluetooth connection needed to sync messages.")
+                                      : _("Select a conversation"));
         }
 
         // Replying needs an open conversation and a live MAP session. A group
@@ -1137,11 +1161,12 @@ namespace tether::ui {
         GtkWidget* placeholder = gtk_box_new(GTK_ORIENTATION_VERTICAL, 10);
         gtk_widget_set_valign(placeholder, GTK_ALIGN_CENTER);
         gtk_widget_set_halign(placeholder, GTK_ALIGN_CENTER);
-        GtkWidget* placeholder_icon = gtk_image_new_from_icon_name("mail-unread-symbolic", GTK_ICON_SIZE_DIALOG);
-        gtk_box_pack_start(GTK_BOX(placeholder), placeholder_icon, FALSE, FALSE, 0);
-        GtkWidget* placeholder_label = gtk_label_new(_("Select a conversation"));
-        gtk_style_context_add_class(gtk_widget_get_style_context(placeholder_label), "muted");
-        gtk_box_pack_start(GTK_BOX(placeholder), placeholder_label, FALSE, FALSE, 0);
+        g_messages.placeholder_icon =
+            gtk_image_new_from_icon_name("mail-unread-symbolic", GTK_ICON_SIZE_DIALOG);
+        gtk_box_pack_start(GTK_BOX(placeholder), g_messages.placeholder_icon, FALSE, FALSE, 0);
+        g_messages.placeholder_label = gtk_label_new(_("Select a conversation"));
+        gtk_style_context_add_class(gtk_widget_get_style_context(g_messages.placeholder_label), "muted");
+        gtk_box_pack_start(GTK_BOX(placeholder), g_messages.placeholder_label, FALSE, FALSE, 0);
         gtk_stack_add_named(GTK_STACK(g_messages.placeholder_stack), placeholder, "placeholder");
 
         GtkWidget* conversation_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(tether_test
     test_base64.cpp
     test_bluetooth_objects.cpp
+    test_bluetooth_monitor.cpp
     test_bluetooth_pairing.cpp
     test_bluetooth_supervisor.cpp
     test_bmessage.cpp

--- a/test/test_bluetooth_monitor.cpp
+++ b/test/test_bluetooth_monitor.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+#include <tether/bluetooth/monitor.hpp>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <fcntl.h>
+#include <string>
+#include <sys/types.h>
+#include <unistd.h>
+
+using namespace std::chrono_literals;
+using tether::bluetooth::probe_secure_connections;
+
+namespace {
+
+    class FakeBtmgmt {
+    public:
+        explicit FakeBtmgmt(const std::string& body) {
+            const char* path = std::getenv("PATH");
+            old_path_ = path ? path : "";
+            dir_ = std::filesystem::path("/var/tmp") /
+                   ("tether-monitor-test-" + std::to_string(getpid()));
+            std::filesystem::remove_all(dir_);
+            std::filesystem::create_directories(dir_);
+
+            const auto executable = dir_ / "btmgmt";
+            std::ofstream script(executable);
+            script << "#!/bin/sh\n" << body;
+            script.close();
+            std::filesystem::permissions(executable,
+                                         std::filesystem::perms::owner_read |
+                                             std::filesystem::perms::owner_write |
+                                             std::filesystem::perms::owner_exec,
+                                         std::filesystem::perm_options::replace);
+            setenv("PATH", dir_.c_str(), 1);
+        }
+
+        ~FakeBtmgmt() {
+            setenv("PATH", old_path_.c_str(), 1);
+            std::filesystem::remove_all(dir_);
+        }
+
+        FakeBtmgmt(const FakeBtmgmt&) = delete;
+        FakeBtmgmt& operator=(const FakeBtmgmt&) = delete;
+
+    private:
+        std::filesystem::path dir_;
+        std::string old_path_;
+    };
+
+} // namespace
+
+TEST(SecureConnectionsProbe, ParsesEnabledAndDisabledSettings) {
+    {
+        FakeBtmgmt fake("printf 'current settings: powered secure-conn bondable\\n'\n");
+        const auto result = probe_secure_connections("hci0", 250ms);
+        ASSERT_TRUE(result.has_value());
+        EXPECT_TRUE(*result);
+    }
+    {
+        FakeBtmgmt fake("printf 'current settings: powered bondable\\n'\n");
+        const auto result = probe_secure_connections("hci0", 250ms);
+        ASSERT_TRUE(result.has_value());
+        EXPECT_FALSE(*result);
+    }
+}
+
+TEST(SecureConnectionsProbe, TimesOutAndTerminatesTheExactChild) {
+    FakeBtmgmt fake("exec /bin/sleep 5\n");
+    const auto started = std::chrono::steady_clock::now();
+    const auto result = probe_secure_connections("hci0", 50ms);
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+
+    EXPECT_FALSE(result.has_value());
+    EXPECT_LT(elapsed, 500ms);
+}
+
+TEST(SecureConnectionsProbe, DoesNotLeakParentDescriptorsIntoBtmgmt) {
+    constexpr int sentinel_fd = 99;
+    const int source = open("/dev/null", O_RDONLY);
+    ASSERT_GE(source, 0);
+    ASSERT_EQ(dup2(source, sentinel_fd), sentinel_fd);
+    close(source);
+
+    FakeBtmgmt fake("if [ -e /proc/self/fd/99 ]; then exit 9; fi\n"
+                    "printf 'current settings: secure-conn\\n'\n");
+    const auto result = probe_secure_connections("hci0", 250ms);
+    close(sentinel_fd);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(*result);
+}

--- a/test/test_bluetooth_objects.cpp
+++ b/test/test_bluetooth_objects.cpp
@@ -187,6 +187,22 @@ TEST(Capability, FullModeWhenBearerConfirmed) {
     EXPECT_TRUE(cap.setup.empty());
 }
 
+TEST(Capability, SecureConnectionsStateIsInjectedRatherThanReadDuringResolution) {
+    Payload p(join(ADAPTER_FULL, IPHONE_BONDED).c_str());
+    const auto objects = parse_managed_objects(p.v);
+
+    const auto unknown = resolve_capability(objects);
+    EXPECT_FALSE(unknown.secure_connections_known);
+
+    const auto enabled = resolve_capability(objects, true);
+    EXPECT_TRUE(enabled.secure_connections_known);
+    EXPECT_TRUE(enabled.secure_connections);
+
+    const auto disabled = resolve_capability(objects, false);
+    EXPECT_TRUE(disabled.secure_connections_known);
+    EXPECT_FALSE(disabled.secure_connections);
+}
+
 // Without --experimental the bearer interface can never appear, so its absence
 // is conclusive.
 TEST(Capability, CompatibilityWhenExperimentalIsOff) {


### PR DESCRIPTION
Hi! Thanks for this project! I had some difficulty getting it working today, but ultimately did. I did a lot of troubleshooting with Codex and wanted to provide this PR for the parts that seemed like universally helpful changes. However, I don't explicitly endorse every single line of the changes it made and would encourage further review. If you don't want to spend time reviewing largely AI-generated changes, then no worries, I totally understand! I just didn't want the work to go to waste if it was welcome or helpful.

## What changed and why

- Move Bluetooth capability probing off the network loop, bound the `btmgmt` probe with a timeout, and safely terminate/reap only its child process. This prevents a slow or hung controller probe from stalling device discovery and connections.
- Promote an already-connected TLS session when a pairing request is accepted through the local client. This makes accepting a discovered iPhone take effect immediately instead of requiring a reconnect.
- Preserve and display the actual BlueZ advertising error so setup failures are actionable rather than hidden behind a generic message.
- Add visible Bluetooth scan progress, expose Bluetooth pairing for a device already connected over Wi-Fi, and keep the pairing button consistent with the existing action buttons.
- Distinguish a raw Bluetooth link from usable Messages/Notifications services with a "Partially connected" state.
- Explain when an empty Messages view needs Bluetooth synchronization and use a Bluetooth-specific icon.
- Update protocol documentation and translation catalogs for the new behavior and strings.

## Testing

- `cmake --build build/release -j4`
- `ctest --test-dir build/release --output-on-failure` (343/343 tests passed)

