### PR TITLE
feat: multiple bluetooth adapter support, LE retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ make install
    Bluetooth outside of Tether, so running them is your call. The same steps
    appear in the GTK app's Devices page, with a "Copy commands" button.
 
+   *If* you have more than one Bluetooth controller, pick the one to use. Default is the first powered one.
+
+   ```bash
+   tether --bt-adapter hci1     # or the controller's address, or "auto"
+   ```
+
    Then pair. In the GTK app, pick your iPhone under BLUETOOTH on the Devices
    page and press "Pair over Bluetooth". Confirm the code on both the iPhone and
    Linux.

--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -187,6 +187,8 @@ checks the daemon does not make.
 | The status says the iPhone is not answering on LE, and its permission is on | The phone's Bluetooth stack is wedged, which the granted permission does not prevent | Turn Bluetooth off and back on **on the iPhone**. Re-pairing and re-toggling the permission do not clear this |
 | Everything connects but `ancs_ready` stays false | Compatibility mode, or iOS has not authorized notification content yet | Check `Mode:` in `tether --bt-status`. In full mode the daemon retries, the first request returns `NotPermitted` until the prompt on the phone is approved |
 | A group conversation cannot be replied to | Working as designed until the route is unambiguous | The thread's `reply_reason` says which condition failed |
+| The iPhone never offers the "Show Notifications" toggle, and messages and contacts work | Fixed. A BR/EDR-only bond used to latch notification mirroring off in the config, which takes the ANCS solicitation off air -- so the phone is never asked for the service | Nothing. On an older build, `tether --bt-ancs on` then `tether --bt-solicit`; `tether --bt-status` now shows mirroring under `Notifications:` -- see 2026-09-01 |
+| Pairing bonds but the LE half never derives, on a machine with a USB dongle plugged in | Tether used the first powered controller, which is the dongle, not the built-in one | `tether --bt-status` marks the controller in use; `tether --bt-adapter <hciN>` picks another -- see 2026-09-01 |
 | The link reads down forever with `br-connection-unknown`, while messages, contacts and notifications all work | This computer offers the iPhone no BR/EDR profile to connect to, and BlueZ only reports a link up while some local profile is connected | Nothing. Tether no longer waits on that link -- see 2026-08-23 below. Restoring the `a2dp_sink` and `hfp_hf` roles makes it read up again, at the cost of the phone's audio moving here |
 | The iPhone's audio moves to the computer when Tether connects | The machine advertises itself as a Bluetooth speaker/headset, and iOS routes to it. Not caused by Tether beyond bringing the link up | See "Keeping the phone's audio on the phone" below |
 
@@ -1381,3 +1383,44 @@ Fixed:
   every tick, so `refresh_capability()` had nothing left to do and is gone.
 - Group replies follow `ancs_enabled`, not only `ancs_content_enabled`. With mirroring off the
   correlator is never fed, so a group thread that still advertised a reply route could only fail.
+
+### 2026-09-01 - Mirroring latched itself off, and pairing ran on the wrong controller
+
+Reported as #69 by two people, two unrelated causes, one symptom each.
+
+**A BR/EDR-only bond turned notification mirroring off, permanently and invisibly.**
+`run_bt_pair()` persisted `ancs_enabled = false` whenever a transaction it ran produced a bond
+without an LE half. `should_solicit_ancs()` is gated on that flag, so the solicitation advert
+never went on air again -- and iOS reveals the "Show Notifications" toggle only while a bonded
+peer is soliciting ANCS. The reporter's words were that the toggle never appeared. It could not:
+the phone was never asked.
+
+Nothing surfaced the state either. `--bt-status` had no row for it, `--bt-devices` no flag; only
+the GTK checkbox read it. The recovery a second reporter found by hand -- `tether --bt-ancs on`
+then `tether --bt-solicit` -- is the only one that existed.
+
+This is the same trap the 2026-08-25 entry records for `auth_strategy`: a failed attempt writing
+its own failure into the config, with nothing in the CLI to undo it. The `ancs_enabled` copy of
+it was missed at the time.
+
+Fixed by deleting the latch. A dual bond still turns the preference on; nothing turns it off but
+the user. The runtime already gates ANCS on `ancs_available()` and on `bearer.le_available`, so a
+BR/EDR-only bond costs one advert that the iPhone ignores, not a permanent silence. `--bt-status`
+grew a `Notifications:` row that names `tether --bt-ancs on` when it is off.
+
+**Everything ran on `hci0`, which was a Cambridge Silicon Radio clone dongle.** The reporter had
+that dongle and an Intel 9460/9560; `resolve_capability()` took the first *powered* adapter from a
+path-sorted list, and `pairing.cpp` took `adapters.front()` at six sites with no powered check at
+all -- so the two could also disagree about which controller they were describing. There was no
+setting, no flag, and `--bt-status` printed adapter addresses without saying which one was in use.
+He found it by accident, unplugged the dongle, and pairing worked on the first attempt.
+
+Fixed with `preferred_adapter(objects, id)`, one picker for both: the configured controller when
+present, else the first powered, else the first. `Config::adapter` holds an `hciN` or an address,
+`tether --bt-adapter <hciN|auto>` sets it, and `--bt-status` marks the controller in use and says
+when a pinned one is absent. `pairing.cpp` routes all six sites through it.
+
+Not captured: whether the CSR dongle can derive the LE keys at all. It reported `class=ok`,
+`secure-connections=on` and both LE roles, and still produced only BR/EDR bonds across several
+attempts -- consistent with the clone firmware these dongles are known for, but no `btmon` capture
+was taken.

--- a/docs/man/man1/tether.1.in
+++ b/docs/man/man1/tether.1.in
@@ -103,6 +103,11 @@ Turn notification mirroring on or off.
 \fB\-\-bt-ancs-content\fR \fIon\fR|\fIoff\fR
 Mirror notification titles and bodies, not just the app.
 .TP
+\fB\-\-bt-adapter\fR \fIhciN\fR|\fIauto\fR
+Choose which Bluetooth controller to use, by \fIhciN\fR or by address. Defaults to
+\fIauto\fR, the first powered controller, which is the wrong one on a machine with
+more than one. \fB\-\-bt-status\fR marks the controller in use.
+.TP
 \fB\-\-bt-diagnostics\fR
 Print a redacted Bluetooth report for a bug report.
 .SH EXAMPLES

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -134,6 +134,10 @@ msgstr "Zapnout nebo vypnout zrcadlení oznámení."
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Zrcadlit názvy a text oznámení, nejen aplikaci."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Vybere, který adaptér Bluetooth se použije."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -276,6 +280,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Vazba"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Oznámení"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "zrcadlení zapnuto"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "zrcadlení vypnuto (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -288,6 +304,15 @@ msgstr "připojuje se"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "vypnuto (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "používá se"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "Adaptér {} není přítomen; použije se první zapnutý."
 
 #: src/cli/main.cpp
 #, c-format
@@ -371,10 +396,6 @@ msgstr "Zprávy (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Kontakty (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Oznámení"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -535,6 +556,25 @@ msgstr "Zrcadlení oznámení zapnuto."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Zrcadlení oznámení vypnuto."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Očekáván adaptér, např. --bt-adapter hci1, nebo --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Žádný adaptér Bluetooth neodpovídá „{}“. Dostupné:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "Výběr adaptéru je automatický: první zapnutý.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Používá se adaptér {}."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1445,3 +1485,7 @@ msgstr "Synchronizace zařízení"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Spárujte zařízení a synchronizujte schránku po síti"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Vazba"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -135,6 +135,10 @@ msgstr "Die Spiegelung von Mitteilungen ein- oder ausschalten."
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Titel und Text der Mitteilungen spiegeln, nicht nur die App."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Wählt den zu verwendenden Bluetooth-Adapter."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -274,6 +278,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Bindung"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Mitteilungen"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "Spiegelung ein"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "Spiegelung aus (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -286,6 +302,15 @@ msgstr "verbindet"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "aus (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "in Verwendung"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "Adapter {} ist nicht vorhanden; es wird der erste eingeschaltete verwendet."
 
 #: src/cli/main.cpp
 #, c-format
@@ -369,10 +394,6 @@ msgstr "Nachrichten (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Kontakte (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Mitteilungen"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -539,6 +560,25 @@ msgstr "Spiegelung von Mitteilungen eingeschaltet."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Spiegelung von Mitteilungen ausgeschaltet."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Adapter erwartet, z. B. --bt-adapter hci1, oder --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Kein Bluetooth-Adapter passt zu „{}“. Verfügbar:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "Die Adapterauswahl ist automatisch: der erste eingeschaltete.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Adapter {} wird verwendet."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1476,6 +1516,10 @@ msgstr "Gerätesynchronisierung"
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr ""
 "Geräte koppeln und die Zwischenablage über das Netzwerk synchronisieren"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Bindung"
 
 #~ msgid ""
 #~ "tether - Wayland companion CLI\n"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -135,6 +135,10 @@ msgstr "Activar o desactivar la duplicación de notificaciones."
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Duplicar títulos y contenido de las notificaciones, no solo la app."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Elige qué adaptador Bluetooth usar."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -276,6 +280,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Vínculo"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Notificaciones"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "duplicación activada"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "duplicación desactivada (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -288,6 +304,15 @@ msgstr "conectando"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "desactivado (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "en uso"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "El adaptador {} no está presente; se usa el primero encendido."
 
 #: src/cli/main.cpp
 #, c-format
@@ -369,10 +394,6 @@ msgstr "Mensajes (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Contactos (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Notificaciones"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -536,6 +557,25 @@ msgstr "Duplicación de notificaciones activada."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Duplicación de notificaciones desactivada."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Se esperaba un adaptador, p. ej. --bt-adapter hci1, o --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Ningún adaptador Bluetooth coincide con «{}». Disponibles:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "La selección de adaptador es automática: el primero encendido.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Usando el adaptador {}."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1463,6 +1503,10 @@ msgstr "Sincronización de dispositivos"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Empareje dispositivos y sincronice el portapapeles a través de la red"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Vínculo"
 
 #~ msgid ""
 #~ "tether - Wayland companion CLI\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -138,6 +138,10 @@ msgstr "Activer ou désactiver la duplication des notifications."
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr ""
 "Dupliquer les titres et le contenu des notifications, pas seulement l'app."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Choisit l'adaptateur Bluetooth à utiliser."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -280,6 +284,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Lien"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Notifications"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "duplication activée"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "duplication désactivée (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -292,6 +308,15 @@ msgstr "connexion en cours"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "désactivé (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "utilisé"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "L'adaptateur {} est absent ; le premier adaptateur allumé est utilisé."
 
 #: src/cli/main.cpp
 #, c-format
@@ -373,10 +398,6 @@ msgstr "Messages (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Contacts (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Notifications"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -541,6 +562,25 @@ msgstr "Duplication des notifications activée."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Duplication des notifications désactivée."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Adaptateur attendu, par ex. --bt-adapter hci1, ou --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Aucun adaptateur Bluetooth ne correspond à « {} ». Disponibles :\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "La sélection de l'adaptateur est automatique : le premier allumé.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Utilisation de l'adaptateur {}."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1471,6 +1511,10 @@ msgstr "Synchronisation d'appareils"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Appairez des appareils et synchronisez le presse-papiers sur le réseau"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Lien"
 
 #~ msgid ""
 #~ "tether - Wayland companion CLI\n"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -136,6 +136,10 @@ msgstr "Attiva o disattiva il mirroring delle notifiche."
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Rispecchia titoli e testo delle notifiche, non solo l'app."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Sceglie quale adattatore Bluetooth usare."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -276,6 +280,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Associazione"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Notifiche"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "mirroring attivo"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "mirroring disattivato (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -288,6 +304,15 @@ msgstr "in connessione"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "disattivato (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "in uso"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "L'adattatore {} non è presente; viene usato il primo acceso."
 
 #: src/cli/main.cpp
 #, c-format
@@ -369,10 +394,6 @@ msgstr "Messaggi (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Contatti (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Notifiche"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -537,6 +558,25 @@ msgstr "Mirroring delle notifiche attivato."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Mirroring delle notifiche disattivato."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Atteso un adattatore, ad es. --bt-adapter hci1, oppure --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Nessun adattatore Bluetooth corrisponde a «{}». Disponibili:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "La selezione dell'adattatore è automatica: il primo acceso.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Uso dell'adattatore {}."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1460,3 +1500,7 @@ msgstr "Sincronizzazione dispositivi"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Accoppia dispositivi e sincronizza gli appunti sulla rete"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Associazione"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -134,6 +134,10 @@ msgstr "通知のミラーリングをオンまたはオフにします。"
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "アプリ名だけでなく、通知のタイトルと本文もミラーリングします。"
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "使用する Bluetooth アダプタを選択します。"
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -270,6 +274,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "ボンド"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "通知"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "ミラーリング有効"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "ミラーリング無効 (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -282,6 +298,15 @@ msgstr "接続中"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "オフ (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "使用中"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "アダプタ {} がありません。電源の入っている最初のアダプタを使用します。"
 
 #: src/cli/main.cpp
 #, c-format
@@ -359,10 +384,6 @@ msgstr "メッセージ (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "連絡先 (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "通知"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -518,6 +539,25 @@ msgstr "通知のミラーリングを有効にしました。"
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "通知のミラーリングを無効にしました。"
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "アダプタを指定してください。例: --bt-adapter hci1 または --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "「{}」に一致する Bluetooth アダプタがありません。利用可能:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "アダプタの選択は自動です。電源の入っている最初のアダプタを使用します。\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "アダプタ {} を使用します。"
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1427,3 +1467,7 @@ msgstr "デバイスの同期"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "デバイスをペアリングし、ネットワーク越しにクリップボードを同期します"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "ボンド"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -133,6 +133,10 @@ msgstr "알림 미러링을 켜거나 끕니다."
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "앱뿐 아니라 알림의 제목과 본문도 미러링합니다."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "사용할 Bluetooth 어댑터를 선택합니다."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -269,6 +273,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "본드"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "알림"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "미러링 켬"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "미러링 끔 (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -281,6 +297,15 @@ msgstr "연결 중"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "꺼짐 (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "사용 중"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "어댑터 {}이(가) 없습니다. 전원이 켜진 첫 번째 어댑터를 사용합니다."
 
 #: src/cli/main.cpp
 #, c-format
@@ -358,10 +383,6 @@ msgstr "메시지 (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "연락처 (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "알림"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -516,6 +537,25 @@ msgstr "알림 미러링을 켰습니다."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "알림 미러링을 껐습니다."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "어댑터를 지정하세요. 예: --bt-adapter hci1 또는 --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "'{}'와(과) 일치하는 Bluetooth 어댑터가 없습니다. 사용 가능:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "어댑터 선택은 자동입니다. 전원이 켜진 첫 번째 어댑터를 사용합니다.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "어댑터 {}을(를) 사용합니다."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1413,3 +1453,7 @@ msgstr "기기 동기화"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "기기를 페어링하고 네트워크를 통해 클립보드를 동기화합니다"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "본드"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -135,6 +135,10 @@ msgstr "Het spiegelen van meldingen in- of uitschakelen."
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Titels en tekst van meldingen spiegelen, niet alleen de app."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Kiest welke Bluetooth-adapter wordt gebruikt."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -275,6 +279,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Koppeling"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Meldingen"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "spiegelen ingeschakeld"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "spiegelen uitgeschakeld (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -287,6 +303,15 @@ msgstr "verbinden"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "uit (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "in gebruik"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "Adapter {} is niet aanwezig; de eerste ingeschakelde adapter wordt gebruikt."
 
 #: src/cli/main.cpp
 #, c-format
@@ -367,10 +392,6 @@ msgstr "Berichten (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Contacten (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Meldingen"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -531,6 +552,25 @@ msgstr "Spiegelen van meldingen ingeschakeld."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Spiegelen van meldingen uitgeschakeld."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Adapter verwacht, bijv. --bt-adapter hci1, of --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Geen Bluetooth-adapter komt overeen met '{}'. Beschikbaar:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "Adapterkeuze is automatisch: de eerste ingeschakelde.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Adapter {} wordt gebruikt."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1453,3 +1493,7 @@ msgstr "Apparaatsynchronisatie"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Apparaten koppelen en het klembord over het netwerk synchroniseren"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Koppeling"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -135,6 +135,10 @@ msgstr "Włącz lub wyłącz kopiowanie powiadomień."
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Kopiuj tytuły i treść powiadomień, nie tylko aplikację."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Wybiera używany adapter Bluetooth."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -277,6 +281,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Powiązanie"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Powiadomienia"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "kopiowanie włączone"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "kopiowanie wyłączone (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -289,6 +305,15 @@ msgstr "łączenie"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "wyłączone (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "w użyciu"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "Adapter {} nie jest obecny; używany jest pierwszy włączony."
 
 #: src/cli/main.cpp
 #, c-format
@@ -372,10 +397,6 @@ msgstr "Wiadomości (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Kontakty (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Powiadomienia"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -537,6 +558,25 @@ msgstr "Kopiowanie powiadomień włączone."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Kopiowanie powiadomień wyłączone."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Oczekiwano adaptera, np. --bt-adapter hci1, lub --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Żaden adapter Bluetooth nie pasuje do „{}”. Dostępne:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "Wybór adaptera jest automatyczny: pierwszy włączony.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Używany adapter: {}."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1460,3 +1500,7 @@ msgstr "Synchronizacja urządzeń"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Sparuj urządzenia i synchronizuj schowek przez sieć"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Powiązanie"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -135,6 +135,10 @@ msgstr "Ativar ou desativar o espelhamento de notificações."
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Espelhar títulos e texto das notificações, não apenas o app."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Escolhe qual adaptador Bluetooth usar."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -275,6 +279,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Vínculo"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Notificações"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "espelhamento ativado"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "espelhamento desativado (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -287,6 +303,15 @@ msgstr "conectando"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "desativado (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "em uso"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "O adaptador {} não está presente; usando o primeiro ligado."
 
 #: src/cli/main.cpp
 #, c-format
@@ -368,10 +393,6 @@ msgstr "Mensagens (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Contatos (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Notificações"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -533,6 +554,25 @@ msgstr "Espelhamento de notificações ativado."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Espelhamento de notificações desativado."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Esperado um adaptador, p. ex. --bt-adapter hci1, ou --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Nenhum adaptador Bluetooth corresponde a '{}'. Disponíveis:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "A seleção de adaptador é automática: o primeiro ligado.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Usando o adaptador {}."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1454,3 +1494,7 @@ msgstr "Sincronização de dispositivos"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Pareie dispositivos e sincronize a área de transferência pela rede"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Vínculo"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -135,6 +135,10 @@ msgstr "Включить или выключить дублирование ув
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Дублировать заголовки и текст уведомлений, а не только приложение."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Выбор используемого адаптера Bluetooth."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -277,6 +281,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Связь"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Уведомления"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "дублирование включено"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "дублирование выключено (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -289,6 +305,15 @@ msgstr "подключение"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "выключено (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "используется"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "Адаптер {} отсутствует; используется первый включённый."
 
 #: src/cli/main.cpp
 #, c-format
@@ -372,10 +397,6 @@ msgstr "Сообщения (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Контакты (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Уведомления"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -539,6 +560,25 @@ msgstr "Дублирование уведомлений включено."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Дублирование уведомлений выключено."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Ожидался адаптер, например --bt-adapter hci1, или --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Ни один адаптер Bluetooth не соответствует «{}». Доступные:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "Выбор адаптера автоматический: первый включённый.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Используется адаптер {}."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1458,3 +1498,7 @@ msgstr "Синхронизация устройств"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Создавайте пары устройств и синхронизируйте буфер обмена по сети"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Связь"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -135,6 +135,10 @@ msgstr "Slå på eller av spegling av aviseringar."
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Spegla aviseringarnas rubrik och text, inte bara appen."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Väljer vilken Bluetooth-adapter som ska användas."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -274,6 +278,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Bindning"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Aviseringar"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "spegling aktiverad"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "spegling avaktiverad (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -286,6 +302,15 @@ msgstr "ansluter"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "av (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "används"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "Adapter {} finns inte; den första påslagna används i stället."
 
 #: src/cli/main.cpp
 #, c-format
@@ -366,10 +391,6 @@ msgstr "Meddelanden (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Kontakter (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Aviseringar"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -530,6 +551,25 @@ msgstr "Spegling av aviseringar aktiverad."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Spegling av aviseringar avaktiverad."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Förväntade en adapter, t.ex. --bt-adapter hci1, eller --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Ingen Bluetooth-adapter matchar ”{}”. Tillgängliga:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "Adaptervalet är automatiskt: den första påslagna.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Använder adapter {}."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1439,3 +1479,7 @@ msgstr "Enhetssynkronisering"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Parkoppla enheter och synkronisera urklipp över nätverket"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Bindning"

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: tether 0.2.20\n"
+"Project-Id-Version: tether 0.2.21\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -128,6 +128,10 @@ msgstr ""
 
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -254,6 +258,18 @@ msgstr ""
 msgid "Bond"
 msgstr ""
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr ""
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -265,6 +281,15 @@ msgstr ""
 
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -336,10 +361,6 @@ msgstr ""
 
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
-msgstr ""
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
 msgstr ""
 
 #: src/cli/main.cpp
@@ -492,6 +513,25 @@ msgstr ""
 
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
 msgstr ""
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -134,6 +134,10 @@ msgstr "Bildirim yansıtmayı aç ya da kapat."
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr ""
 "Yalnızca uygulamayı değil, bildirimlerin başlığını ve metnini de yansıt."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Hangi Bluetooth bağdaştırıcısının kullanılacağını seçer."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -273,6 +277,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Bağ"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Bildirimler"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "yansıtma açık"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "yansıtma kapalı (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -285,6 +301,15 @@ msgstr "bağlanıyor"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "kapalı (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "kullanımda"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "{} bağdaştırıcısı yok; bunun yerine açık olan ilk bağdaştırıcı kullanılıyor."
 
 #: src/cli/main.cpp
 #, c-format
@@ -365,10 +390,6 @@ msgstr "Mesajlar (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Kişiler (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Bildirimler"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -529,6 +550,25 @@ msgstr "Bildirim yansıtma etkinleştirildi."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Bildirim yansıtma devre dışı bırakıldı."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Bir bağdaştırıcı bekleniyordu, ör. --bt-adapter hci1 veya --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "'{}' ile eşleşen Bluetooth bağdaştırıcısı yok. Kullanılabilir:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "Bağdaştırıcı seçimi otomatik: açık olan ilk bağdaştırıcı.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "{} bağdaştırıcısı kullanılıyor."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1436,3 +1476,7 @@ msgstr "Aygıt eşzamanlaması"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Aygıtları eşleştirin ve panoyu ağ üzerinden eşzamanlayın"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Bağ"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -136,6 +136,10 @@ msgstr "Увімкнути або вимкнути дублювання спов
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "Дублювати заголовки та текст сповіщень, а не лише програму."
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "Вибирає, який адаптер Bluetooth використовувати."
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -278,6 +282,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "Зв'язок"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "Сповіщення"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "дублювання увімкнено"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "дублювання вимкнено (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -290,6 +306,15 @@ msgstr "з'єднання"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "вимкнено (--bt-enable on)"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "використовується"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "Адаптера {} немає; використовується перший увімкнений."
 
 #: src/cli/main.cpp
 #, c-format
@@ -373,10 +398,6 @@ msgstr "Повідомлення (MAP)"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "Контакти (PBAP)"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "Сповіщення"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -538,6 +559,25 @@ msgstr "Дублювання сповіщень увімкнено."
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "Дублювання сповіщень вимкнено."
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "Очікувався адаптер, наприклад --bt-adapter hci1, або --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "Жоден адаптер Bluetooth не відповідає «{}». Доступні:\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "Вибір адаптера автоматичний: перший увімкнений.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "Використовується адаптер {}."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1455,3 +1495,7 @@ msgstr "Синхронізація пристроїв"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "Створюйте пари пристроїв і синхронізуйте буфер обміну через мережу"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "Зв'язок"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-08-31 22:04-0700\n"
+"POT-Creation-Date: 2026-09-01 13:57-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -131,6 +131,10 @@ msgstr "开启或关闭通知镜像。"
 #: src/cli/main.cpp
 msgid "Mirror notification titles and bodies, not just the app."
 msgstr "镜像通知的标题和正文，而不只是所属 App。"
+
+#: src/cli/main.cpp
+msgid "Choose which Bluetooth controller to use."
+msgstr "选择要使用的蓝牙适配器。"
 
 #: src/cli/main.cpp
 msgid "List mirrored iPhone notifications."
@@ -265,6 +269,18 @@ msgstr "Secure Connections={}"
 msgid "Bond"
 msgstr "绑定"
 
+#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Notifications"
+msgstr "通知"
+
+#: src/cli/main.cpp
+msgid "mirroring on"
+msgstr "镜像已启用"
+
+#: src/cli/main.cpp
+msgid "mirroring off (tether --bt-ancs on)"
+msgstr "镜像已停用 (tether --bt-ancs on)"
+
 #: src/cli/main.cpp src/daemon/main.cpp src/gtk/main.cpp
 #: src/gtk/tether-gtk.desktop.in
 msgid "Tether"
@@ -277,6 +293,15 @@ msgstr "正在连接"
 #: src/cli/main.cpp
 msgid "off (--bt-enable on)"
 msgstr "已关闭（--bt-enable on）"
+
+#: src/cli/main.cpp
+msgid "in use"
+msgstr "使用中"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Controller {} is not present; using the first powered one instead."
+msgstr "适配器 {} 不存在；改用第一个已开启的适配器。"
 
 #: src/cli/main.cpp
 #, c-format
@@ -354,10 +379,6 @@ msgstr "信息（MAP）"
 #: src/cli/main.cpp
 msgid "Contacts (PBAP)"
 msgstr "通讯录（PBAP）"
-
-#: src/cli/main.cpp src/gtk/devices_view.cpp src/gtk/main.cpp
-msgid "Notifications"
-msgstr "通知"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth diagnostics from the daemon.\n"
@@ -511,6 +532,25 @@ msgstr "通知镜像已启用。"
 #: src/cli/main.cpp
 msgid "Notification mirroring disabled."
 msgstr "通知镜像已停用。"
+
+#: src/cli/main.cpp
+msgid "Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"
+msgstr "需要指定适配器，例如 --bt-adapter hci1 或 --bt-adapter auto\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "No Bluetooth controller matches '{}'. Available:\n"
+msgstr "没有与“{}”匹配的蓝牙适配器。可用：\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Controller selection is automatic: the first powered one.\n"
+msgstr "适配器选择为自动：第一个已开启的适配器。\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Using controller {}."
+msgstr "正在使用适配器 {}。"
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1387,3 +1427,7 @@ msgstr "设备同步"
 #: src/gtk/tether-gtk.desktop.in
 msgid "Pair devices and synchronize clipboard across the network"
 msgstr "配对设备并通过网络同步剪贴板"
+
+#, fuzzy
+#~ msgid "on"
+#~ msgstr "绑定"

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
+#include <strings.h>
 #include <sys/ioctl.h>
 #include <tether/client.hpp>
 #include <tether/core.hpp>
@@ -200,6 +201,7 @@ static const Opt kOptions[] = {
     {"--bt-enable <on|off>", N_("Connect to the iPhone over Bluetooth, or stop.")},
     {"--bt-ancs <on|off>", N_("Turn notification mirroring on or off.")},
     {"--bt-ancs-content <on|off>", N_("Mirror notification titles and bodies, not just the app.")},
+    {"--bt-adapter <hciN|auto>", N_("Choose which Bluetooth controller to use.")},
     {"--bt-notifications", N_("List mirrored iPhone notifications.")},
     {"--bt-diagnostics", N_("Print a redacted Bluetooth report for a bug report.")},
     {"--install-extension-host",
@@ -305,6 +307,23 @@ static int print_bt_setup(tether::Client& client) {
     return 0;
 }
 
+// /org/bluez/hci0 -> hci0
+static std::string adapter_id(const std::string& path) {
+    const auto slash = path.find_last_of('/');
+    return slash == std::string::npos ? path : path.substr(slash + 1);
+}
+
+// Accepts either spelling: hciN or the address.
+static bool adapter_known(const nlohmann::json& status, const std::string& id) {
+    for (const auto& adapter : status.value("adapters", nlohmann::json::array())) {
+        const std::string path = adapter.value("path", "");
+        const std::string address = adapter.value("address", "");
+        if (strcasecmp(adapter_id(path).c_str(), id.c_str()) == 0 || strcasecmp(address.c_str(), id.c_str()) == 0)
+            return true;
+    }
+    return false;
+}
+
 static int print_bt_status(tether::Client& client) {
     nlohmann::json resp;
     try {
@@ -327,23 +346,44 @@ static int print_bt_status(tether::Client& client) {
     const std::string secure = cap.contains("secure_connections") && cap["secure_connections"].is_boolean()
                                    ? (cap["secure_connections"].get<bool>() ? "on" : "OFF")
                                    : _("unknown");
+    const std::string in_use = cap.value("adapter_id", "");
     fields.emplace_back(_("Adapter"),
-                        tether::tr_format(_("powered={0} central={1} peripheral={2} advertising={3} class={4}"),
-                                          yn(cap.value("powered", false)),
-                                          yn(cap.value("le_central", false)),
-                                          yn(cap.value("le_peripheral", false)),
-                                          yn(cap.value("advertising", false)),
-                                          cap.value("class_ok", false) ? _("ok") : _("wrong")) +
+                        (in_use.empty() ? std::string{} : in_use + "  ") +
+                            tether::tr_format(_("powered={0} central={1} peripheral={2} advertising={3} class={4}"),
+                                              yn(cap.value("powered", false)),
+                                              yn(cap.value("le_central", false)),
+                                              yn(cap.value("le_peripheral", false)),
+                                              yn(cap.value("advertising", false)),
+                                              cap.value("class_ok", false) ? _("ok") : _("wrong")) +
                             "\n" + tether::tr_format(_("secure-connections={}"), secure));
 
     if (cap.value("bonded_device_present", false))
         fields.emplace_back(_("Bond"), cap.value("bond_has_le", false) ? "BR/EDR + LE" : "BR/EDR only");
+    // Mirroring off is otherwise invisible here, and it takes the ANCS
+    // solicitation off air, so the iPhone never offers notification access.
+    fields.emplace_back(_("Notifications"),
+                        resp.value("ancs_enabled", true) ? _("mirroring on")
+                                                         : _("mirroring off (tether --bt-ancs on)"));
     fields.emplace_back(_("Tether"), resp.value("enabled", true) ? _("connecting") : _("off (--bt-enable on)"));
     print_fields(fields);
 
     for (const auto& adapter : resp["adapters"]) {
-        fprintf(stdout, "  %s  %s\n", adapter.value("address", "").c_str(), adapter.value("name", "").c_str());
+        const std::string id = adapter_id(adapter.value("path", ""));
+        const std::string marker = id == in_use ? std::string("  <- ") + _("in use") : std::string{};
+        fprintf(stdout,
+                "  %-5s  %s  %s%s\n",
+                id.c_str(),
+                adapter.value("address", "").c_str(),
+                adapter.value("name", "").c_str(),
+                marker.c_str());
     }
+
+    const std::string pinned = resp.value("adapter", "");
+    if (!pinned.empty() && !adapter_known(resp, pinned))
+        fprintf(
+            stdout,
+            "\n  %s\n",
+            tether::tr_format(_("Controller {} is not present; using the first powered one instead."), pinned).c_str());
 
     if (cap.contains("reasons") && !cap["reasons"].empty()) {
         fprintf(stdout, "\n");
@@ -761,6 +801,10 @@ int main(int argc, char* argv[]) {
             action = "bt_ancs_content";
             if (i + 1 < argc && argv[i + 1][0] != '-')
                 arg_val = argv[++i];
+        } else if (arg == "--bt-adapter") {
+            action = "bt_adapter";
+            if (i + 1 < argc && argv[i + 1][0] != '-')
+                arg_val = argv[++i];
         } else if (arg == "--bt-notifications") {
             action = "bt_notifications";
         } else if (arg == "--bt-pair") {
@@ -978,6 +1022,43 @@ int main(int argc, char* argv[]) {
                 "%s\n",
                 content ? (on ? _("Notification contents enabled.") : _("Notification contents disabled."))
                         : (on ? _("Notification mirroring enabled.") : _("Notification mirroring disabled.")));
+    } else if (action == "bt_adapter") {
+        if (arg_val.empty()) {
+            debug::log(ERR, _("Expected a controller, e.g. --bt-adapter hci1, or --bt-adapter auto\n"));
+            return 1;
+        }
+        const bool automatic = arg_val == "auto";
+
+        nlohmann::json status;
+        try {
+            status = nlohmann::json::parse(client.send_and_wait("{\"command\":\"bt_status\"}\n"));
+        } catch (const std::exception&) {
+            debug::log(ERR, _("Could not read Bluetooth status from the daemon.\n"));
+            return 1;
+        }
+
+        if (!automatic && !adapter_known(status, arg_val)) {
+            debug::log(ERR, _("No Bluetooth controller matches '{}'. Available:\n"), arg_val);
+            for (const auto& adapter : status.value("adapters", nlohmann::json::array()))
+                fprintf(stderr,
+                        "  %s  %s  %s\n",
+                        adapter_id(adapter.value("path", "")).c_str(),
+                        adapter.value("address", "").c_str(),
+                        adapter.value("name", "").c_str());
+            return 1;
+        }
+
+        nlohmann::json request;
+        request["command"] = "bt_set_adapter";
+        request["adapter"] = automatic ? "" : arg_val;
+        if (!client.send(request.dump() + "\n")) {
+            debug::log(ERR, _("Could not reach the daemon.\n"));
+            return 1;
+        }
+        if (automatic)
+            fprintf(stdout, _("Controller selection is automatic: the first powered one.\n"));
+        else
+            fprintf(stdout, "%s\n", tether::tr_format(_("Using controller {}."), arg_val).c_str());
     }
 
     return 0;

--- a/src/core/include/tether/bluetooth/config.hpp
+++ b/src/core/include/tether/bluetooth/config.hpp
@@ -20,8 +20,7 @@ namespace tether::bluetooth {
         // Address of the selected iPhone, e.g. "81:71:C8:30:6A:F3".
         std::string device_address;
         AuthStrategy auth_strategy = AuthStrategy::ConnectFirst;
-        // Cleared when pairing resolves to compatibility mode, so later runs do
-        // not keep trying to bring up an LE bearer the phone will not answer.
+        // Whether to mirror notifications. Dual bond turns it on; nothing else writes it but the user
         bool ancs_enabled = true;
         // Whether to request notification contents rather than only the app
         // they came from. The iPhone's own notification-access toggle is the
@@ -31,6 +30,9 @@ namespace tether::bluetooth {
         bool group_messages_enabled = false;
         // When off, supervision runs against no device, so the daemon stops re-dialling
         bool enabled = true;
+        // Controller to use, "hci1" or its address. Empty picks the first
+        // powered one, which is wrong on any machine with a second controller.
+        std::string adapter;
 
         bool operator==(const Config&) const = default;
     };

--- a/src/core/include/tether/bluetooth/monitor.hpp
+++ b/src/core/include/tether/bluetooth/monitor.hpp
@@ -36,6 +36,10 @@ namespace tether::bluetooth {
         BluezObjects snapshot() const;
         Capability capability() const;
 
+        // Which controller to use: "hciN" or an address, empty for the first powered one.
+        void set_preferred_adapter(std::string id);
+        std::string preferred_adapter_id() const;
+
         // Shared system-bus connection. GDBusConnection is thread-safe for call.
         GDBusConnection* connection() const;
 

--- a/src/core/include/tether/bluetooth/objects.hpp
+++ b/src/core/include/tether/bluetooth/objects.hpp
@@ -136,7 +136,13 @@ namespace tether::bluetooth {
     // setting read by BluezMonitor. Keeping the external btmgmt probe out of
     // this function makes capability resolution deterministic and prevents a
     // stalled controller query from blocking unrelated callers.
-    Capability resolve_capability(const BluezObjects& objects, std::optional<bool> secure_connections = std::nullopt);
+    // The adapter tether uses: by `id` ("hciN" or an address),
+    // Null only when there is no adapter at all.
+    const Adapter* preferred_adapter(const BluezObjects& objects, const std::string& id = {});
+
+    Capability resolve_capability(const BluezObjects& objects,
+                                  std::optional<bool> secure_connections = std::nullopt,
+                                  const std::string& preferred_id = {});
 
     nlohmann::json to_json(const Adapter& adapter);
     nlohmann::json to_json(const Device& device);

--- a/src/core/src/bluetooth/config.cpp
+++ b/src/core/src/bluetooth/config.cpp
@@ -50,6 +50,7 @@ namespace tether::bluetooth {
         j["ancs_content_enabled"] = config.ancs_content_enabled;
         j["group_messages_enabled"] = config.group_messages_enabled;
         j["enabled"] = config.enabled;
+        j["adapter"] = config.adapter;
         return j.dump(2);
     }
 
@@ -66,6 +67,7 @@ namespace tether::bluetooth {
             config.ancs_content_enabled = version < 1 ? true : j.value("ancs_content_enabled", true);
             config.group_messages_enabled = j.value("group_messages_enabled", false);
             config.enabled = j.value("enabled", true);
+            config.adapter = j.value("adapter", "");
         } catch (const std::exception&) {
             // A corrupt file must not stop the daemon; defaults are safe.
         }

--- a/src/core/src/bluetooth/monitor.cpp
+++ b/src/core/src/bluetooth/monitor.cpp
@@ -48,6 +48,7 @@ namespace tether::bluetooth {
         mutable std::mutex mutex;
         BluezObjects objects;
         Capability cap;
+        std::string preferred_adapter_id;
         std::string secure_adapter;
         std::optional<bool> secure_connections;
         std::chrono::steady_clock::time_point secure_checked_at{};
@@ -292,8 +293,13 @@ namespace tether::bluetooth {
         BluezObjects parsed = parse_managed_objects(reply);
         g_variant_unref(reply);
         parsed.experimental_api = bluetoothd_has_experimental();
-        Capability resolved = resolve_capability(parsed);
-        resolved = resolve_capability(parsed, read_secure_connections(resolved.adapter_id));
+        std::string preferred;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            preferred = preferred_adapter_id;
+        }
+        Capability resolved = resolve_capability(parsed, std::nullopt, preferred);
+        resolved = resolve_capability(parsed, read_secure_connections(resolved.adapter_id), preferred);
 
         {
             std::lock_guard<std::mutex> lock(mutex);
@@ -483,6 +489,23 @@ namespace tether::bluetooth {
     Capability BluezMonitor::capability() const {
         std::lock_guard<std::mutex> lock(impl_->mutex);
         return impl_->cap;
+    }
+
+    void BluezMonitor::set_preferred_adapter(std::string id) {
+        {
+            std::lock_guard<std::mutex> lock(impl_->mutex);
+            if (impl_->preferred_adapter_id == id)
+                return;
+            impl_->preferred_adapter_id = std::move(id);
+        }
+
+        if (impl_->running)
+            invoke_sync([this] { impl_->refresh(); });
+    }
+
+    std::string BluezMonitor::preferred_adapter_id() const {
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        return impl_->preferred_adapter_id;
     }
 
 } // namespace tether::bluetooth

--- a/src/core/src/bluetooth/objects.cpp
+++ b/src/core/src/bluetooth/objects.cpp
@@ -321,22 +321,34 @@ namespace tether::bluetooth {
                    enable;
         }
 
+        // /org/bluez/hci0 -> hci0
+        std::string adapter_id_of(const std::string& path) {
+            const auto slash = path.find_last_of('/');
+            return slash == std::string::npos ? path : path.substr(slash + 1);
+        }
+
     } // namespace
 
-    Capability resolve_capability(const BluezObjects& objects, std::optional<bool> secure_connections) {
-        Capability cap;
-
-        // prefer powered adapter, fall back to the first so the reasons below
-        // can explain an unpowered one rather than reporting nothing at all.
-        const Adapter* adapter = nullptr;
-        for (const auto& a : objects.adapters) {
-            if (a.powered) {
-                adapter = &a;
-                break;
+    const Adapter* preferred_adapter(const BluezObjects& objects, const std::string& id) {
+        if (!id.empty()) {
+            for (const auto& a : objects.adapters) {
+                if (iequals(adapter_id_of(a.path), id) || iequals(a.address, id))
+                    return &a;
             }
         }
-        if (!adapter && !objects.adapters.empty())
-            adapter = &objects.adapters.front();
+        for (const auto& a : objects.adapters) {
+            if (a.powered)
+                return &a;
+        }
+        return objects.adapters.empty() ? nullptr : &objects.adapters.front();
+    }
+
+    Capability resolve_capability(const BluezObjects& objects,
+                                  std::optional<bool> secure_connections,
+                                  const std::string& preferred_id) {
+        Capability cap;
+
+        const Adapter* adapter = preferred_adapter(objects, preferred_id);
 
         // ponytail: tetherd is per-user, so its locale is the user's and these
         // strings can be translated here. A system-wide daemon serving several
@@ -347,7 +359,7 @@ namespace tether::bluetooth {
         }
 
         cap.adapter_present = true;
-        cap.adapter_id = adapter->path.substr(adapter->path.find_last_of('/') + 1);
+        cap.adapter_id = adapter_id_of(adapter->path);
         cap.powered = adapter->powered;
         cap.le_central = adapter->has_role("central");
         cap.le_peripheral = adapter->has_role("peripheral");

--- a/src/core/src/bluetooth/pairing.cpp
+++ b/src/core/src/bluetooth/pairing.cpp
@@ -172,14 +172,21 @@ namespace tether::bluetooth {
             return value;
         }
 
+        // The controller every transaction runs on: the configured one, or else first powered. Empty when BlueZ reports
+        // no adapter at all.
+        std::string adapter_path(BluezMonitor& monitor) {
+            auto objects = monitor.snapshot();
+            const Adapter* adapter = preferred_adapter(objects, monitor.preferred_adapter_id());
+            return adapter ? adapter->path : std::string{};
+        }
+
         // Scans until the device shows up. Needed because an unpair makes BlueZ
         // forget the device entirely, which would otherwise leave no way to pair
         // again from inside the app.
         bool discover(BluezMonitor& monitor, GDBusConnection* conn, const std::string& address, Device& out) {
-            auto objects = monitor.snapshot();
-            if (objects.adapters.empty())
+            const std::string adapter = adapter_path(monitor);
+            if (adapter.empty())
                 return false;
-            const std::string adapter = objects.adapters.front().path;
 
             if (!call_adapter(conn, adapter, "StartDiscovery"))
                 return false;
@@ -268,8 +275,7 @@ namespace tether::bluetooth {
         std::string adapter_for(BluezMonitor& monitor, const Device& device) {
             if (!device.adapter_path.empty())
                 return device.adapter_path;
-            auto objects = monitor.snapshot();
-            return objects.adapters.empty() ? std::string{} : objects.adapters.front().path;
+            return adapter_path(monitor);
         }
 
         std::mutex g_advert_mutex;
@@ -386,9 +392,7 @@ namespace tether::bluetooth {
         // free instances while one of our own adverts is registered, which is
         // precisely the state a user retrying this is likely to be in. Try, and
         // report what BlueZ actually says.
-        auto objects = monitor.snapshot();
-        const std::string adapter = objects.adapters.empty() ? std::string{} : objects.adapters.front().path;
-        if (!start_advert(monitor, adapter, err))
+        if (!start_advert(monitor, adapter_path(monitor), err))
             return false;
         hold_advert_for(ANCS_ADVERT_TIMEOUT_SECONDS);
         return true;
@@ -402,9 +406,7 @@ namespace tether::bluetooth {
                 err = "Bluetooth is unavailable.";
                 return false;
             }
-            auto objects = monitor.snapshot();
-            const std::string adapter = objects.adapters.empty() ? std::string{} : objects.adapters.front().path;
-            return start_advert(monitor, adapter, err);
+            return start_advert(monitor, adapter_path(monitor), err);
         }
     } // namespace
 
@@ -558,10 +560,7 @@ namespace tether::bluetooth {
         }
 
         AdvertOwnership advert_owned;
-        PairableWindow pairable(conn, [&] {
-            auto objects = monitor.snapshot();
-            return objects.adapters.empty() ? std::string{} : objects.adapters.front().path;
-        }());
+        PairableWindow pairable(conn, adapter_path(monitor));
 
         Device device;
         if (!lookup(monitor, result.device_address, device)) {
@@ -786,12 +785,11 @@ namespace tether::bluetooth {
             return false;
         }
 
-        auto objects = monitor.snapshot();
-        if (objects.adapters.empty()) {
+        const std::string adapter = adapter_path(monitor);
+        if (adapter.empty()) {
             err = "No Bluetooth adapter is present.";
             return false;
         }
-        const std::string adapter = objects.adapters.front().path;
 
         // InProgress means BlueZ believes a discovery is already running.
         std::string start_err;

--- a/src/core/src/net.cpp
+++ b/src/core/src/net.cpp
@@ -292,6 +292,7 @@ namespace tether {
         const auto config = bluetooth::load_config();
         status["device_address"] = config.device_address;
         status["ancs_enabled"] = config.ancs_enabled;
+        status["adapter"] = config.adapter;
         status["ancs_content_enabled"] = config.ancs_content_enabled;
         status["enabled"] = config.enabled;
         if (!bluetooth::g_bluez) {
@@ -422,14 +423,10 @@ namespace tether {
 
         if (result.success) {
             config.device_address = result.device_address;
-            // A BR/EDR-only bond can never have ANCS. Only a bond this transaction
-            // actually created settles that: an "already_paired" result, or a phone
-            // that merely wasn't exposing its LE bearer at this instant, must not
-            // latch mirroring off — nothing in the UI could turn it back on.
+            // A dual bond proves mirroring can work, so it turns the preference back on.
+            // A BR/EDR-only bond must not turn it off.
             if (result.dual_bond)
                 config.ancs_enabled = true;
-            else if (result.status == "paired")
-                config.ancs_enabled = false;
             // Remember the transaction that bonded only when it produced a bond worth repeating.
             if (result.status == "paired" && result.dual_bond)
                 config.auth_strategy = result.auth_strategy_used;
@@ -959,6 +956,13 @@ namespace tether {
                         bluetooth::set_group_replies_enabled(config.group_messages_enabled &&
                                                              config.ancs_content_enabled && config.ancs_enabled);
                         broadcast_local_event(build_bt_status().dump());
+                    } else if (j.contains("command") && j["command"] == "bt_set_adapter") {
+                        auto config = bluetooth::load_config();
+                        config.adapter = j.value("adapter", "");
+                        bluetooth::save_config(config);
+                        if (bluetooth::g_bluez)
+                            bluetooth::g_bluez->set_preferred_adapter(config.adapter);
+                        std::thread(restart_supervision, config).detach();
                     } else if (j.contains("command") && j["command"] == "bt_set_enabled") {
                         auto config = bluetooth::load_config();
                         config.enabled = j.value("enabled", true);

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -218,6 +218,9 @@ int main(int argc, char** argv) {
                              repliable ? message.thread_key : std::string{},
                              otp});
         });
+
+    // Pick the controller before the first capability, a second adapter never comes up bound to the wrong one.
+    bluez.set_preferred_adapter(tether::bluetooth::load_config().adapter);
     if (bluez.start()) {
         tether::bluetooth::g_bluez = &bluez;
         loop.addFd(bluez.event_fd(), [&bluez](int) {

--- a/test/test_bluetooth_objects.cpp
+++ b/test/test_bluetooth_objects.cpp
@@ -491,6 +491,59 @@ TEST(Capability, PrefersAPoweredAdapter) {
     EXPECT_TRUE(cap.le_peripheral);
 }
 
+// Two controllers is the common case that broke #69: the first one is a clone
+// dongle whose LE half never works, and everything ran on it because it sorts
+// first. The configured id has to win.
+constexpr const char* TWO_ADAPTERS = R"({
+  '/org/bluez/hci0': {
+    'org.bluez.Adapter1': { 'Address': <'AA:AA:AA:AA:AA:AA'>, 'Powered': <true>, 'Roles': <['central']> }
+  },
+  '/org/bluez/hci1': {
+    'org.bluez.Adapter1': { 'Address': <'BB:BB:BB:BB:BB:BB'>, 'Powered': <true>, 'Roles': <['central', 'peripheral']> }
+  }
+})";
+
+TEST(PreferredAdapter, ConfiguredIdWinsOverTheFirstPowered) {
+    Payload p(TWO_ADAPTERS);
+    auto objects = parse_managed_objects(p.v);
+
+    ASSERT_TRUE(preferred_adapter(objects, "hci1"));
+    EXPECT_EQ(preferred_adapter(objects, "hci1")->path, "/org/bluez/hci1");
+    // The address is the other spelling a user has in front of them.
+    EXPECT_EQ(preferred_adapter(objects, "bb:bb:bb:bb:bb:bb")->path, "/org/bluez/hci1");
+    EXPECT_EQ(resolve_capability(objects, std::nullopt, "hci1").adapter_id, "hci1");
+    EXPECT_TRUE(resolve_capability(objects, std::nullopt, "hci1").le_peripheral);
+}
+
+// An unplugged controller must not leave the machine with no Bluetooth at all.
+TEST(PreferredAdapter, FallsBackWhenTheConfiguredOneIsAbsent) {
+    Payload p(TWO_ADAPTERS);
+    auto objects = parse_managed_objects(p.v);
+
+    ASSERT_TRUE(preferred_adapter(objects, "hci7"));
+    EXPECT_EQ(preferred_adapter(objects, "hci7")->path, "/org/bluez/hci0");
+    EXPECT_EQ(preferred_adapter(objects, "")->path, "/org/bluez/hci0");
+}
+
+TEST(PreferredAdapter, PrefersPoweredThenFirst) {
+    Payload p(R"({
+      '/org/bluez/hci0': {
+        'org.bluez.Adapter1': { 'Powered': <false>, 'Roles': <['central']> }
+      },
+      '/org/bluez/hci1': {
+        'org.bluez.Adapter1': { 'Powered': <true>, 'Roles': <['central']> }
+      }
+    })");
+    auto objects = parse_managed_objects(p.v);
+    EXPECT_EQ(preferred_adapter(objects, "")->path, "/org/bluez/hci1");
+    // An unpowered adapter named outright is still the one to describe, so the
+    // capability reasons can say it is off rather than reporting nothing.
+    EXPECT_EQ(preferred_adapter(objects, "hci0")->path, "/org/bluez/hci0");
+
+    BluezObjects empty;
+    EXPECT_EQ(preferred_adapter(empty, "hci0"), nullptr);
+}
+
 // Device1.Connected is an aggregate across bearers. A phone holding an LE link
 // with no BR/EDR link reports Connected=true while MAP and PBAP — which both
 // ride BR/EDR — are unreachable, so obexd answers every session attempt with

--- a/test/test_bluetooth_pairing.cpp
+++ b/test/test_bluetooth_pairing.cpp
@@ -50,6 +50,7 @@ TEST(BluetoothConfig, RoundTrips) {
     config.auth_strategy = AuthStrategy::ExplicitPair;
     config.ancs_enabled = false;
     config.enabled = false;
+    config.adapter = "hci1";
 
     EXPECT_EQ(deserialize_config(serialize_config(config)), config);
 }
@@ -61,6 +62,8 @@ TEST(BluetoothConfig, DefaultsToConnectFirstAndAncsEnabled) {
     EXPECT_TRUE(config.device_address.empty());
     // A config written before the toggle existed keeps connecting.
     EXPECT_TRUE(config.enabled);
+    // No controller pinned means the first powered one.
+    EXPECT_TRUE(config.adapter.empty());
 }
 
 // Switching Bluetooth off supervises no device, which is what stops the daemon


### PR DESCRIPTION
Introduces a setting to pin the adadpter Tether uses: `tether --bt-adapter hc1`. 
Tether used to blindly pick the first adapter BlueZ sees, which is often wrong witcho dongles. 
Also, over cautions LE latch removed. If a ANCS+LE connection doesn't work once that doesn't mean it wont work next time.

Fixes: https://github.com/zackb/tether/issues/69