### PR TITLE
Add finer control over extensions in the NixOS Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ programs.tether = {
     enable = true;
     adapters = [ "hci0" ];
   };
+
+  extensions = [
+    "firefox"
+    "chromium"
+    "thunderbird"
+  ];
 };
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,14 @@
           app = name: {
             type = "app";
             program = "${tether}/bin/${name}";
+
+            meta = {
+              description = "Bridge an iPhone to the Linux desktop: clipboard, files, messages, and notifications";
+              maintainers = [ { email = "zack@bartel.com"; } ];
+              homepage = "https://github.com/zackb/tether";
+              license = nixpkgs.lib.licenses.mit;
+              platforms = systems;
+            };
           };
         in
         {
@@ -52,7 +60,7 @@
         };
       };
 
-      nixosModules.default = tetherModule;
+      nixosModules.default = self.nixosModules.tether;
       nixosModules.tether = tetherModule;
 
       checks = forAllSystems (system: {

--- a/nix/module-test.nix
+++ b/nix/module-test.nix
@@ -20,6 +20,11 @@ let
             "hci0"
             "hci1"
           ];
+          extensions = [
+            "firefox"
+            "chromium"
+            "thunderbird"
+          ];
         };
       }
     ];
@@ -50,6 +55,11 @@ let
               "hci0"
               "hci1"
             ];
+            extensions = [
+              "firefox"
+              "chromium"
+              "thunderbird"
+            ];
           };
         }
       ];
@@ -67,6 +77,25 @@ let
         }
       ];
     }).config;
+  extensionOnlyConfig = (
+    lib.nixosSystem {
+      inherit system;
+      modules = [
+        tetherModule
+        {
+          programs.tether = {
+            enable = true;
+            extensions = [
+              "firefox"
+              "chromium"
+              "thunderbird"
+            ];
+          };
+        }
+      ];
+    }
+  );
+  extOnlyConfig = extensionOnlyConfig.config;
   hasTetherBluetoothService =
     moduleConfig:
     lib.any (lib.hasPrefix "tether-btclass@") (builtins.attrNames moduleConfig.systemd.services);
@@ -83,6 +112,12 @@ assert !baseOnlyConfig.services.avahi.enable;
 assert !lib.elem 5134 baseOnlyConfig.networking.firewall.allowedTCPPorts;
 assert !baseOnlyConfig.hardware.bluetooth.enable;
 assert !hasTetherBluetoothService baseOnlyConfig;
+assert
+  !lib.elem baseOnlyConfig.programs.tether.package baseOnlyConfig.programs.firefox.nativeMessagingHosts.packages;
+assert
+  !baseOnlyConfig.environment.etc ? "chromium/native-messaging-hosts/com.tether.extension.json";
+assert
+  !baseOnlyConfig.environment.etc ? "opt/chrome/native-messaging-hosts/com.tether.extension.json";
 assert !masterDisabledConfig.services.avahi.enable;
 assert !lib.elem 5134 masterDisabledConfig.networking.firewall.allowedTCPPorts;
 assert !masterDisabledConfig.hardware.bluetooth.enable;
@@ -90,6 +125,15 @@ assert !hasTetherBluetoothService masterDisabledConfig;
 assert wifiOnlyConfig.services.avahi.enable;
 assert !wifiOnlyConfig.services.avahi.openFirewall;
 assert !lib.elem 5134 wifiOnlyConfig.networking.firewall.allowedTCPPorts;
+assert !extOnlyConfig.services.avahi.enable;
+assert !extOnlyConfig.hardware.bluetooth.enable;
+assert !extOnlyConfig.services.avahi.enable;
+assert lib.elem extOnlyConfig.programs.tether.package
+  extOnlyConfig.programs.firefox.nativeMessagingHosts.packages;
+assert !extOnlyConfig.programs.thunderbird.enable;
+assert extOnlyConfig.environment.etc ? "chromium/native-messaging-hosts/com.tether.extension.json";
+assert
+  extOnlyConfig.environment.etc ? "opt/chrome/native-messaging-hosts/com.tether.extension.json";
 assert config.hardware.bluetooth.enable;
 assert config.hardware.bluetooth.settings.General.Experimental;
 assert config.systemd.services ? "tether-btclass@hci0";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -33,20 +33,21 @@ let
     };
   };
 in
+with lib;
 {
   options.programs.tether = {
-    enable = lib.mkEnableOption "Tether, an iPhone integration bridge for Linux";
-    package = lib.mkOption {
-      type = lib.types.package;
+    enable = mkEnableOption "Tether, an iPhone integration bridge for Linux";
+    package = mkOption {
+      type = with types; package;
       default = pkgs.callPackage ./package.nix { };
-      defaultText = lib.literalExpression "pkgs.callPackage ./nix/package.nix { }";
+      defaultText = literalExpression "pkgs.callPackage ./nix/package.nix { }";
       description = "The Tether package to install and integrate.";
     };
-    wifi.enable = lib.mkEnableOption "Tether Wi-Fi discovery through Avahi";
-    wifi.openFirewall = lib.mkEnableOption "the mDNS and TCP firewall ports required by Tether";
-    bluetooth.enable = lib.mkEnableOption "Tether Bluetooth integration";
-    bluetooth.adapters = lib.mkOption {
-      type = lib.types.listOf (lib.types.strMatching "hci[0-9]+");
+    wifi.enable = mkEnableOption "Tether Wi-Fi discovery through Avahi";
+    wifi.openFirewall = mkEnableOption "the mDNS and TCP firewall ports required by Tether";
+    bluetooth.enable = mkEnableOption "Tether Bluetooth integration";
+    bluetooth.adapters = mkOption {
+      type = with types; listOf (strMatching "hci[0-9]+");
       default = [ "hci0" ];
       example = [
         "hci0"
@@ -54,17 +55,30 @@ in
       ];
       description = "Bluetooth HCI adapters whose class Tether should configure.";
     };
+    extensions = mkOption {
+      type =
+        with types;
+        listOf (enum [
+          "firefox"
+          "chromium"
+          "thunderbird"
+        ]);
+      default = [ ];
+      defaultText = literalExpression "[ ]";
+      description = "The Tether Browser/Mail extensions to retrieve OTP codes";
+    };
   };
 
-  config = lib.mkMerge [
-    (lib.mkIf cfg.enable {
+  config = mkMerge [
+    (mkIf cfg.enable {
       environment.systemPackages = [ cfg.package ];
+    })
+
+    (mkIf (cfg.enable && (builtins.elem "firefox" cfg.extensions)) {
       programs.firefox.nativeMessagingHosts.packages = [ cfg.package ];
-      programs.thunderbird.package = lib.mkDefault (
-        pkgs.thunderbird.override {
-          nativeMessagingHosts = [ cfg.package ];
-        }
-      );
+    })
+
+    (mkIf (cfg.enable && (builtins.elem "chromium" cfg.extensions)) {
       environment.etc = {
         "chromium/native-messaging-hosts/com.tether.extension.json".source =
           "${cfg.package}/etc/chromium/native-messaging-hosts/com.tether.extension.json";
@@ -73,17 +87,25 @@ in
       };
     })
 
-    (lib.mkIf (cfg.enable && cfg.wifi.enable) {
-      services.avahi.enable = true;
-      services.avahi.openFirewall = lib.mkDefault false;
+    (mkIf (cfg.enable && (builtins.elem "thunderbird" cfg.extensions)) {
+      programs.thunderbird.package = mkDefault (
+        pkgs.thunderbird.override {
+          nativeMessagingHosts = [ cfg.package ];
+        }
+      );
     })
 
-    (lib.mkIf (cfg.enable && cfg.wifi.openFirewall) {
+    (mkIf (cfg.enable && cfg.wifi.enable) {
+      services.avahi.enable = true;
+      services.avahi.openFirewall = mkDefault false;
+    })
+
+    (mkIf (cfg.enable && cfg.wifi.openFirewall) {
       services.avahi.openFirewall = true;
       networking.firewall.allowedTCPPorts = [ 5134 ];
     })
 
-    (lib.mkIf (cfg.enable && cfg.bluetooth.enable) {
+    (mkIf (cfg.enable && cfg.bluetooth.enable) {
       hardware.bluetooth.enable = true;
       hardware.bluetooth.settings.General.Experimental = true;
       systemd.services = builtins.listToAttrs (map bluetoothService cfg.bluetooth.adapters);


### PR DESCRIPTION
First of all, I'm loving the project :D
This adds the option to toggle the individual extensions inside the NixOS module, so users can toggle off extensions for programs they don't use.
For that, there's a new field `extensions`, where users can add `firefox`, `chromium` or `thunderbird` to enable the according extension. (see README)
By default all extensions are now disabled to match the behaviour of the other options.