### PR TITLE
fix: respect XDG_{CONFIG,DATA}_HOME

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -55,7 +55,8 @@ Check what you are running with `tether --version` and compare against the
 The parts of Tether where a bug is a security bug:
 
 - **Pairing and TLS.** Certificate and key handling
-  (`~/.config/tether/cert.pem`, `key.pem`, `known_hosts.json`), the pairing
+  (`cert.pem`, `key.pem`, `known_hosts.json` under `$XDG_CONFIG_HOME/tether`,
+  `~/.config/tether` by default), the pairing
   approval flow, and anything that lets an unpaired peer be trusted, or a
   paired peer be impersonated.
 - **Bluetooth.** ANCS notification and MAP message handling, and the parsers

--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -96,7 +96,8 @@ that can never connect and a bond that never looks dual.
 
 ## Pairing strategies
 
-Two ways to make the bond, recorded in `auth_strategy` in `~/.config/tether/bluetooth.json`.
+Two ways to make the bond, recorded in `auth_strategy` in `$XDG_CONFIG_HOME/tether/bluetooth.json`
+(`~/.config/tether` by default).
 
 **Connect-first** (`connect-first`, the default) calls `Device1.Connect()` on the unpaired
 device. That is a *profile* connect, not an authentication request: it brings the ACL up, the
@@ -664,7 +665,7 @@ replayed backlog arrived stamped all alike -- see issue #48.
 
 ### Group messages
 
-Off by default, `group_messages_enabled` in `~/.config/tether/bluetooth.json`. It also
+Off by default, `group_messages_enabled` in `$XDG_CONFIG_HOME/tether/bluetooth.json`. It also
 needs `ancs_content_enabled` (on by default, `tether --bt-ancs-content off` to disable),
 so group support cannot work without content mirroring.
 
@@ -676,7 +677,7 @@ the group's name. Neither form contains a member list...
 - Correlation is bounded to a 30-second window, and two notifications with the same
   text are refused instead of guessing, the wrong choice would put a message in the wrong conversation and send a reply at the wrong people.
 - An unnamed group is repliable only when **every** participant name resolves to exactly one contact address. A name matching several contacts is refused.
-- A named group stays read-only until we figure out the member list in `~/.config/tether/groups.json`.
+- A named group stays read-only until we figure out the member list in `$XDG_CONFIG_HOME/tether/groups.json`.
     That list affects Tether's reply routing only and never modifies the group on the phone.
 - iOS reports nothing when a member is added or removed, so an unknown sender is the only available signal that a member list has gone stale.
 - Because iOS supplies a name but no conversation identifier, distinct named groups
@@ -1100,7 +1101,7 @@ The key is 32 bytes from `RAND_bytes`, kept in the desktop secret service
 `secret_service_search_sync` **without** `SECRET_SEARCH_UNLOCK`:
 `secret_password_lookup_sync` would raise an unlock prompt, which is wrong for a
 user unit that can start before the graphical session. On a host with no secret
-service on the bus at all the key falls back to `~/.config/tether/store.key`,
+service on the bus at all the key falls back to `$XDG_CONFIG_HOME/tether/store.key`,
 mode 0600 — that stops a backup or a synced home, not another process running as
 you, and it is never written when a wallet is merely locked.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -157,7 +157,7 @@ The vault is encrypted with a user passphrase. Sync between the iPhone app and t
 | Name | Tether |
 | Daemon binary | `tetherd` |
 | CLI | `tether` |
-| Config | `~/.config/tether/tether.toml` |
+| Config | `$XDG_CONFIG_HOME/tether` (`~/.config/tether` by default) |
 | Primary packaging | AUR (Arch), daemon works on any Wayland Linux |
 | iOS distribution | App Store (required for `ASCredentialProviderExtension`) |
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -410,14 +410,14 @@ a `tetherd` left running across a package upgrade.
 #### `bt_set_ancs_content` (Client -> Daemon, broadcast)
 **Payload**: `{"command": "bt_set_ancs_content", "enabled": true}`
 Turns notification content mirroring on or off. Persists to
-`ancs_content_enabled` in `~/.config/tether/bluetooth.json`, applies to the running ANCS
+`ancs_content_enabled` in `$XDG_CONFIG_HOME/tether/bluetooth.json`, applies to the running ANCS
 client without a restart, and answers with a fresh `bt_status`. `bt_status` carries
 `ancs_enabled` and `ancs_content_enabled` so a client can render the current state.
 
 #### `bt_set_retention` (Client -> Daemon, broadcast)
 **Payload**: `{"command": "bt_set_retention", "retention": "encrypted"}`
 One of `encrypted` (the default), `plaintext`, or `none`. Persists to `retention` in
-`~/.config/tether/bluetooth.json` and answers with a fresh `bt_status`.
+`$XDG_CONFIG_HOME/tether/bluetooth.json` and answers with a fresh `bt_status`.
 
 Changing the mode moves what is already stored to the path the new mode uses; `none`
 deletes the message journal and the contact cache outright. `bt_status` carries

--- a/scripts/tether-reset.sh
+++ b/scripts/tether-reset.sh
@@ -6,9 +6,8 @@
 #                          and the key the encrypted store was written with
 #   tether-reset.sh all    both, plus the daemon log
 #
-# Paths are spelled out rather than derived from XDG_CONFIG_HOME/XDG_DATA_HOME
-# because the daemon itself builds them from $HOME; following the spec here
-# would delete files nothing ever wrote.
+# Paths follow the same XDG variables the daemon resolves, so a custom
+# XDG_CONFIG_HOME or XDG_DATA_HOME is cleaned rather than skipped.
 
 set -uo pipefail
 
@@ -31,8 +30,8 @@ esac
 red=$'\e[31m'; grn=$'\e[32m'; ylw=$'\e[33m'; dim=$'\e[2m'; rst=$'\e[0m'
 [[ -t 1 ]] || { red=; grn=; ylw=; dim=; rst=; }
 
-config="$HOME/.config/tether"
-share="$HOME/.local/share/tether"
+config="${XDG_CONFIG_HOME:-$HOME/.config}/tether"
+share="${XDG_DATA_HOME:-$HOME/.local/share}/tether"
 state="${XDG_STATE_HOME:-$HOME/.local/state}/tether"
 runtime="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/tether"
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(tether STATIC
     src/event_loop.cpp
     src/net.cpp
     src/base64.cpp
+    src/paths.cpp
     src/otp.cpp
     src/file_transfer.cpp
     src/crypto.cpp

--- a/src/core/include/tether/paths.hpp
+++ b/src/core/include/tether/paths.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <filesystem>
+
+namespace tether::paths {
+
+    // XDG base directories for tether's own files. Returns an empty path
+    // when there is no home directory to fall back on. Nothing is created.
+    //
+    // A directory named by an XDG variable is used only when the value is
+    // absolute, per the spec. When the XDG location does not exist yet but the
+    // legacy $HOME one does, the legacy path wins so an existing install
+    // doesn't break.
+
+    // $XDG_CONFIG_HOME/tether, else ~/.config/tether.
+    std::filesystem::path config_dir();
+
+    // $XDG_DATA_HOME/tether, else ~/.local/share/tether.
+    std::filesystem::path data_dir();
+
+    // $XDG_STATE_HOME/tether, else ~/.local/state/tether.
+    std::filesystem::path state_dir();
+
+} // namespace tether::paths

--- a/src/core/src/bluetooth/config.cpp
+++ b/src/core/src/bluetooth/config.cpp
@@ -1,26 +1,14 @@
 #include "tether/bluetooth/config.hpp"
 #include "tether/log.hpp"
+#include "tether/paths.hpp"
 
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <nlohmann/json.hpp>
-#include <pwd.h>
 #include <unistd.h>
 
 namespace tether::bluetooth {
-
-    namespace {
-
-        std::string home_dir() {
-            if (const char* home = getenv("HOME"); home && *home)
-                return home;
-            if (const passwd* pw = getpwuid(getuid()); pw && pw->pw_dir)
-                return pw->pw_dir;
-            return {};
-        }
-
-    } // namespace
 
     namespace {
         // 2 since 0.2.24 how to tell "never had a retention setting" from "lost one".
@@ -36,10 +24,10 @@ namespace tether::bluetooth {
     }
 
     std::string config_path() {
-        std::string home = home_dir();
-        if (home.empty())
+        const std::filesystem::path dir = paths::config_dir();
+        if (dir.empty())
             return {};
-        return (std::filesystem::path(home) / ".config" / "tether" / "bluetooth.json").string();
+        return (dir / "bluetooth.json").string();
     }
 
     std::string serialize_config(const Config& config) {

--- a/src/core/src/bluetooth/contacts.cpp
+++ b/src/core/src/bluetooth/contacts.cpp
@@ -1,6 +1,7 @@
 #include "tether/bluetooth/contacts.hpp"
 #include "tether/bluetooth/bmessage.hpp"
 #include "tether/log.hpp"
+#include "tether/paths.hpp"
 #include "tether/secret_store.hpp"
 
 #include <algorithm>
@@ -10,22 +11,9 @@
 #include <filesystem>
 #include <fstream>
 #include <glib.h>
-#include <pwd.h>
 #include <unistd.h>
 
 namespace tether::bluetooth {
-
-    namespace {
-
-        std::string home_dir() {
-            if (const char* home = getenv("HOME"); home && *home)
-                return home;
-            if (const passwd* pw = getpwuid(getuid()); pw && pw->pw_dir)
-                return pw->pw_dir;
-            return {};
-        }
-
-    } // namespace
 
     void ContactStore::set(std::vector<VCard> contacts) {
         contacts_ = std::move(contacts);
@@ -134,10 +122,9 @@ namespace tether::bluetooth {
     }
 
     std::string contacts_path(Retention mode) {
-        std::string home = home_dir();
-        if (home.empty() || mode == Retention::None)
+        const std::filesystem::path dir = paths::data_dir();
+        if (dir.empty() || mode == Retention::None)
             return {};
-        const std::filesystem::path dir = std::filesystem::path(home) / ".local" / "share" / "tether";
         return (dir / (mode == Retention::Encrypted ? "contacts.json.enc" : "contacts.json")).string();
     }
 

--- a/src/core/src/bluetooth/diagnostics.cpp
+++ b/src/core/src/bluetooth/diagnostics.cpp
@@ -4,6 +4,7 @@
 #include "tether/bluetooth/config.hpp"
 #include "tether/bluetooth/monitor.hpp"
 #include "tether/bluetooth/pairing.hpp"
+#include "tether/paths.hpp"
 #include "tether/version.hpp"
 
 #include <algorithm>
@@ -169,6 +170,11 @@ namespace tether::bluetooth {
         if (const char* runtime = std::getenv("XDG_RUNTIME_DIR"); runtime && *runtime)
             out = replace_literal(out, runtime, "<runtime>");
         out = replace_all(out, kRuntimeDir, [](const std::string&) { return "<runtime>"; });
+        // Before $HOME, so an XDG directory outside the home is still covered.
+        if (const std::string config = paths::config_dir().string(); !config.empty())
+            out = replace_literal(out, config, "<config>");
+        if (const std::string data = paths::data_dir().string(); !data.empty())
+            out = replace_literal(out, data, "<data>");
         if (const char* home = std::getenv("HOME"); home && *home)
             out = replace_literal(out, home, "<home>");
 

--- a/src/core/src/bluetooth/groups.cpp
+++ b/src/core/src/bluetooth/groups.cpp
@@ -1,5 +1,6 @@
 #include "tether/bluetooth/groups.hpp"
 #include <tether/i18n.hpp>
+#include <tether/paths.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -7,20 +8,11 @@
 #include <filesystem>
 #include <fstream>
 #include <nlohmann/json.hpp>
-#include <pwd.h>
 #include <unistd.h>
 
 namespace tether::bluetooth {
 
     namespace {
-
-        std::string home_dir() {
-            if (const char* home = getenv("HOME"); home && *home)
-                return home;
-            if (const passwd* pw = getpwuid(getuid()); pw && pw->pw_dir)
-                return pw->pw_dir;
-            return {};
-        }
 
         std::string trim(const std::string& text) {
             size_t begin = text.find_first_not_of(" \t\r\n");
@@ -220,10 +212,10 @@ namespace tether::bluetooth {
     }
 
     std::string roster_path() {
-        std::string home = home_dir();
-        if (home.empty())
+        const std::filesystem::path dir = paths::config_dir();
+        if (dir.empty())
             return {};
-        return (std::filesystem::path(home) / ".config" / "tether" / "groups.json").string();
+        return (dir / "groups.json").string();
     }
 
     GroupRoster load_rosters() {

--- a/src/core/src/bluetooth/journal.cpp
+++ b/src/core/src/bluetooth/journal.cpp
@@ -1,5 +1,6 @@
 #include "tether/bluetooth/journal.hpp"
 #include "tether/log.hpp"
+#include "tether/paths.hpp"
 #include "tether/secret_store.hpp"
 
 #include <algorithm>
@@ -8,20 +9,11 @@
 #include <filesystem>
 #include <map>
 #include <nlohmann/json.hpp>
-#include <pwd.h>
 #include <unistd.h>
 
 namespace tether::bluetooth {
 
     namespace {
-
-        std::string home_dir() {
-            if (const char* home = getenv("HOME"); home && *home)
-                return home;
-            if (const passwd* pw = getpwuid(getuid()); pw && pw->pw_dir)
-                return pw->pw_dir;
-            return {};
-        }
 
         void restrict_permissions(const std::string& path) {
             std::error_code ec;
@@ -47,10 +39,9 @@ namespace tether::bluetooth {
     } // namespace
 
     std::string journal_path(Retention mode) {
-        std::string home = home_dir();
-        if (home.empty() || mode == Retention::None)
+        const std::filesystem::path dir = paths::data_dir();
+        if (dir.empty() || mode == Retention::None)
             return {};
-        const std::filesystem::path dir = std::filesystem::path(home) / ".local" / "share" / "tether";
         return (dir / (mode == Retention::Encrypted ? "messages.ndjson.enc" : "messages.ndjson")).string();
     }
 

--- a/src/core/src/crypto.cpp
+++ b/src/core/src/crypto.cpp
@@ -8,9 +8,9 @@
 #include <openssl/pem.h>
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
-#include <pwd.h>
 #include <sstream>
 #include <tether/log.hpp>
+#include <tether/paths.hpp>
 #include <unistd.h>
 
 namespace tether {
@@ -30,21 +30,13 @@ namespace tether {
     SSL_CTX* Crypto::get_server_context() { return server_ctx_; }
     SSL_CTX* Crypto::get_client_context() { return client_ctx_; }
 
-    static std::string home_dir() {
-        if (const char* home = getenv("HOME"); home && *home) {
-            return home;
-        }
-        if (const passwd* pw = getpwuid(getuid()); pw && pw->pw_dir) {
-            return pw->pw_dir;
-        }
-        throw std::runtime_error("Cannot determine home directory (HOME unset and no passwd entry)");
-    }
-
     bool Crypto::init() {
         if (server_ctx_ && client_ctx_)
             return true;
 
-        std::filesystem::path config_dir = std::filesystem::path(home_dir()) / ".config" / "tether";
+        const std::filesystem::path config_dir = paths::config_dir();
+        if (config_dir.empty())
+            throw std::runtime_error("Cannot determine home directory (HOME unset and no passwd entry)");
         std::filesystem::create_directories(config_dir);
         cert_path_ = (config_dir / "cert.pem").string();
         key_path_ = (config_dir / "key.pem").string();

--- a/src/core/src/net.cpp
+++ b/src/core/src/net.cpp
@@ -26,6 +26,7 @@
 #include "tether/discovery.hpp"
 #include "tether/file_transfer.hpp"
 #include "tether/otp.hpp"
+#include "tether/paths.hpp"
 #include "tether/wayland.hpp"
 #include <algorithm>
 #include <atomic>
@@ -774,17 +775,9 @@ namespace tether {
     }
 
     std::string get_state_dir() {
-        const char* xdg_state = std::getenv("XDG_STATE_HOME");
-        const char* home = std::getenv("HOME");
-        std::filesystem::path base;
-        if (xdg_state && *xdg_state)
-            base = xdg_state;
-        else if (home && *home)
-            base = std::filesystem::path(home) / ".local" / "state";
-        else
-            base = "/tmp";
-
-        std::filesystem::path tether_dir = base / "tether";
+        std::filesystem::path tether_dir = paths::state_dir();
+        if (tether_dir.empty())
+            tether_dir = "/tmp/tether";
         std::filesystem::create_directories(tether_dir);
         return tether_dir.string();
     }

--- a/src/core/src/paths.cpp
+++ b/src/core/src/paths.cpp
@@ -1,0 +1,47 @@
+#include "tether/paths.hpp"
+
+#include <cstdlib>
+#include <pwd.h>
+#include <unistd.h>
+
+namespace tether::paths {
+
+    namespace {
+
+        std::filesystem::path home_dir() {
+            if (const char* home = getenv("HOME"); home && *home)
+                return home;
+            if (const passwd* pw = getpwuid(getuid()); pw && pw->pw_dir)
+                return pw->pw_dir;
+            return {};
+        }
+
+        bool dir_exists(const std::filesystem::path& path) {
+            std::error_code ec;
+            return std::filesystem::exists(path, ec);
+        }
+
+        std::filesystem::path xdg_dir(const char* variable, const char* fallback) {
+            const std::filesystem::path home = home_dir();
+            const std::filesystem::path legacy = home.empty() ? std::filesystem::path{} : home / fallback / "tether";
+
+            const char* value = getenv(variable);
+            // A relative XDG value is invalid and ignored.
+            if (!value || !*value || !std::filesystem::path(value).is_absolute())
+                return legacy;
+
+            const std::filesystem::path dir = std::filesystem::path(value) / "tether";
+            if (!legacy.empty() && !dir_exists(dir) && dir_exists(legacy))
+                return legacy;
+            return dir;
+        }
+
+    } // namespace
+
+    std::filesystem::path config_dir() { return xdg_dir("XDG_CONFIG_HOME", ".config"); }
+
+    std::filesystem::path data_dir() { return xdg_dir("XDG_DATA_HOME", ".local/share"); }
+
+    std::filesystem::path state_dir() { return xdg_dir("XDG_STATE_HOME", ".local/state"); }
+
+} // namespace tether::paths

--- a/src/core/src/secret_store.cpp
+++ b/src/core/src/secret_store.cpp
@@ -1,6 +1,7 @@
 #include "tether/secret_store.hpp"
 #include "tether/base64.hpp"
 #include "tether/log.hpp"
+#include "tether/paths.hpp"
 
 #include <chrono>
 #include <cstdlib>
@@ -10,7 +11,6 @@
 #include <mutex>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
-#include <pwd.h>
 #include <unistd.h>
 
 namespace tether {
@@ -63,19 +63,11 @@ namespace tether {
                 return &schema;
             }
 
-            std::string home_dir() {
-                if (const char* home = getenv("HOME"); home && *home)
-                    return home;
-                if (const passwd* pw = getpwuid(getuid()); pw && pw->pw_dir)
-                    return pw->pw_dir;
-                return {};
-            }
-
             std::string keyfile_path() {
-                std::string home = home_dir();
-                if (home.empty())
+                const std::filesystem::path dir = paths::config_dir();
+                if (dir.empty())
                     return {};
-                return (std::filesystem::path(home) / ".config" / "tether" / "store.key").string();
+                return (dir / "store.key").string();
             }
 
             int64_t now_seconds() {

--- a/src/gtk/prefs.cpp
+++ b/src/gtk/prefs.cpp
@@ -4,16 +4,17 @@
 #include <fstream>
 #include <glib.h>
 #include <tether/log.hpp>
+#include <tether/paths.hpp>
 
 namespace tether::ui {
 
     namespace {
 
         std::string prefs_path() {
-            const char* home = g_get_home_dir();
-            if (!home || !*home)
+            const std::filesystem::path dir = tether::paths::config_dir();
+            if (dir.empty())
                 return {};
-            return (std::filesystem::path(home) / ".config" / "tether" / "gtk.json").string();
+            return (dir / "gtk.json").string();
         }
 
     } // namespace

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(tether_test
     test_log.cpp
     test_net.cpp
     test_otp.cpp
+    test_paths.cpp
     test_message_format.cpp
     ../src/gtk/message_format.cpp
 )

--- a/test/secret_test_env.cpp
+++ b/test/secret_test_env.cpp
@@ -13,6 +13,13 @@ namespace {
     const bool sandboxed = [] {
         setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/nonexistent/tether-test", 1);
 
+        // Store paths follow the XDG variables before $HOME, so a developer who
+        // sets them would otherwise have the suite writing into their real
+        // config and data directories.
+        unsetenv("XDG_CONFIG_HOME");
+        unsetenv("XDG_DATA_HOME");
+        unsetenv("XDG_STATE_HOME");
+
         const auto home = std::filesystem::temp_directory_path() / ("tether-test-home-" + std::to_string(::getpid()));
         std::error_code ec;
         std::filesystem::create_directories(home, ec);

--- a/test/test_bt_diagnostics.cpp
+++ b/test/test_bt_diagnostics.cpp
@@ -77,8 +77,14 @@ TEST(BtDiagnostics, RedactsHomeAndRuntimeDirectories) {
     tether::testing::ScopedEnv runtime("XDG_RUNTIME_DIR", std::string("/run/user/1000"));
     Redactor r;
     EXPECT_EQ(r.text("staged /run/user/1000/tether/out.bmsg"), "staged <runtime>/tether/out.bmsg");
-    EXPECT_EQ(r.text("wrote /home/someone/.config/tether/bluetooth.json"),
-              "wrote <home>/.config/tether/bluetooth.json");
+    EXPECT_EQ(r.text("wrote /home/someone/.config/tether/bluetooth.json"), "wrote <config>/bluetooth.json");
+}
+
+TEST(BtDiagnostics, RedactsAConfigDirectoryOutsideTheHome) {
+    tether::testing::ScopedEnv home("HOME", std::string("/home/someone"));
+    tether::testing::ScopedEnv config("XDG_CONFIG_HOME", std::string("/elsewhere/config"));
+    Redactor r;
+    EXPECT_EQ(r.text("wrote /elsewhere/config/tether/bluetooth.json"), "wrote <config>/bluetooth.json");
 }
 
 TEST(BtDiagnostics, RedactsRuntimeDirectoryWithoutTheEnvironmentVariable) {

--- a/test/test_paths.cpp
+++ b/test/test_paths.cpp
@@ -1,0 +1,82 @@
+#include "scoped_env.hpp"
+
+#include <gtest/gtest.h>
+#include <tether/paths.hpp>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+    // A throwaway $HOME per test, so a legacy directory made here cannot leak
+    // into the next one.
+    class PathsTest : public ::testing::Test {
+    protected:
+        void SetUp() override {
+            fs::create_directories(home_);
+            fs::create_directories(xdg_);
+        }
+
+        void TearDown() override {
+            std::error_code ec;
+            fs::remove_all(root_, ec);
+        }
+
+        const fs::path root_ =
+            fs::temp_directory_path() / ("tether-paths-" + std::to_string(::getpid()) + "-" +
+                                         ::testing::UnitTest::GetInstance()->current_test_info()->name());
+        const fs::path home_ = root_ / "home";
+        const fs::path xdg_ = root_ / "xdg";
+    };
+
+} // namespace
+
+TEST_F(PathsTest, FallsBackToTheDefaultsWhenNoXdgVariableIsSet) {
+    tether::testing::ScopedEnv home("HOME", home_);
+
+    EXPECT_EQ(tether::paths::config_dir(), home_ / ".config/tether");
+    EXPECT_EQ(tether::paths::data_dir(), home_ / ".local/share/tether");
+    EXPECT_EQ(tether::paths::state_dir(), home_ / ".local/state/tether");
+}
+
+TEST_F(PathsTest, HonorsTheXdgVariables) {
+    tether::testing::ScopedEnv home("HOME", home_);
+    tether::testing::ScopedEnv config("XDG_CONFIG_HOME", xdg_ / "config");
+    tether::testing::ScopedEnv data("XDG_DATA_HOME", xdg_ / "data");
+    tether::testing::ScopedEnv state("XDG_STATE_HOME", xdg_ / "state");
+
+    EXPECT_EQ(tether::paths::config_dir(), xdg_ / "config/tether");
+    EXPECT_EQ(tether::paths::data_dir(), xdg_ / "data/tether");
+    EXPECT_EQ(tether::paths::state_dir(), xdg_ / "state/tether");
+}
+
+TEST_F(PathsTest, IgnoresAnEmptyOrRelativeXdgValue) {
+    tether::testing::ScopedEnv home("HOME", home_);
+
+    {
+        tether::testing::ScopedEnv config("XDG_CONFIG_HOME", std::string(""));
+        EXPECT_EQ(tether::paths::config_dir(), home_ / ".config/tether");
+    }
+    {
+        tether::testing::ScopedEnv config("XDG_CONFIG_HOME", std::string("relative/config"));
+        EXPECT_EQ(tether::paths::config_dir(), home_ / ".config/tether");
+    }
+}
+
+// An install that predates XDG support keeps its certificates and pairing.
+TEST_F(PathsTest, PrefersAnExistingLegacyDirectoryOverAnAbsentXdgOne) {
+    tether::testing::ScopedEnv home("HOME", home_);
+    tether::testing::ScopedEnv config("XDG_CONFIG_HOME", xdg_ / "config");
+    fs::create_directories(home_ / ".config/tether");
+
+    EXPECT_EQ(tether::paths::config_dir(), home_ / ".config/tether");
+}
+
+TEST_F(PathsTest, UsesTheXdgDirectoryOnceItExists) {
+    tether::testing::ScopedEnv home("HOME", home_);
+    tether::testing::ScopedEnv config("XDG_CONFIG_HOME", xdg_ / "config");
+    fs::create_directories(home_ / ".config/tether");
+    fs::create_directories(xdg_ / "config/tether");
+
+    EXPECT_EQ(tether::paths::config_dir(), xdg_ / "config/tether");
+}


### PR DESCRIPTION
STATE, DOWNLOADS, and RUNTIME XDG directories were respected but not CONFIG, SHARE, DATA, which was super dumb. This refactors it all into a shared helpers in `paths.cpp`.

All standard XDG directory locations now work.

Fixes: #135 