### PR TITLE
fix: btmgmt hangs forever

### DIFF
--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -165,6 +165,7 @@ checks the daemon does not make.
 
 | Symptom | Cause | What to do |
 |---|---|---|
+| `systemctl enable --now tether-btclass@hci0` hangs in `activating (start)` forever | `btmgmt` epolls its stdin before running the command, and epoll rejects the `/dev/null` systemd hands it, so it waits having done nothing | Update the unit -- it pipes into `btmgmt` now. On an older build, `sudo btmgmt class 4 8` by hand sets the class until `bluetoothd` restarts, see 2026-09-01 below |
 | Messages and contacts worked, then stopped, and the error mentions a service record | `bluetoothd` restarted and reset the Class of Device | `sudo systemctl enable --now tether-btclass@hci0`, then re-pair if the phone dropped the bond |
 | The phone never offers notifications / Sync Contacts | The class is wrong, or the ANCS advertisement is not running | Check for `class=ok` in `tether --bt-status`, can take minutes |
 | MAP or PBAP reports `forbidden` | The matching toggle on the phone is off | Turn it on. This is not a pairing failure |
@@ -1424,3 +1425,48 @@ Not captured: whether the CSR dongle can derive the LE keys at all. It reported 
 `secure-connections=on` and both LE roles, and still produced only BR/EDR bonds across several
 attempts -- consistent with the clone firmware these dongles are known for, but no `btmon` capture
 was taken.
+
+### 2026-09-01 - `btmgmt` never runs its command when stdin is `/dev/null`
+
+Reported as #93 by several people: `sudo systemctl enable --now tether-btclass@hci0` hangs. The
+unit sits in `activating (start)` indefinitely with `btmgmt --index hci0 class 4 8` alive on 4ms of
+CPU, while `sudo btmgmt class 4 8` typed by hand succeeds instantly.
+
+`bt_shell_attach()` in BlueZ's `src/shared/shell.c` registers stdin with the mainloop *before* it
+looks at whether the shell is interactive:
+
+```c
+input = input_new(fd);        /* -> io_new(fd) -> mainloop_add_fd(fd, 0, ...) */
+if (!input)
+        return false;         /* returns here; shell_exec() never runs */
+
+if (data.mode == MODE_INTERACTIVE) {
+        ...
+} else {
+        if (shell_exec(data.argc, data.argv) < 0)
+```
+
+`mainloop_add_fd()` ends in `epoll_ctl(EPOLL_CTL_ADD, fd)`. `/dev/null` has no `.poll` in its file
+operations, so the kernel answers `EPERM` -- an event mask of `0` does not help, the rejection is
+about the file, not the events. `io_new()` returns NULL, the attach bails out one line before the
+branch that would have run the command, and the mainloop then runs forever with nothing registered
+to wake it. The process is not slow or blocked on the controller; it never issued the command.
+
+systemd gives every service `StandardInput=null`, so both `btmgmt` calls in the unit inherited
+`/dev/null` on fd 0. Terminals, pipes and sockets are all pollable, which is why running it by hand
+works, and why `RLovelett` found that `printf "\n" | btmgmt ...` works around it.
+
+It only bites where BlueZ is built against `src/shared/mainloop.c`. The `mainloop-glib.c` build goes
+through `g_io_add_watch`, which accepts `/dev/null` -- so it reproduces on the reporters' Ubuntu
+26.04 and not on Arch's bluez 5.87.
+
+`probe_secure_connections()` had the quiet version of the same bug: it passed `nullptr` for
+`standard_input` to `g_spawn_async_with_pipes`, so `btmgmt info` inherited whatever fd 0 `tetherd`
+had. Launched from a `.desktop` entry that is `/dev/null`, the child hung, the 1s deadline killed
+it, and `--bt-status` printed `secure-connections=unknown`. The reporter's paste shows exactly that
+line.
+
+Fixed by giving `btmgmt` a pipe everywhere it is spawned: `echo |` in the unit, in the NixOS module
+and in `bt-probe.sh`, and a real stdin pipe closed immediately for EOF in `probe_secure_connections()`.
+The unit also grew `TimeoutStartSec=60`, because `Type=oneshot` defaults to no start timeout -- that
+is why a stall wedged `bluetooth.service` and everything ordered after it instead of failing.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -16,10 +16,11 @@ let
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
+        # btmgmt epolls its stdin before it runs the command,
         ExecStart = pkgs.writeShellScript "tether-btclass-${adapter}" ''
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
-            ${pkgs.bluez}/bin/btmgmt --index ${adapter} class 4 8 >/dev/null 2>&1
-            if ${pkgs.bluez}/bin/btmgmt --index ${adapter} info 2>/dev/null \
+            echo | ${pkgs.bluez}/bin/btmgmt --index ${adapter} class 4 8 >/dev/null 2>&1
+            if echo | ${pkgs.bluez}/bin/btmgmt --index ${adapter} info 2>/dev/null \
               | ${pkgs.gnugrep}/bin/grep -q "class 0x..0408"; then
               exit 0
             fi
@@ -27,6 +28,7 @@ let
           done
           exit 1
         '';
+        TimeoutStartSec = 60;
       };
     };
   };

--- a/packaging/systemd/tether-btclass@.service
+++ b/packaging/systemd/tether-btclass@.service
@@ -12,11 +12,13 @@ PartOf=bluetooth.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# btmgmt epolls its stdin before it runs the command, rejects /dev/null with EPERM.
 ExecStart=/bin/sh -c 'for i in 1 2 3 4 5 6 7 8 9 10; do \
-    btmgmt --index %i class 4 8 >/dev/null 2>&1; \
-    btmgmt --index %i info 2>/dev/null | grep -q "class 0x..0408" && exit 0; \
+    echo | btmgmt --index %i class 4 8 >/dev/null 2>&1; \
+    echo | btmgmt --index %i info 2>/dev/null | grep -q "class 0x..0408" && exit 0; \
     sleep 1; \
 done; exit 1'
+TimeoutStartSec=60
 
 [Install]
 WantedBy=bluetooth.service

--- a/scripts/bt-probe.sh
+++ b/scripts/bt-probe.sh
@@ -130,7 +130,7 @@ else
         if (( set_class )); then
             echo
             note "running: btmgmt class 4 8"
-            if sudo btmgmt --index "${ADAPTER#hci}" class 4 8; then
+            if echo | sudo btmgmt --index "${ADAPTER#hci}" class 4 8; then
                 note "class set; re-run this probe to confirm"
                 note "Make it stick: sudo systemctl enable --now tether-btclass@$ADAPTER"
             else

--- a/src/core/src/bluetooth/monitor.cpp
+++ b/src/core/src/bluetooth/monitor.cpp
@@ -155,12 +155,23 @@ namespace tether::bluetooth {
         };
 
         GPid child = 0;
+        gint input_fd = -1;
         gint output_fd = -1;
         GError* error = nullptr;
         const auto flags = static_cast<GSpawnFlags>(G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD |
                                                     G_SPAWN_STDERR_TO_DEV_NULL | G_SPAWN_CLOEXEC_PIPES);
-        if (!g_spawn_async_with_pipes(
-                nullptr, argv.data(), nullptr, flags, nullptr, nullptr, &child, nullptr, &output_fd, nullptr, &error)) {
+        // btmgmt epolls its stdin before it runs the command, rejects /dev/null with EPERM.
+        if (!g_spawn_async_with_pipes(nullptr,
+                                      argv.data(),
+                                      nullptr,
+                                      flags,
+                                      nullptr,
+                                      nullptr,
+                                      &child,
+                                      &input_fd,
+                                      &output_fd,
+                                      nullptr,
+                                      &error)) {
             debug::log(WARN,
                        "bluetooth: cannot start btmgmt for {}: {}",
                        adapter_id,
@@ -168,6 +179,8 @@ namespace tether::bluetooth {
             g_clear_error(&error);
             return std::nullopt;
         }
+        if (input_fd >= 0)
+            close(input_fd);
 
         const int old_flags = fcntl(output_fd, F_GETFL, 0);
         if (old_flags >= 0)

--- a/test/test_bluetooth_monitor.cpp
+++ b/test/test_bluetooth_monitor.cpp
@@ -90,3 +90,24 @@ TEST(SecureConnectionsProbe, DoesNotLeakParentDescriptorsIntoBtmgmt) {
     ASSERT_TRUE(result.has_value());
     EXPECT_TRUE(*result);
 }
+
+// btmgmt epolls its stdin before running the command and epoll rejects
+// /dev/null with EPERM, so an inherited /dev/null fd 0 makes it hang.
+TEST(SecureConnectionsProbe, GivesBtmgmtAPollableStdin) {
+    const int devnull = open("/dev/null", O_RDONLY);
+    ASSERT_GE(devnull, 0);
+    const int saved_stdin = dup(STDIN_FILENO);
+    ASSERT_GE(saved_stdin, 0);
+    ASSERT_EQ(dup2(devnull, STDIN_FILENO), STDIN_FILENO);
+    close(devnull);
+
+    FakeBtmgmt fake("[ -p /proc/self/fd/0 ] || exit 9\n"
+                    "printf 'current settings: secure-conn\\n'\n");
+    const auto result = probe_secure_connections("hci0", 250ms);
+
+    dup2(saved_stdin, STDIN_FILENO);
+    close(saved_stdin);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(*result);
+}


### PR DESCRIPTION
It turns out `btmgmt` is built with epoll on some system and gio/glib on others. epoll doesn't like /dev/null.

Fixes #93 

Credit: @RLovelett

