### PR TITLE
fix(gtk): use phone's notification timestamp

### DIFF
--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -398,6 +398,13 @@ responses carry no total length (?!?) and come back fragmented, so the only way 
 response has ended is to know exactly which attributes were requested. Those two facts
 are why the sequencer exists.
 
+`NotificationAttributeIDDate` (5) is requested for every notification, content
+mirroring on or off -- a delivery time is metadata, not content. It is the phone's
+local wall clock as `yyyyMMddTHHmmSS` with no zone, parsed by `parse_map_timestamp`
+like a MAP timestamp. Some apps send none, and those fall back to the time the
+attributes were fetched. Without it every notification carried the fetch time, so a
+replayed backlog arrived stamped all alike -- see issue #48.
+
 ### Group messages
 
 Off by default, `group_messages_enabled` in `~/.config/tether/bluetooth.json`. It also

--- a/src/core/src/bluetooth/ancs/client.cpp
+++ b/src/core/src/bluetooth/ancs/client.cpp
@@ -1,5 +1,6 @@
 #include "tether/bluetooth/ancs/client.hpp"
 #include "tether/bluetooth/ancs/sequencer.hpp"
+#include "tether/bluetooth/bmessage.hpp"
 #include "tether/bluetooth/monitor.hpp"
 #include "tether/log.hpp"
 
@@ -416,7 +417,8 @@ namespace tether::bluetooth::ancs {
             break;
         }
 
-        std::vector<NotificationAttributeId> attributes{NotificationAttributeId::AppIdentifier};
+        std::vector<NotificationAttributeId> attributes{NotificationAttributeId::AppIdentifier,
+                                                        NotificationAttributeId::Date};
         if (content_enabled) {
             attributes.push_back(NotificationAttributeId::Title);
             attributes.push_back(NotificationAttributeId::Subtitle);
@@ -486,7 +488,10 @@ namespace tether::bluetooth::ancs {
         notification.silent = event.silent();
         notification.has_positive_action = event.has_positive_action();
         notification.has_negative_action = event.has_negative_action();
-        notification.received = now;
+        // ANCS dates are the phone's wall clock with no zone, some apps send none at all.
+        const int64_t delivered =
+            parse_map_timestamp(response.attribute(static_cast<uint8_t>(NotificationAttributeId::Date)));
+        notification.received = delivered ? delivered : now;
 
         {
             std::lock_guard<std::mutex> lock(registry_mutex);

--- a/src/core/src/bluetooth/ancs/notifications.cpp
+++ b/src/core/src/bluetooth/ancs/notifications.cpp
@@ -88,12 +88,19 @@ namespace tether::bluetooth::ancs {
     }
 
     std::vector<Notification> NotificationRegistry::recent(size_t limit) const {
+        // sorted by the delivery time, not arrival: backlog replay is not ordered.
         std::vector<Notification> out;
-        for (auto it = order_.rbegin(); it != order_.rend() && out.size() < limit; ++it) {
+        out.reserve(notifications_.size());
+        for (auto it = order_.rbegin(); it != order_.rend(); ++it) {
             auto found = notifications_.find(*it);
             if (found != notifications_.end())
                 out.push_back(found->second);
         }
+        std::stable_sort(out.begin(), out.end(), [](const Notification& a, const Notification& b) {
+            return a.received > b.received;
+        });
+        if (out.size() > limit)
+            out.resize(limit);
         return out;
     }
 

--- a/src/gtk/notifications_view.cpp
+++ b/src/gtk/notifications_view.cpp
@@ -1,5 +1,6 @@
 #include "notifications_view.hpp"
 #include "daemon_client.hpp"
+#include "message_format.hpp"
 #include "ui_util.hpp"
 #include <tether/i18n.hpp>
 
@@ -20,17 +21,6 @@ namespace tether::ui {
         };
 
         NotificationsState g_notifications;
-
-        std::string format_timestamp(int64_t epoch) {
-            if (epoch <= 0)
-                return "";
-            std::time_t t = static_cast<std::time_t>(epoch);
-            std::tm tm{};
-            localtime_r(&t, &tm);
-            char buffer[32];
-            std::strftime(buffer, sizeof(buffer), "%H:%M", &tm);
-            return buffer;
-        }
 
         void request_notifications() {
             nlohmann::json j;
@@ -59,7 +49,8 @@ namespace tether::ui {
             const std::string title = notification.value("title", "");
             const std::string subtitle = notification.value("subtitle", "");
             const std::string body = notification.value("body", "");
-            const std::string stamp = format_timestamp(notification.value("timestamp", static_cast<int64_t>(0)));
+            const std::string stamp =
+                format_thread_time(notification.value("timestamp", static_cast<int64_t>(0)), std::time(nullptr));
 
             GtkWidget* row = gtk_list_box_row_new();
             gtk_list_box_row_set_selectable(GTK_LIST_BOX_ROW(row), FALSE);

--- a/test/test_ancs_notifications.cpp
+++ b/test/test_ancs_notifications.cpp
@@ -75,6 +75,26 @@ TEST(AncsRegistry, RenameAppIgnoresEmptyArguments) {
     EXPECT_EQ(registry.find(1)->app_name, "Instagram");
 }
 
+TEST(AncsRegistry, RecentIsOrderedByDeliveryTime) {
+    NotificationRegistry registry;
+    // Stored in the order iOS replayed them, which bears no relation to when the
+    // phone delivered them.
+    for (auto [uid, received] : {std::pair<uint32_t, int64_t>{1, 300}, {2, 100}, {3, 200}}) {
+        Notification n = make(uid, "com.example.app");
+        n.received = received;
+        registry.store(n);
+    }
+
+    std::vector<Notification> recent = registry.recent();
+    ASSERT_EQ(recent.size(), 3u);
+    EXPECT_EQ(recent[0].uid, 1u);
+    EXPECT_EQ(recent[1].uid, 3u);
+    EXPECT_EQ(recent[2].uid, 2u);
+
+    EXPECT_EQ(registry.recent(2).size(), 2u) << "the limit applies after sorting";
+    EXPECT_EQ(registry.recent(2)[0].uid, 1u);
+}
+
 // Content mirroring was off with no way to turn it on, so a stored false from
 // before the toggle existed must not pin the new default.
 TEST(BluetoothConfig, UnversionedFileTakesTheContentDefault) {

--- a/test/test_ancs_sequencer.cpp
+++ b/test/test_ancs_sequencer.cpp
@@ -66,6 +66,18 @@ TEST(AncsSequencer, EncodesANotificationRequest) {
     EXPECT_EQ(request.attribute_ids, (std::vector<uint8_t>{0, 3}));
 }
 
+TEST(AncsSequencer, EncodesDateWithoutALength) {
+    Request request = build_notification_request(
+        1, {NotificationAttributeId::AppIdentifier, NotificationAttributeId::Date, NotificationAttributeId::Title});
+
+    // 0x00 command, four UID bytes, then the attribute ids.
+    EXPECT_EQ(request.payload[5], 0x00) << "AppIdentifier takes no length";
+    EXPECT_EQ(request.payload[6], 0x05) << "Date follows immediately";
+    EXPECT_EQ(request.payload[7], 0x01) << "Date takes no length either";
+    EXPECT_EQ(request.payload[8] | (request.payload[9] << 8), MAX_TITLE_LENGTH);
+    EXPECT_EQ(request.attribute_ids, (std::vector<uint8_t>{0, 5, 1}));
+}
+
 TEST(AncsSequencer, EncodesAnAppRequest) {
     Request request = build_app_request("com.apple.MobileSMS");
 


### PR DESCRIPTION
Request the ANCS date with all of the other notification data. Allows delivery timestamps instead of arrival.

Fixes #48 