### PR TITLE
feat(gtk): launch the linux app for a notification if installed

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -198,7 +198,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Zapíše jednotku tether-btclass@.service, která nastavuje třídu adaptéru Bluetooth vyžadovanou systémem iOS. Vyžaduje root a nikdy ji nepovolí. Potřebné pouze pro přenosná sestavení; balíčky distribuce ji instalují samy."
+msgstr ""
+"Zapíše jednotku tether-btclass@.service, která nastavuje třídu adaptéru "
+"Bluetooth vyžadovanou systémem iOS. Vyžaduje root a nikdy ji nepovolí. "
+"Potřebné pouze pro přenosná sestavení; balíčky distribuce ji instalují samy."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -264,7 +267,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nNení povolena. Spusťte 'systemctl daemon-reload' a poté 'systemctl enable --now tether-btclass@hci0', aby se použila.\n"
+msgstr ""
+"\n"
+"Není povolena. Spusťte 'systemctl daemon-reload' a poté 'systemctl enable --"
+"now tether-btclass@hci0', aby se použila.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1231,6 +1237,11 @@ msgstr "Odpovědět"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Kopírovat kód"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Otevřít v {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -200,7 +200,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Schreibt die Unit tether-btclass@.service, die die von iOS geforderte Bluetooth-Adapterklasse setzt. Benötigt root und aktiviert sie nie. Nur für portable Builds nötig; die Distributionspakete installieren sie selbst."
+msgstr ""
+"Schreibt die Unit tether-btclass@.service, die die von iOS geforderte "
+"Bluetooth-Adapterklasse setzt. Benötigt root und aktiviert sie nie. Nur für "
+"portable Builds nötig; die Distributionspakete installieren sie selbst."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -266,7 +269,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nSie ist nicht aktiviert. Führen Sie 'systemctl daemon-reload' aus und danach 'systemctl enable --now tether-btclass@hci0', um sie anzuwenden.\n"
+msgstr ""
+"\n"
+"Sie ist nicht aktiviert. Führen Sie 'systemctl daemon-reload' aus und danach "
+"'systemctl enable --now tether-btclass@hci0', um sie anzuwenden.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1257,6 +1263,11 @@ msgstr "Antworten"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Code kopieren"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "In {} öffnen"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -200,7 +200,11 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Escribe la unidad tether-btclass@.service, que establece la clase de adaptador Bluetooth que iOS requiere. Necesita root y nunca la activa. Solo es necesario para compilaciones portables; los paquetes de la distribución la instalan."
+msgstr ""
+"Escribe la unidad tether-btclass@.service, que establece la clase de "
+"adaptador Bluetooth que iOS requiere. Necesita root y nunca la activa. Solo "
+"es necesario para compilaciones portables; los paquetes de la distribución "
+"la instalan."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -266,7 +270,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nNo está activada. Ejecuta 'systemctl daemon-reload' y luego 'systemctl enable --now tether-btclass@hci0' para aplicarla.\n"
+msgstr ""
+"\n"
+"No está activada. Ejecuta 'systemctl daemon-reload' y luego 'systemctl "
+"enable --now tether-btclass@hci0' para aplicarla.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1247,6 +1254,11 @@ msgstr "Responder"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Copiar código"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Abrir en {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -204,7 +204,11 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Écrit l'unité tether-btclass@.service, qui définit la classe d'adaptateur Bluetooth exigée par iOS. Nécessite root et ne l'active jamais. Utile uniquement pour les builds portables ; les paquets de la distribution l'installent."
+msgstr ""
+"Écrit l'unité tether-btclass@.service, qui définit la classe d'adaptateur "
+"Bluetooth exigée par iOS. Nécessite root et ne l'active jamais. Utile "
+"uniquement pour les builds portables ; les paquets de la distribution "
+"l'installent."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -271,7 +275,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nElle n'est pas activée. Lancez 'systemctl daemon-reload', puis 'systemctl enable --now tether-btclass@hci0' pour l'appliquer.\n"
+msgstr ""
+"\n"
+"Elle n'est pas activée. Lancez 'systemctl daemon-reload', puis 'systemctl "
+"enable --now tether-btclass@hci0' pour l'appliquer.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1254,6 +1261,11 @@ msgstr "Répondre"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Copier le code"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Ouvrir dans {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -201,7 +201,11 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Scrive l'unità tether-btclass@.service, che imposta la classe dell'adattatore Bluetooth richiesta da iOS. Richiede root e non la abilita mai. Serve solo per le build portabili; i pacchetti della distribuzione la installano."
+msgstr ""
+"Scrive l'unità tether-btclass@.service, che imposta la classe "
+"dell'adattatore Bluetooth richiesta da iOS. Richiede root e non la abilita "
+"mai. Serve solo per le build portabili; i pacchetti della distribuzione la "
+"installano."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -267,7 +271,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nNon è abilitata. Esegui 'systemctl daemon-reload', poi 'systemctl enable --now tether-btclass@hci0' per applicarla.\n"
+msgstr ""
+"\n"
+"Non è abilitata. Esegui 'systemctl daemon-reload', poi 'systemctl enable --"
+"now tether-btclass@hci0' per applicarla.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1245,6 +1252,11 @@ msgstr "Rispondi"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Copia codice"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Apri in {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -199,7 +199,11 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "iOS が要求する Bluetooth アダプターのクラスを設定する tether-btclass@.service ユニットを書き出します。root が必要で、有効化は行いません。ポータブルビルドでのみ必要です。ディストリビューションのパッケージは自分でインストールします。"
+msgstr ""
+"iOS が要求する Bluetooth アダプターのクラスを設定する tether-"
+"btclass@.service ユニットを書き出します。root が必要で、有効化は行いません。"
+"ポータブルビルドでのみ必要です。ディストリビューションのパッケージは自分でイ"
+"ンストールします。"
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -265,7 +269,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\n有効にはなっていません。適用するには 'systemctl daemon-reload' を実行し、続けて 'systemctl enable --now tether-btclass@hci0' を実行してください。\n"
+msgstr ""
+"\n"
+"有効にはなっていません。適用するには 'systemctl daemon-reload' を実行し、続け"
+"て 'systemctl enable --now tether-btclass@hci0' を実行してください。\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1220,6 +1227,11 @@ msgstr "返信"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "コードをコピー"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "{} で開く"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -198,7 +198,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "iOS가 요구하는 블루투스 어댑터 클래스를 설정하는 tether-btclass@.service 유닛을 씁니다. root가 필요하며 활성화는 하지 않습니다. 포터블 빌드에만 필요합니다. 배포판 패키지는 직접 설치합니다."
+msgstr ""
+"iOS가 요구하는 블루투스 어댑터 클래스를 설정하는 tether-btclass@.service 유닛"
+"을 씁니다. root가 필요하며 활성화는 하지 않습니다. 포터블 빌드에만 필요합니"
+"다. 배포판 패키지는 직접 설치합니다."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -264,7 +267,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\n활성화되지 않았습니다. 적용하려면 'systemctl daemon-reload'를 실행한 다음 'systemctl enable --now tether-btclass@hci0'을 실행하세요.\n"
+msgstr ""
+"\n"
+"활성화되지 않았습니다. 적용하려면 'systemctl daemon-reload'를 실행한 다음 "
+"'systemctl enable --now tether-btclass@hci0'을 실행하세요.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1208,6 +1214,11 @@ msgstr "답장"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "코드 복사"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "{}에서 열기"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -200,7 +200,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Schrijft de unit tether-btclass@.service, die de Bluetooth-adapterklasse instelt die iOS vereist. Vereist root en schakelt hem nooit in. Alleen nodig voor draagbare builds; de distributiepakketten installeren hem zelf."
+msgstr ""
+"Schrijft de unit tether-btclass@.service, die de Bluetooth-adapterklasse "
+"instelt die iOS vereist. Vereist root en schakelt hem nooit in. Alleen nodig "
+"voor draagbare builds; de distributiepakketten installeren hem zelf."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -266,7 +269,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nHij is niet ingeschakeld. Voer 'systemctl daemon-reload' uit en daarna 'systemctl enable --now tether-btclass@hci0' om hem toe te passen.\n"
+msgstr ""
+"\n"
+"Hij is niet ingeschakeld. Voer 'systemctl daemon-reload' uit en daarna "
+"'systemctl enable --now tether-btclass@hci0' om hem toe te passen.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1241,6 +1247,11 @@ msgstr "Antwoorden"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Code kopiëren"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Openen in {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -200,7 +200,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Zapisuje jednostkę tether-btclass@.service, która ustawia klasę adaptera Bluetooth wymaganą przez iOS. Wymaga roota i nigdy jej nie włącza. Potrzebne tylko dla wersji przenośnych; pakiety dystrybucji instalują ją same."
+msgstr ""
+"Zapisuje jednostkę tether-btclass@.service, która ustawia klasę adaptera "
+"Bluetooth wymaganą przez iOS. Wymaga roota i nigdy jej nie włącza. Potrzebne "
+"tylko dla wersji przenośnych; pakiety dystrybucji instalują ją same."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -266,7 +269,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nNie jest włączona. Uruchom 'systemctl daemon-reload', a następnie 'systemctl enable --now tether-btclass@hci0', aby ją zastosować.\n"
+msgstr ""
+"\n"
+"Nie jest włączona. Uruchom 'systemctl daemon-reload', a następnie 'systemctl "
+"enable --now tether-btclass@hci0', aby ją zastosować.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1242,6 +1248,11 @@ msgstr "Odpowiedz"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Kopiuj kod"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Otwórz w {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -200,7 +200,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Grava a unidade tether-btclass@.service, que define a classe do adaptador Bluetooth exigida pelo iOS. Precisa de root e nunca a habilita. Necessário apenas para builds portáteis; os pacotes da distribuição a instalam."
+msgstr ""
+"Grava a unidade tether-btclass@.service, que define a classe do adaptador "
+"Bluetooth exigida pelo iOS. Precisa de root e nunca a habilita. Necessário "
+"apenas para builds portáteis; os pacotes da distribuição a instalam."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -267,7 +270,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nEla não está habilitada. Execute 'systemctl daemon-reload' e depois 'systemctl enable --now tether-btclass@hci0' para aplicá-la.\n"
+msgstr ""
+"\n"
+"Ela não está habilitada. Execute 'systemctl daemon-reload' e depois "
+"'systemctl enable --now tether-btclass@hci0' para aplicá-la.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1242,6 +1248,11 @@ msgstr "Responder"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Copiar código"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Abrir no {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -200,7 +200,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Записывает юнит tether-btclass@.service, задающий класс Bluetooth-адаптера, который требует iOS. Требует root и никогда его не включает. Нужно только для переносимых сборок; пакеты дистрибутива устанавливают его сами."
+msgstr ""
+"Записывает юнит tether-btclass@.service, задающий класс Bluetooth-адаптера, "
+"который требует iOS. Требует root и никогда его не включает. Нужно только "
+"для переносимых сборок; пакеты дистрибутива устанавливают его сами."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -266,7 +269,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nОн не включён. Выполните 'systemctl daemon-reload', затем 'systemctl enable --now tether-btclass@hci0', чтобы применить его.\n"
+msgstr ""
+"\n"
+"Он не включён. Выполните 'systemctl daemon-reload', затем 'systemctl enable "
+"--now tether-btclass@hci0', чтобы применить его.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1241,6 +1247,11 @@ msgstr "Ответить"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Скопировать код"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Открыть в {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -200,7 +200,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Skriver enheten tether-btclass@.service, som sätter den Bluetooth-adapterklass som iOS kräver. Kräver root och aktiverar den aldrig. Behövs bara för portabla byggen; distributionspaketen installerar den själva."
+msgstr ""
+"Skriver enheten tether-btclass@.service, som sätter den Bluetooth-"
+"adapterklass som iOS kräver. Kräver root och aktiverar den aldrig. Behövs "
+"bara för portabla byggen; distributionspaketen installerar den själva."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -266,7 +269,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nDen är inte aktiverad. Kör 'systemctl daemon-reload' och sedan 'systemctl enable --now tether-btclass@hci0' för att tillämpa den.\n"
+msgstr ""
+"\n"
+"Den är inte aktiverad. Kör 'systemctl daemon-reload' och sedan 'systemctl "
+"enable --now tether-btclass@hci0' för att tillämpa den.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1228,6 +1234,11 @@ msgstr "Svara"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Kopiera kod"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Öppna i {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether 0.2.25\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1113,6 +1113,11 @@ msgstr ""
 
 #: src/daemon/notification.cpp
 msgid "Copy Code"
+msgstr ""
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
 msgstr ""
 
 #: src/gtk/calls_view.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -199,7 +199,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "iOS'un istediği Bluetooth adaptör sınıfını ayarlayan tether-btclass@.service birimini yazar. root gerektirir ve onu asla etkinleştirmez. Yalnızca taşınabilir yapılar için gereklidir; dağıtım paketleri onu kendisi kurar."
+msgstr ""
+"iOS'un istediği Bluetooth adaptör sınıfını ayarlayan tether-btclass@.service "
+"birimini yazar. root gerektirir ve onu asla etkinleştirmez. Yalnızca "
+"taşınabilir yapılar için gereklidir; dağıtım paketleri onu kendisi kurar."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -265,7 +268,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nEtkin değil. Uygulamak için 'systemctl daemon-reload' ve ardından 'systemctl enable --now tether-btclass@hci0' çalıştırın.\n"
+msgstr ""
+"\n"
+"Etkin değil. Uygulamak için 'systemctl daemon-reload' ve ardından 'systemctl "
+"enable --now tether-btclass@hci0' çalıştırın.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1227,6 +1233,11 @@ msgstr "Yanıtla"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Kodu kopyala"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "{} ile aç"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -201,7 +201,10 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "Записує юніт tether-btclass@.service, який задає клас адаптера Bluetooth, потрібний iOS. Потребує root і ніколи його не вмикає. Потрібно лише для переносних збірок; пакунки дистрибутива встановлюють його самі."
+msgstr ""
+"Записує юніт tether-btclass@.service, який задає клас адаптера Bluetooth, "
+"потрібний iOS. Потребує root і ніколи його не вмикає. Потрібно лише для "
+"переносних збірок; пакунки дистрибутива встановлюють його самі."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -267,7 +270,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\nВін не увімкнений. Виконайте 'systemctl daemon-reload', потім 'systemctl enable --now tether-btclass@hci0', щоб застосувати його.\n"
+msgstr ""
+"\n"
+"Він не увімкнений. Виконайте 'systemctl daemon-reload', потім 'systemctl "
+"enable --now tether-btclass@hci0', щоб застосувати його.\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1240,6 +1246,11 @@ msgstr "Відповісти"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "Скопіювати код"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "Відкрити в {}"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 11:01-0700\n"
+"POT-Creation-Date: 2026-09-05 13:35-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -192,7 +192,9 @@ msgid ""
 "Write the tether-btclass@.service unit, which sets the Bluetooth adapter "
 "class iOS requires. Needs root, and never enables it. Needed only for "
 "portable builds; the distro packages install it."
-msgstr "写入 tether-btclass@.service 单元，它设置 iOS 所需的蓝牙适配器类别。需要 root，且从不启用它。仅便携式构建需要；发行版软件包会自行安装。"
+msgstr ""
+"写入 tether-btclass@.service 单元，它设置 iOS 所需的蓝牙适配器类别。需要 "
+"root，且从不启用它。仅便携式构建需要；发行版软件包会自行安装。"
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -257,7 +259,10 @@ msgid ""
 "\n"
 "It is not enabled. Run 'systemctl daemon-reload', then 'systemctl enable --"
 "now tether-btclass@hci0' to apply it.\n"
-msgstr "\n它尚未启用。运行 'systemctl daemon-reload'，然后运行 'systemctl enable --now tether-btclass@hci0' 以应用。\n"
+msgstr ""
+"\n"
+"它尚未启用。运行 'systemctl daemon-reload'，然后运行 'systemctl enable --now "
+"tether-btclass@hci0' 以应用。\n"
 
 #: src/cli/main.cpp
 msgid "Could not read Bluetooth status from the daemon.\n"
@@ -1179,6 +1184,11 @@ msgstr "回复"
 #: src/daemon/notification.cpp
 msgid "Copy Code"
 msgstr "复制验证码"
+
+#: src/daemon/notification.cpp
+#, c++-format
+msgid "Open in {}"
+msgstr "在 {} 中打开"
 
 #: src/gtk/calls_view.cpp
 msgid "Incoming"

--- a/scripts/ci-deps.sh
+++ b/scripts/ci-deps.sh
@@ -42,5 +42,5 @@ esac
 command -v msgfmt >/dev/null || { echo "ci-deps: msgfmt missing; translations would be skipped" >&2; exit 1; }
 
 pkg-config --print-errors --exists \
-    "wayland-client avahi-client openssl glib-2.0 gio-2.0 libsecret-1 gtk+-3.0 gtk-layer-shell-0 libnotify"
+    "wayland-client avahi-client openssl glib-2.0 gio-2.0 gio-unix-2.0 libsecret-1 gtk+-3.0 gtk-layer-shell-0 libnotify"
 echo "==> ready: gtk $(pkg-config --modversion gtk+-3.0), openssl $(pkg-config --modversion openssl)"

--- a/src/core/include/tether/bluetooth/ancs/notifications.hpp
+++ b/src/core/include/tether/bluetooth/ancs/notifications.hpp
@@ -81,6 +81,18 @@ namespace tether::bluetooth::ancs {
     // own logo, then something generic for its category.
     std::vector<std::string> icon_candidates(const Notification& notification);
 
+    // How to find the Linux counterpart of an iPhone app.
+    struct LaunchTarget {
+        // No "://".
+        std::string uri_scheme;
+        // No ".desktop" suffix.
+        std::vector<std::string> desktop_ids;
+
+        bool empty() const { return uri_scheme.empty() && desktop_ids.empty(); }
+    };
+
+    LaunchTarget launch_target(const std::string& app_id);
+
     nlohmann::json to_json(const Notification& notification);
 
 } // namespace tether::bluetooth::ancs

--- a/src/core/src/bluetooth/ancs/notifications.cpp
+++ b/src/core/src/bluetooth/ancs/notifications.cpp
@@ -178,6 +178,32 @@ namespace tether::bluetooth::ancs {
         return out;
     }
 
+    LaunchTarget launch_target(const std::string& app_id) {
+        static const std::map<std::string, LaunchTarget> by_app_id{
+            {"com.apple.mobilemail", {"mailto", {}}},
+            {"com.facebook.Messenger", {"", {"caprine", "com.sindresorhus.Caprine"}}},
+            {"com.google.Gmail", {"mailto", {}}},
+            {"com.hammerandchisel.discord", {"discord", {"discord", "com.discordapp.Discord"}}},
+            {"com.microsoft.Office.Outlook", {"mailto", {}}},
+            {"com.spotify.client", {"spotify", {"spotify", "com.spotify.Client"}}},
+            {"com.tinyspeck.chatlyio", {"slack", {"slack", "com.slack.Slack"}}},
+            {"net.whatsapp.WhatsApp",
+             {"whatsapp",
+              {"com.rtosta.zapzap",
+               "io.github.mimbrero.WhatsAppDesktop",
+               "com.github.eneshecan.WhatsAppForLinux",
+               "whatsapp-for-linux"}}},
+            {"org.telegram.messenger", {"tg", {"org.telegram.desktop", "telegramdesktop", "telegram-desktop"}}},
+            {"org.whispersystems.signal", {"sgnl", {"signal-desktop", "signal", "org.signal.Signal"}}},
+            {"ph.telegra.Telegraph", {"tg", {"org.telegram.desktop", "telegramdesktop", "telegram-desktop"}}},
+            {"us.zoom.videomeetings", {"zoommtg", {"Zoom", "us.zoom.Zoom"}}},
+        };
+
+        if (auto found = by_app_id.find(app_id); found != by_app_id.end())
+            return found->second;
+        return {};
+    }
+
     nlohmann::json to_json(const Notification& notification) {
         return {
             {"uid", notification.uid},

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -4,8 +4,9 @@ add_executable(tetherd
 )
 
 pkg_check_modules(LIBNOTIFY REQUIRED IMPORTED_TARGET libnotify)
+pkg_check_modules(GIO_UNIX REQUIRED IMPORTED_TARGET gio-unix-2.0)
 
-target_link_libraries(tetherd PRIVATE tether PkgConfig::LIBNOTIFY)
+target_link_libraries(tetherd PRIVATE tether PkgConfig::LIBNOTIFY PkgConfig::GIO_UNIX)
 
 # Output into root build dir instead of nested build/src/daemon
 set_target_properties(tetherd PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -299,7 +299,8 @@ int main(int argc, char** argv) {
                                      tether::bluetooth::ancs::icon_candidates(notification),
                                      notification.silent,
                                      "",
-                                     otp});
+                                     otp,
+                                     notification.app_id});
                 },
                 [](uint32_t uid) {
                     nlohmann::json event;

--- a/src/daemon/notification.cpp
+++ b/src/daemon/notification.cpp
@@ -2,6 +2,7 @@
 
 #include <tether/i18n.hpp>
 
+#include <gio/gdesktopappinfo.h>
 #include <gio/gio.h>
 #include <glib.h>
 #include <libnotify/notify.h>
@@ -9,6 +10,7 @@
 #include <functional>
 #include <mutex>
 #include <string>
+#include <tether/bluetooth/ancs/notifications.hpp>
 #include <tether/log.hpp>
 #include <tether/net.hpp>
 #include <thread>
@@ -155,6 +157,71 @@ namespace tether {
                 open_gui_thread(action->payload);
         }
 
+        // Whether this process can see the host's installed applications. A flatpak sandbox cannot.
+        bool sandboxed() {
+            static const bool yes = std::filesystem::exists("/.flatpak-info");
+            return yes;
+        }
+
+        // How to open the Linux counterpart of an iPhone app.
+        struct AppLauncher {
+            // "scheme://" URI, a "<id>.desktop" entry, or empty when
+            std::string payload;
+            std::string name;
+        };
+
+        AppLauncher resolve_launcher(const std::string& app_id) {
+            const auto target = bluetooth::ancs::launch_target(app_id);
+
+            if (!target.uri_scheme.empty()) {
+                if (GAppInfo* info = g_app_info_get_default_for_uri_scheme(target.uri_scheme.c_str())) {
+                    // Launch the handler itself rather than a bare "scheme://" the app
+                    // would have to make sense of.
+                    const char* id = g_app_info_get_id(info);
+                    const char* name = g_app_info_get_display_name(info);
+                    AppLauncher launcher{id ? id : target.uri_scheme + "://", name ? name : ""};
+                    g_object_unref(info);
+                    return launcher;
+                }
+                if (sandboxed())
+                    return {target.uri_scheme + "://", ""};
+            }
+
+            for (const auto& id : target.desktop_ids) {
+                const std::string entry = id + ".desktop";
+                if (GDesktopAppInfo* info = g_desktop_app_info_new(entry.c_str())) {
+                    const char* name = g_app_info_get_display_name(G_APP_INFO(info));
+                    AppLauncher launcher{entry, name ? name : ""};
+                    g_object_unref(info);
+                    return launcher;
+                }
+            }
+            return {};
+        }
+
+        void on_open_app_action(NotifyNotification*, char*, gpointer user_data) {
+            auto* action = static_cast<NotificationActionData*>(user_data);
+            if (!action)
+                return;
+
+            if (!action->payload.ends_with(".desktop")) {
+                launch_uri(action->payload);
+                return;
+            }
+
+            GDesktopAppInfo* info = g_desktop_app_info_new(action->payload.c_str());
+            if (!info) {
+                debug::log(ERR, "No desktop entry '{}' to open", action->payload);
+                return;
+            }
+            GError* error = nullptr;
+            if (!g_app_info_launch(G_APP_INFO(info), nullptr, nullptr, &error)) {
+                debug::log(ERR, "Failed to launch {}: {}", action->payload, error ? error->message : "unknown");
+                g_clear_error(&error);
+            }
+            g_object_unref(info);
+        }
+
         void on_notification_action(NotifyNotification*, char*, gpointer user_data) {
             auto* action = static_cast<NotificationActionData*>(user_data);
             if (!action) {
@@ -230,7 +297,9 @@ namespace tether {
             set_identity(notification, spec->app_name);
             notify_notification_set_urgency(notification, spec->quiet ? NOTIFY_URGENCY_LOW : NOTIFY_URGENCY_NORMAL);
 
-            const bool has_actions = !spec->reply_thread.empty() || !spec->otp_code.empty();
+            const AppLauncher launcher = spec->app_id.empty() ? AppLauncher{} : resolve_launcher(spec->app_id);
+            const bool has_actions =
+                !spec->reply_thread.empty() || !spec->otp_code.empty() || !launcher.payload.empty();
             if (has_actions)
                 g_signal_connect(notification, "closed", G_CALLBACK(on_notification_closed), nullptr);
 
@@ -255,6 +324,17 @@ namespace tether {
                                                _("Copy Code"),
                                                on_copy_code_action,
                                                new NotificationActionData{spec->otp_code},
+                                               free_action_data);
+            }
+
+            if (!launcher.payload.empty()) {
+                const std::string label =
+                    tr_format(_("Open in {}"), launcher.name.empty() ? spec->app_name : launcher.name);
+                notify_notification_add_action(notification,
+                                               "open-app",
+                                               label.c_str(),
+                                               on_open_app_action,
+                                               new NotificationActionData{launcher.payload},
                                                free_action_data);
             }
 

--- a/src/daemon/notification.hpp
+++ b/src/daemon/notification.hpp
@@ -20,6 +20,8 @@ namespace tether {
         std::string reply_thread;
         // OTP found in this notification, or empty. Non-empty adds a copy action.
         std::string otp_code;
+        // Originating iPhone bundle id.
+        std::string app_id;
     };
 
     class DesktopNotifier {

--- a/test/test_ancs_notifications.cpp
+++ b/test/test_ancs_notifications.cpp
@@ -52,6 +52,25 @@ TEST(AncsIcons, AlwaysEndsWithAnIconThatShipsWithTether) {
     }
 }
 
+TEST(AncsLaunchTarget, OffersAWayToReachTheLinuxApp) {
+    const auto whatsapp = launch_target("net.whatsapp.WhatsApp");
+    EXPECT_EQ(whatsapp.uri_scheme, "whatsapp");
+    EXPECT_FALSE(whatsapp.desktop_ids.empty());
+
+    const auto telegram = launch_target("ph.telegra.Telegraph");
+    EXPECT_EQ(telegram.uri_scheme, launch_target("org.telegram.messenger").uri_scheme)
+        << "both Telegram bundle ids reach the same client";
+
+    EXPECT_FALSE(launch_target("org.whispersystems.signal").empty());
+}
+
+TEST(AncsLaunchTarget, IsEmptyWithoutALinuxCounterpart) {
+    EXPECT_TRUE(launch_target("com.example.unheardof").empty());
+    EXPECT_TRUE(launch_target("").empty());
+    // Messages notifications reply through tether-gtk instead.
+    EXPECT_TRUE(launch_target(APP_ID_MESSAGES).empty());
+}
+
 TEST(AncsRegistry, RenameAppTouchesOnlyThatApp) {
     NotificationRegistry registry;
     registry.store(make(1, "com.burbn.instagram"));


### PR DESCRIPTION
If a notification's ios app/bundle ID match a known list of xdg-desktop entry IDs it will add a button to open the app on Linux.

Fixes: #126 

Credit @orychalk for the idea!