### PR TITLE
Add Nix flake and NixOS module support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,19 +4,21 @@ project(tether VERSION 0.2.18 LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# version from git
-execute_process(
-    COMMAND git describe --tags --always --dirty
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
+# version from git unless a packager supplied one
+if(NOT DEFINED TETHER_VERSION)
+    execute_process(
+        COMMAND git describe --tags --always --dirty
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
 
-if(GIT_VERSION)
-    string(REGEX REPLACE "^v" "" TETHER_VERSION "${GIT_VERSION}")
-else()
-    set(TETHER_VERSION "${PROJECT_VERSION}-unknown")
+    if(GIT_VERSION)
+        string(REGEX REPLACE "^v" "" TETHER_VERSION "${GIT_VERSION}")
+    else()
+        set(TETHER_VERSION "${PROJECT_VERSION}-unknown")
+    endif()
 endif()
 
 configure_file(

--- a/README.md
+++ b/README.md
@@ -84,6 +84,73 @@ The extension communicates with `tetherd` via native messaging. This allows user
 yay -S tether
 ```
 
+### Nix
+
+#### Build from source
+
+Enter the development shell and run the test suite:
+
+```console
+nix develop
+make test
+```
+
+Build or run Tether directly from the flake:
+
+```console
+nix build
+nix run
+nix run .#tether -- --help
+nix run .#tetherd
+```
+
+Bare `nix run` launches `tether-gtk`. The named app outputs are `tether` (CLI),
+`tether-gtk` (GUI), `tetherd` (daemon), and `tether-dialog` (dialog helper).
+
+#### Use the package in NixOS
+
+After adding Tether as a flake input, install its package directly:
+
+```nix
+environment.systemPackages = [
+  inputs.tether.packages.${pkgs.system}.default
+];
+```
+
+Alternatively, apply the overlay and install `pkgs.tether`:
+
+```nix
+nixpkgs.overlays = [ inputs.tether.overlays.default ];
+environment.systemPackages = [ pkgs.tether ];
+```
+
+#### Use the NixOS module
+
+Import the module in your NixOS configuration:
+
+```nix
+imports = [ inputs.tether.nixosModules.default ];
+
+programs.tether = {
+  enable = true;
+
+  wifi = {
+    enable = true;
+    openFirewall = true;
+  };
+
+  bluetooth = {
+    enable = true;
+    adapters = [ "hci0" ];
+  };
+};
+```
+
+Base enablement installs Tether and registers its native messaging hosts; it
+does not start a daemon. Firewall opening is opt-in. Bluetooth experimental
+mode and adapter class changes are also opt-in. If your system uses another
+adapter or multiple adapters, change `bluetooth.adapters` accordingly.
+
 ### Build from Source
 
 On Debian/Ubuntu:

--- a/extension/build.sh
+++ b/extension/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 echo "Building Tether Extensions..."
@@ -14,6 +14,19 @@ CHROME_DIR="$BUILD_DIR/chromium"
 
 ESBUILD=extension/node_modules/.bin/esbuild
 
+make_archive() {
+    local source_dir="$1"
+    local archive="$2"
+
+    if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+        local archive_epoch="$SOURCE_DATE_EPOCH"
+        [ "$archive_epoch" -ge 315532800 ] || archive_epoch=315532800
+        find "$source_dir" -exec touch -d "@$archive_epoch" {} +
+    fi
+
+    (cd "$source_dir" && find . -type f -print | LC_ALL=C sort | zip -Xq "$archive" -@)
+}
+
 mkdir -p "$BROWSER_DIR/src/background" "$BROWSER_DIR/src/content"
 mkdir -p "$MAIL_DIR/src/mail"
 mkdir -p "$CHROME_DIR/src/background" "$CHROME_DIR/src/content"
@@ -24,14 +37,14 @@ echo "Bundling Firefox browser extension..."
 "$ESBUILD" extension/src/content/autofill.js --bundle --outfile="$BROWSER_DIR/src/content/autofill.js"
 cp extension/manifest-browser.json "$BROWSER_DIR/manifest.json"
 if [ -d "extension/icons" ]; then cp -R extension/icons "$BROWSER_DIR/"; fi
-(cd "$BROWSER_DIR" && zip -qr ../tether-browser-extension.zip .)
+make_archive "$BROWSER_DIR" ../tether-browser-extension.zip
 
 # Bundle Mail Extension
 echo "Bundling mail extension..."
 "$ESBUILD" extension/src/mail/extractor.js --bundle --outfile="$MAIL_DIR/src/mail/extractor.js"
 cp extension/manifest-mail.json "$MAIL_DIR/manifest.json"
 if [ -d "extension/icons" ]; then cp -R extension/icons "$MAIL_DIR/"; fi
-(cd "$MAIL_DIR" && zip -qr ../tether-mail-extension.xpi .)
+make_archive "$MAIL_DIR" ../tether-mail-extension.xpi
 
 # Bundle Chromium Extension (Web Store upload)
 echo "Bundling Chromium extension..."
@@ -39,7 +52,7 @@ echo "Bundling Chromium extension..."
 "$ESBUILD" extension/src/content/autofill.js --bundle --outfile="$CHROME_DIR/src/content/autofill.js"
 cp extension/manifest-browser.json "$CHROME_DIR/manifest.json"
 if [ -d "extension/icons" ]; then cp -R extension/icons "$CHROME_DIR/"; fi
-(cd "$CHROME_DIR" && zip -qr ../tether-chromium-extension.zip .)
+make_archive "$CHROME_DIR" ../tether-chromium-extension.zip
 
 echo "Extensions successfully built and packaged in $BUILD_DIR"
 echo "  Firefox browser: $BUILD_DIR/tether-browser-extension.zip"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  description = "Use an iPhone with Linux";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      tetherModule = import ./nix/module.nix;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          tether = pkgs.callPackage ./nix/package.nix {
+            npmConfigHook = pkgs.npmHooks.npmConfigHook;
+          };
+        in
+        {
+          default = tether;
+          inherit tether;
+        }
+      );
+
+      apps = forAllSystems (
+        system:
+        let
+          tether = self.packages.${system}.tether;
+          app = name: {
+            type = "app";
+            program = "${tether}/bin/${name}";
+          };
+        in
+        {
+          default = app "tether-gtk";
+          tether = app "tether";
+          tether-gtk = app "tether-gtk";
+          tetherd = app "tetherd";
+          tether-dialog = app "tether-dialog";
+        }
+      );
+
+      overlays.default = final: _prev: {
+        tether = final.callPackage ./nix/package.nix {
+          npmConfigHook = final.npmHooks.npmConfigHook;
+        };
+      };
+
+      nixosModules.default = tetherModule;
+      nixosModules.tether = tetherModule;
+
+      checks = forAllSystems (system: {
+        package = self.packages.${system}.tether;
+        module = import ./nix/module-test.nix {
+          inherit nixpkgs system tetherModule;
+        };
+      });
+
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt);
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.tether ];
+            packages = [ pkgs.clang-tools ];
+          };
+        }
+      );
+    };
+}

--- a/nix/module-test.nix
+++ b/nix/module-test.nix
@@ -26,6 +26,7 @@ let
   };
   config = evaluated.config;
   tether = config.programs.tether.package;
+  thunderbird = config.programs.thunderbird.package;
   baseOnlyConfig =
     (lib.nixosSystem {
       inherit system;
@@ -72,6 +73,7 @@ let
 in
 assert lib.elem tether config.environment.systemPackages;
 assert lib.elem tether config.programs.firefox.nativeMessagingHosts.packages;
+assert !config.programs.thunderbird.enable;
 assert config.environment.etc ? "chromium/native-messaging-hosts/com.tether.extension.json";
 assert config.environment.etc ? "opt/chrome/native-messaging-hosts/com.tether.extension.json";
 assert config.services.avahi.enable;
@@ -93,5 +95,15 @@ assert config.hardware.bluetooth.settings.General.Experimental;
 assert config.systemd.services ? "tether-btclass@hci0";
 assert config.systemd.services ? "tether-btclass@hci1";
 pkgs.runCommand "tether-module-test" { } ''
+  export HOME="$TMPDIR/home"
+  export MOZ_HOME="$TMPDIR/mozilla"
+
+  ${thunderbird}/bin/thunderbird --version
+
+  manifest="$MOZ_HOME/native-messaging-hosts/com.tether.extension.json"
+  test -L "$manifest"
+  test "$(readlink "$manifest")" = \
+    "${tether}/lib/mozilla/native-messaging-hosts/com.tether.extension.json"
+
   touch "$out"
 ''

--- a/nix/module-test.nix
+++ b/nix/module-test.nix
@@ -1,0 +1,97 @@
+{
+  nixpkgs,
+  system,
+  tetherModule,
+}:
+let
+  lib = nixpkgs.lib;
+  pkgs = import nixpkgs { inherit system; };
+  evaluated = lib.nixosSystem {
+    inherit system;
+    modules = [
+      tetherModule
+      {
+        programs.tether = {
+          enable = true;
+          wifi.enable = true;
+          wifi.openFirewall = true;
+          bluetooth.enable = true;
+          bluetooth.adapters = [
+            "hci0"
+            "hci1"
+          ];
+        };
+      }
+    ];
+  };
+  config = evaluated.config;
+  tether = config.programs.tether.package;
+  baseOnlyConfig =
+    (lib.nixosSystem {
+      inherit system;
+      modules = [
+        tetherModule
+        { programs.tether.enable = true; }
+      ];
+    }).config;
+  masterDisabledConfig =
+    (lib.nixosSystem {
+      inherit system;
+      modules = [
+        tetherModule
+        {
+          programs.tether = {
+            enable = false;
+            wifi.enable = true;
+            wifi.openFirewall = true;
+            bluetooth.enable = true;
+            bluetooth.adapters = [
+              "hci0"
+              "hci1"
+            ];
+          };
+        }
+      ];
+    }).config;
+  wifiOnlyConfig =
+    (lib.nixosSystem {
+      inherit system;
+      modules = [
+        tetherModule
+        {
+          programs.tether = {
+            enable = true;
+            wifi.enable = true;
+          };
+        }
+      ];
+    }).config;
+  hasTetherBluetoothService =
+    moduleConfig:
+    lib.any (lib.hasPrefix "tether-btclass@") (builtins.attrNames moduleConfig.systemd.services);
+in
+assert lib.elem tether config.environment.systemPackages;
+assert lib.elem tether config.programs.firefox.nativeMessagingHosts.packages;
+assert config.environment.etc ? "chromium/native-messaging-hosts/com.tether.extension.json";
+assert config.environment.etc ? "opt/chrome/native-messaging-hosts/com.tether.extension.json";
+assert config.services.avahi.enable;
+assert config.services.avahi.openFirewall;
+assert lib.elem 5134 config.networking.firewall.allowedTCPPorts;
+assert !baseOnlyConfig.services.avahi.enable;
+assert !lib.elem 5134 baseOnlyConfig.networking.firewall.allowedTCPPorts;
+assert !baseOnlyConfig.hardware.bluetooth.enable;
+assert !hasTetherBluetoothService baseOnlyConfig;
+assert !masterDisabledConfig.services.avahi.enable;
+assert !lib.elem 5134 masterDisabledConfig.networking.firewall.allowedTCPPorts;
+assert !masterDisabledConfig.hardware.bluetooth.enable;
+assert !hasTetherBluetoothService masterDisabledConfig;
+assert wifiOnlyConfig.services.avahi.enable;
+assert !wifiOnlyConfig.services.avahi.openFirewall;
+assert !lib.elem 5134 wifiOnlyConfig.networking.firewall.allowedTCPPorts;
+assert config.hardware.bluetooth.enable;
+assert config.hardware.bluetooth.settings.General.Experimental;
+assert config.systemd.services ? "tether-btclass@hci0";
+assert config.systemd.services ? "tether-btclass@hci1";
+pkgs.runCommand "tether-module-test" { } ''
+  touch "$out"
+''

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,85 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.tether;
+  bluetoothService = adapter: {
+    name = "tether-btclass@${adapter}";
+    value = {
+      description = "Set Bluetooth Class of Device for Tether on ${adapter}";
+      after = [ "bluetooth.service" ];
+      partOf = [ "bluetooth.service" ];
+      wantedBy = [ "bluetooth.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = pkgs.writeShellScript "tether-btclass-${adapter}" ''
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            ${pkgs.bluez}/bin/btmgmt --index ${adapter} class 4 8 >/dev/null 2>&1
+            if ${pkgs.bluez}/bin/btmgmt --index ${adapter} info 2>/dev/null \
+              | ${pkgs.gnugrep}/bin/grep -q "class 0x..0408"; then
+              exit 0
+            fi
+            ${pkgs.coreutils}/bin/sleep 1
+          done
+          exit 1
+        '';
+      };
+    };
+  };
+in
+{
+  options.programs.tether = {
+    enable = lib.mkEnableOption "Tether, an iPhone integration bridge for Linux";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./nix/package.nix { }";
+      description = "The Tether package to install and integrate.";
+    };
+    wifi.enable = lib.mkEnableOption "Tether Wi-Fi discovery through Avahi";
+    wifi.openFirewall = lib.mkEnableOption "the mDNS and TCP firewall ports required by Tether";
+    bluetooth.enable = lib.mkEnableOption "Tether Bluetooth integration";
+    bluetooth.adapters = lib.mkOption {
+      type = lib.types.listOf (lib.types.strMatching "hci[0-9]+");
+      default = [ "hci0" ];
+      example = [
+        "hci0"
+        "hci1"
+      ];
+      description = "Bluetooth HCI adapters whose class Tether should configure.";
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+      programs.firefox.nativeMessagingHosts.packages = [ cfg.package ];
+      environment.etc = {
+        "chromium/native-messaging-hosts/com.tether.extension.json".source =
+          "${cfg.package}/etc/chromium/native-messaging-hosts/com.tether.extension.json";
+        "opt/chrome/native-messaging-hosts/com.tether.extension.json".source =
+          "${cfg.package}/etc/opt/chrome/native-messaging-hosts/com.tether.extension.json";
+      };
+    })
+
+    (lib.mkIf (cfg.enable && cfg.wifi.enable) {
+      services.avahi.enable = true;
+      services.avahi.openFirewall = lib.mkDefault false;
+    })
+
+    (lib.mkIf (cfg.enable && cfg.wifi.openFirewall) {
+      services.avahi.openFirewall = true;
+      networking.firewall.allowedTCPPorts = [ 5134 ];
+    })
+
+    (lib.mkIf (cfg.enable && cfg.bluetooth.enable) {
+      hardware.bluetooth.enable = true;
+      hardware.bluetooth.settings.General.Experimental = true;
+      systemd.services = builtins.listToAttrs (map bluetoothService cfg.bluetooth.adapters);
+    })
+  ];
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -58,6 +58,11 @@ in
     (lib.mkIf cfg.enable {
       environment.systemPackages = [ cfg.package ];
       programs.firefox.nativeMessagingHosts.packages = [ cfg.package ];
+      programs.thunderbird.package = lib.mkDefault (
+        pkgs.thunderbird.override {
+          nativeMessagingHosts = [ cfg.package ];
+        }
+      );
       environment.etc = {
         "chromium/native-messaging-hosts/com.tether.extension.json".source =
           "${cfg.package}/etc/chromium/native-messaging-hosts/com.tether.extension.json";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  stdenv,
+  fetchNpmDeps,
+  npmHooks,
+  npmConfigHook ? npmHooks.npmConfigHook,
+  cmake,
+  ninja,
+  pkg-config,
+  gettext,
+  nodejs,
+  zip,
+  git,
+  wrapGAppsHook3,
+  wayland,
+  avahi,
+  openssl,
+  glib,
+  gtk3,
+  gtk-layer-shell,
+  libnotify,
+  nlohmann_json,
+  gtest,
+  bluez,
+  runtimeShell,
+  gnugrep,
+  coreutils,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tether";
+  version = "0.2.18";
+
+  src = lib.cleanSourceWith {
+    name = "source";
+    src = ../.;
+    filter =
+      path: _type:
+      let
+        relative = lib.removePrefix "${toString ../.}/" (toString path);
+        components = lib.splitString "/" relative;
+        topLevel = lib.head components;
+      in
+      (builtins.elem topLevel [
+        "CMakeLists.txt"
+        "LICENSE"
+        "README.md"
+        "cmake_uninstall.cmake.in"
+        "docs"
+        "extension"
+        "packaging"
+        "po"
+        "src"
+        "test"
+      ])
+      && !(lib.any (
+        name:
+        builtins.elem name [
+          ".git"
+          "build"
+          "node_modules"
+          "result"
+        ]
+      ) components)
+      && !(lib.any (lib.hasPrefix "result-") components);
+  };
+
+  npmRoot = "extension";
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    sourceRoot = "source/extension";
+    hash = "sha256-/GrpRCr9/xv8fwh7b8zl37aMUh2rKeE6vJuyw8S/S+o=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    gettext
+    nodejs
+    npmConfigHook
+    zip
+    git
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    wayland
+    avahi
+    openssl
+    glib
+    gtk3
+    gtk-layer-shell
+    libnotify
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_JSON" "${nlohmann_json.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_GOOGLETEST" "${gtest.src}")
+    (lib.cmakeFeature "TETHER_VERSION" finalAttrs.version)
+    (lib.cmakeFeature "BLUETOOTHD_PATH" "${bluez}/libexec/bluetooth/bluetoothd")
+    (lib.cmakeFeature "SYSTEMD_UNIT_DIR" "lib/systemd/system")
+    (lib.cmakeFeature "CHROME_MESSAGING_DIR" "${placeholder "out"}/etc/chromium/native-messaging-hosts")
+    (lib.cmakeFeature "GOOGLE_CHROME_MESSAGING_DIR" "${placeholder "out"}/etc/opt/chrome/native-messaging-hosts")
+    (lib.cmakeFeature "MOZILLA_MESSAGING_DIR" "${placeholder "out"}/lib/mozilla/native-messaging-hosts")
+    (lib.cmakeFeature "THUNDERBIRD_MESSAGING_DIR" "${placeholder "out"}/lib/thunderbird/native-messaging-hosts")
+  ];
+
+  postPatch = ''
+    patchShebangs extension/build.sh
+    substituteInPlace packaging/systemd/tether-btclass@.service \
+      --replace-fail "/bin/sh" "${runtimeShell}" \
+      --replace-fail "btmgmt --index" "${bluez}/bin/btmgmt --index" \
+      --replace-fail "| grep -q" "| ${gnugrep}/bin/grep -q" \
+      --replace-fail "    sleep 1;" "    ${coreutils}/bin/sleep 1;"
+  '';
+
+  doCheck = true;
+  # Crypto tests share a temporary HOME and must not run concurrently.
+  enableParallelChecking = false;
+
+  postCheck = ''
+    (cd .. && npm test --prefix extension)
+  '';
+
+  postInstall = ''
+    patchShebangs "$out/bin/tether-native-host"
+
+    for manifest in \
+      "$out/etc/chromium/native-messaging-hosts/com.tether.extension.json" \
+      "$out/etc/opt/chrome/native-messaging-hosts/com.tether.extension.json" \
+      "$out/lib/mozilla/native-messaging-hosts/com.tether.extension.json" \
+      "$out/lib/thunderbird/native-messaging-hosts/com.tether.extension.json"; do
+      test -f "$manifest"
+    done
+  '';
+
+  meta = {
+    description = "Use an iPhone with Linux";
+    homepage = "https://github.com/zackb/tether";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "tether-gtk";
+  };
+})


### PR DESCRIPTION
First of all, excellent work on this! I got it setup and running on my NixOS and thought it might be helpful to others to get it rolled in upstream

## Summary

- add a pinned Nix flake supporting `x86_64-linux` and `aarch64-linux`
- provide packages, apps, a development shell, checks, formatter, overlay, and NixOS module
- package Tether and its browser/mail extensions with offline, reproducible builds
- register native-messaging hosts for Firefox, Chromium, Chrome, and Thunderbird
- add explicit NixOS options for Wi-Fi/firewall and Bluetooth host integration
- allow packagers to supply `TETHER_VERSION`

## Verification

- `nix flake check`
- `nix run .#tether -- --help`
- 342 CTest tests passed
- 53 extension tests passed

`aarch64-linux` outputs were evaluation-tested but not built