### PR TITLE
feat(telephony): add native pipewire HFP support via dbus

### DIFF
--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -269,8 +269,10 @@ PipeWire's `bluez5` plugin implements the same profile in the HF role and publis
 `org.pipewire.Telephony`, and it *can* carry the audio (`AudioGatewayTransport1.Activate()`,
 with `bluez5.telephony.default-reject-sco` to keep it on the phone until asked).
 
-It cannot be used at the same time. Both register for UUID `0000111e`, and which one
-gets the link depends on who opens it.
+The two cannot own the profile at the same time. Both register for UUID `0000111e`, and
+which one gets the link depends on who opens it. Tether reads both, so which one wins
+decides where the call audio plays, not whether call control works -- see "Either stack
+can serve the calls" below.
 
 A connect from this side routes into BlueZ's built-in profile and fails there:
 
@@ -311,6 +313,35 @@ requires for `org.bluez.Bearer.LE1`, already detects, and already prints the fix
 Users who want the audio on the desktop can still have it, at the cost of Tether's call
 control -- see below.
 
+### Either stack can serve the calls
+
+`TelephonyClient` holds a list of `TelephonySource`s and uses the first one serving the
+phone: BlueZ, then PipeWire. So the machine keeps call control whichever stack ends up
+with `0000111e`, and the four objections above stop applying to Tether:
+
+- No new dependency. PipeWire is reached over its D-Bus API on the session bus, and
+  `gio-2.0` was already linked. Nothing changes in the package or the build.
+- No new requirement. A machine with no PipeWire finds no bus name, the source reports
+  nothing, and calls read exactly as they did before -- unavailable, with the same
+  sentence. A working BlueZ setup never touches the session bus at all, because BlueZ is
+  consulted first and short-circuits.
+- CI is unaffected: the parser is a pure function over a recorded `GetManagedObjects`
+  payload, tested with no bus, like the BlueZ one beside it.
+
+What differs between the two sources is what they can report and carry:
+
+| | BlueZ | PipeWire |
+|---|---|---|
+| Call control | yes | yes |
+| Call audio | never | on this computer |
+| Carrier, signal, battery, roaming | yes | none of them |
+
+PipeWire's `AudioGateway1` carries no HFP indicators at all, so the payload marks them
+absent (`indicators: false`) rather than reporting their defaults, and both the CLI and
+the Calls page drop that line instead of claiming "No service" for a phone that has
+service. `--bt-call-audio on` calls `AudioGatewayTransport1.Activate()`; `off` sets
+`RejectSCO`, which gates the next voice link rather than tearing down one already up.
+
 ### Getting the call audio onto the desktop instead
 
 Possible, and it costs more than it first appears. Walked end to end on 2026-09-04, so
@@ -318,8 +349,10 @@ what follows is measured rather than reasoned.
 
 You give up two things:
 
-- **Tether's call control.** Handing the profile to PipeWire means BlueZ no longer owns
-  it, exports no `org.bluez.Telephony1`, and the Calls page goes empty.
+- **The HFP indicators.** Handing the profile to PipeWire means BlueZ no longer owns it
+  and exports no `org.bluez.Telephony1`. Call control itself survives -- Tether reads
+  PipeWire's API too -- but carrier, signal strength, battery and roaming have no
+  PipeWire equivalent and stop being reported.
 - **The phone's audio staying on the phone.** `a2dp_sink` turns out to be mandatory
   here, so music and system sounds move to the desktop as well. Everything
   "Keeping the phone's audio on the phone" below is written to avoid, you are opting
@@ -497,9 +530,9 @@ checks the daemon does not make.
 | Pairing bonds but the LE half never derives, on a machine with a USB dongle plugged in | Tether used the first powered controller, which is the dongle, not the built-in one | `tether --bt-status` marks the controller in use; `tether --bt-adapter <hciN>` picks another -- see 2026-09-01 |
 | The link reads down forever with `br-connection-unknown`, while messages, contacts and notifications all work | This computer offers the iPhone no BR/EDR profile to connect to, and BlueZ only reports a link up while some local profile is connected | Nothing. Tether no longer waits on that link -- see 2026-08-23 below. Call support does not change this: BlueZ's hands-free profile is not one of the local profiles BlueZ counts |
 | The iPhone's audio moves to the computer when Tether connects | The machine advertises itself as a Bluetooth speaker/headset, and iOS routes to it. Not caused by Tether beyond bringing the link up | See "Keeping the phone's audio on the phone" below |
-| `tether --bt-calls` reports call control off | PipeWire's default `bluez5.roles` includes `hfp_hf` and took the profile, the iPhone reconnected on its own and never opened hands-free, or `bluetoothd` is running without `--experimental` | Drop `hfp_hf` from `bluez5.roles` -- see "Calls". The daemon cycles the BR/EDR bearer once per outage for the second cause; confirm with `busctl --system tree org.bluez \| grep telephony` |
+| `tether --bt-calls` reports call control off | PipeWire took the profile *and* its telephony D-Bus service is off, the iPhone reconnected on its own and never opened hands-free, or `bluetoothd` is running without `--experimental` | Either give BlueZ the profile by dropping `hfp_hf` from `bluez5.roles`, or set `bluez5.telephony-dbus-service = true` and let Tether drive PipeWire's gateway -- see "Calls". The daemon cycles the BR/EDR bearer once per outage for the second cause; confirm with `busctl --system tree org.bluez \| grep telephony` and `busctl --user tree org.pipewire.Telephony` |
 | Calls work but the audio is on the iPhone | Working as designed. BlueZ signals the call and never opens the voice link, so there is nothing to route here | Nothing. `./scripts/bt-probe.sh --calls` during a call shows the evidence; "Getting the call audio onto the desktop instead" is the trade if you want it |
-| The Calls page is empty after configuring PipeWire for call audio | Expected. PipeWire owns the hands-free profile now, so BlueZ exports no `telephony0` for Tether to drive | Pick one: the revert steps under "Getting the call audio onto the desktop instead", or keep PipeWire and use an oFono-compatible dialer |
+| The Calls page is empty after configuring PipeWire for call audio | PipeWire's telephony D-Bus service is off, so neither stack exports anything Tether can read | Set `bluez5.telephony-dbus-service = true` and reconnect. With it on, Tether drives PipeWire's gateway directly and the Calls page works, minus carrier and signal |
 | Configured PipeWire for call audio and the machine is not in the iPhone's audio picker | `a2dp_sink` is missing from `bluez5.roles`. iOS only speaks hands-free to a machine it considers an audio destination | Add `a2dp_sink`, and accept that the phone's music comes here too -- see "Getting the call audio onto the desktop instead" |
 | `hfp_connect() unable to start connection` in the bluetoothd log | PipeWire's `hfp_hf` role and BlueZ's built-in profile are both claiming UUID `0000111e` | Remove `hfp_hf` from `bluez5.roles` -- see "Calls" and 2026-09-04 |
 

--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -183,6 +183,38 @@ Documented in `man org.bluez.Telephony` and `man org.bluez.Call`, with a
 snapshot with no new bus, thread or subscription. `TelephonyClient` holds no state at
 all: it reads the snapshot and issues method calls on the monitor's connection.
 
+### Hands-free after a phone-initiated reconnect
+
+BlueZ connects its hands-free profile only on a fresh BR/EDR connect. When the phone
+reconnects on its own -- after a Bluetooth toggle, or walking back into range -- it
+brings the other profiles up without hands-free, and nothing retries. Measured
+2026-09-06, with the phone reconnecting after a Bluetooth toggle:
+
+```
+bluetoothd: Device is already marked as connected
+bluetoothd: .../sep3/fd0: fd(41) ready
+```
+
+No `telephony0`, and all three re-connect paths are dead ends on a live ACL:
+`Device1.Connect()` returns success and does nothing, `ConnectProfile("0000111e")`
+fails `No more profiles to connect to` (BlueZ matches the remote's UUID list, and the
+iPhone advertises `0000111f`), `ConnectProfile("0000111f")` returns success and does
+nothing.
+
+Dropping the BR/EDR bearer alone is what recovers it, and it leaves LE and the ANCS
+subscription untouched:
+
+```bash
+busctl --system call org.bluez /org/bluez/hciN/dev_BDADDR org.bluez.Bearer.BREDR1 Disconnect
+```
+
+`BearerSupervisor` does this once per hands-free outage, `HFP_ABSENT_SECONDS` after
+BR/EDR comes up without a telephony object, and only while call control is enabled --
+the cycle costs the MAP and PBAP sessions riding on that bearer. The flag survives
+`reset()`, because the drop the cycle causes runs straight back through it, and clears
+only when a telephony object is seen, so a phone that never offers hands-free is asked
+exactly once per daemon.
+
 ### The audio stays on the phone
 
 Control only, by construction. Ringing, caller ID, answering, hanging up and dialling
@@ -203,9 +235,24 @@ say so:
   up: BlueZ exports no `/fd#` object and PipeWire creates no `bluez_card`.
   `./scripts/bt-probe.sh --calls` checks all of this in one command.
 
-So the consequence is that **no WirePlumber configuration is needed or wanted**. The
-`hfp_hf` role stays off, the machine never becomes an audio destination for the phone,
-and "Keeping the phone's audio on the phone" below continues to apply unchanged.
+So no WirePlumber configuration is needed for the audio to stay on the phone, and
+"Keeping the phone's audio on the phone" below continues to apply unchanged. One is
+needed for call control, though: stock `bluez5.roles` **includes** `hfp_hf`, a
+phone-initiated link then goes to PipeWire, and BlueZ exports no `org.bluez.Telephony1`
+at all -- `Calls (HFP): no`, Calls page empty, with nothing wrong on the phone.
+Measured 2026-09-06 on wireplumber 0.5.17. Dropping that one role is enough, and it
+does not require giving up the phone's music on the desktop:
+
+```
+monitor.bluez.properties = {
+ bluez5.roles = [ a2dp_sink a2dp_source bap_sink bap_source asha_sink hfp_ag ]
+}
+```
+
+That gave `telephony0`, a `Calls (HFP): yes` line carrying carrier, signal and battery,
+and the iPhone's music still arriving as A2DP AAC at 44100 Hz stereo. Dropping
+`a2dp_sink` too is what "Keeping the phone's audio on the phone" describes, and also
+leaves call control working.
 
 `org.bluez.Telephony1` is also where desktop call audio arrives on its own eventually.
 It is not an HFP-specific interface: `profiles/audio/telephony.c` is a shared layer
@@ -222,14 +269,24 @@ PipeWire's `bluez5` plugin implements the same profile in the HF role and publis
 `org.pipewire.Telephony`, and it *can* carry the audio (`AudioGatewayTransport1.Activate()`,
 with `bluez5.telephony.default-reject-sco` to keep it on the phone until asked).
 
-It cannot be used at the same time. Both register for UUID `0000111e`, and BlueZ's
-built-in profile wins: `Device1.Connect()` routes into it and fails, and PipeWire's
-profile never gets the link.
+It cannot be used at the same time. Both register for UUID `0000111e`, and which one
+gets the link depends on who opens it.
+
+A connect from this side routes into BlueZ's built-in profile and fails there:
 
 ```
 profiles/audio/hfp-hf.c:hfp_connect() unable to start connection
 btd_service_connect() hfp profile connect failed for <phone>: Input/output error
 ```
+
+**A connect the phone opens goes to PipeWire**, measured 2026-09-06 on bluez 5.87 with
+`bluetoothd --experimental` and the hfp plugin loaded -- no `--noplugin=hfp` anywhere.
+PipeWire's `/Profile/HFPHF` ran the service level connection, `spa.bluez5.native` logged
+`rfcomm_hfp_hf: AG indicator state: service = 1`, a live call arrived on
+`bluez_input.<addr>` as `api.bluez5.profile = "headset-audio-gateway"` at 24000 Hz mono,
+and BlueZ exported no telephony object at all. So the earlier claim that the built-in
+profile always wins holds only for the direction this side initiates, and an iPhone
+reconnecting on its own is the other direction.
 
 Dropping `hfp_hf` from `bluez5.roles` makes BlueZ's profile connect immediately and
 export `telephony0`. Using PipeWire's instead would mean `bluetoothd --noplugin=hfp`,
@@ -270,7 +327,12 @@ You give up two things:
 
 Tether has no code on this path and does not test it in CI.
 
-All three settings are required. Any one missing and nothing works at all.
+Step 3 is the one that matters. Steps 1 and 2 were both required in the 2026-09-04 walk
+and neither was on 2026-09-06 with pipewire 1.6.8 / wireplumber 0.5.17 / bluez 5.87:
+stock `bluez5.roles` already carries `hfp_hf` and `a2dp_sink`, so with no wireplumber
+configuration at all and the hfp plugin still loaded, a phone-initiated link put call
+audio on the desktop on its own. Treat steps 1 and 2 as what to reach for when the
+defaults do not do it, and check the versions before assuming they are needed.
 
 1. Stop BlueZ's built-in profile claiming UUID `0000111e`. Only needed on BlueZ >= 5.87;
    older builds have no built-in to disable.
@@ -435,7 +497,7 @@ checks the daemon does not make.
 | Pairing bonds but the LE half never derives, on a machine with a USB dongle plugged in | Tether used the first powered controller, which is the dongle, not the built-in one | `tether --bt-status` marks the controller in use; `tether --bt-adapter <hciN>` picks another -- see 2026-09-01 |
 | The link reads down forever with `br-connection-unknown`, while messages, contacts and notifications all work | This computer offers the iPhone no BR/EDR profile to connect to, and BlueZ only reports a link up while some local profile is connected | Nothing. Tether no longer waits on that link -- see 2026-08-23 below. Call support does not change this: BlueZ's hands-free profile is not one of the local profiles BlueZ counts |
 | The iPhone's audio moves to the computer when Tether connects | The machine advertises itself as a Bluetooth speaker/headset, and iOS routes to it. Not caused by Tether beyond bringing the link up | See "Keeping the phone's audio on the phone" below |
-| `tether --bt-calls` reports call control off | The iPhone has not connected Hands-Free, or `bluetoothd` is running without `--experimental` | The daemon's reason line names which. Confirm with `busctl --system tree org.bluez \| grep telephony` |
+| `tether --bt-calls` reports call control off | PipeWire's default `bluez5.roles` includes `hfp_hf` and took the profile, the iPhone reconnected on its own and never opened hands-free, or `bluetoothd` is running without `--experimental` | Drop `hfp_hf` from `bluez5.roles` -- see "Calls". The daemon cycles the BR/EDR bearer once per outage for the second cause; confirm with `busctl --system tree org.bluez \| grep telephony` |
 | Calls work but the audio is on the iPhone | Working as designed. BlueZ signals the call and never opens the voice link, so there is nothing to route here | Nothing. `./scripts/bt-probe.sh --calls` during a call shows the evidence; "Getting the call audio onto the desktop instead" is the trade if you want it |
 | The Calls page is empty after configuring PipeWire for call audio | Expected. PipeWire owns the hands-free profile now, so BlueZ exports no `telephony0` for Tether to drive | Pick one: the revert steps under "Getting the call audio onto the desktop instead", or keep PipeWire and use an oFono-compatible dialer |
 | Configured PipeWire for call audio and the machine is not in the iPhone's audio picker | `a2dp_sink` is missing from `bluez5.roles`. iOS only speaks hands-free to a machine it considers an audio destination | Add `a2dp_sink`, and accept that the phone's music comes here too -- see "Getting the call audio onto the desktop instead" |
@@ -444,7 +506,9 @@ checks the daemon does not make.
 ### Keeping the phone's audio on the phone
 
 Unaffected by call support: calls run over BlueZ's own profile and never make this
-machine an audio destination. This still applies exactly as written.
+machine an audio destination. This still applies exactly as written -- and the role
+list below is also what hands BlueZ the hands-free profile in the first place, since
+dropping `hfp_hf` is what keeps PipeWire from taking it.
 
 Once the Classic link is up, the iPhone's calls, music, and system sounds play on the
 computer instead of the phone. PipeWire registers A2DP sink and HFP audio-gateway
@@ -2196,3 +2260,53 @@ so the AppImage now prints three short lines instead of a 24-line paste. Flatpak
 here-document, because `flatpak run` under `sudo` is the wrong user. The test on
 `set_class_command()` now asserts the unit text ends in a newline and that the here-document
 carries a bare `EOF` line to close it.
+
+### 2026-09-06 - Hands-free was never reconnected after the phone brought the link back
+
+Reported as "the iPhone has not connected Hands-Free", on a machine where it had been
+connected minutes earlier. Three separate things, measured on bluez 5.87,
+pipewire 1.6.8, wireplumber 0.5.17, `bluetoothd --experimental` with the hfp plugin
+loaded.
+
+**Stock WirePlumber takes the profile.** Default `bluez5.roles` already contains
+`hfp_hf` and `a2dp_sink`, so no configuration is needed for PipeWire to claim
+`0000111e`. With no file in `wireplumber.conf.d` at all, a phone-initiated link went to
+`/Profile/HFPHF` -- `spa.bluez5.native` logging `rfcomm_hfp_hf: AG indicator state:
+service = 1` -- and a live call played on the desktop as
+`api.bluez5.profile = "headset-audio-gateway"`, 24000 Hz mono, with the laptop
+microphone linked back to the phone. BlueZ exported no telephony object, so
+`Calls (HFP)` read `no` with nothing wrong on the phone. The 2026-09-04 entry's summary
+that the built-in profile "wins" describes the outbound direction only; the direction an
+iPhone actually uses is the other one. `--noplugin=hfp` was never applied here and was
+not needed, which also retires "all three settings are required" from the PipeWire
+walkthrough.
+
+**Dropping one role is enough, and it need not cost the music.**
+`bluez5.roles = [ a2dp_sink a2dp_source bap_sink bap_source asha_sink hfp_ag ]`
+gave `telephony0` and `Calls (HFP): yes` with carrier, signal and battery, while the
+phone's music still arrived over A2DP AAC at 44100 Hz stereo. Keeping `a2dp_sink` is
+what lets the phone stay an audio destination; only `hfp_hf` has to go.
+
+**BlueZ connects hands-free once, on a fresh BR/EDR connect.** After a Bluetooth toggle
+on the phone, the phone reconnected on its own and brought everything except
+hands-free:
+
+```
+bluetoothd: Device is already marked as connected
+bluetoothd: .../sep3/fd0: fd(41) ready
+```
+
+Nothing retries it, and on a live ACL there is nothing to retry with:
+`Device1.Connect()` returns success and does nothing, `ConnectProfile("0000111e")` fails
+`No more profiles to connect to` because BlueZ matches the remote's UUID list and the
+iPhone advertises `0000111f`, and `ConnectProfile("0000111f")` returns success and does
+nothing. `org.bluez.Bearer.BREDR1 Disconnect` recovers it: the reconnect that follows is
+a fresh profile connect and carries hands-free, while LE and its ANCS subscription stay
+up throughout.
+
+`BearerSupervisor` now does that itself, `HFP_ABSENT_SECONDS` after BR/EDR comes up with
+no telephony object and only while call control is on, because the cycle costs the MAP
+and PBAP sessions on that bearer. It is one cycle per outage: the drop it causes runs
+back through `reset()`, so the spent flag survives `reset()` and clears only when a
+telephony object is actually seen. A phone that never offers hands-free -- the PipeWire
+case above -- is therefore asked exactly once and then left alone.

--- a/docs/man/man1/tether.1.in
+++ b/docs/man/man1/tether.1.in
@@ -143,10 +143,16 @@ Answer the ringing call.
 End every call.
 .TP
 \fB\-\-bt-calls-enable\fR \fIon\fR|\fIoff\fR
-Turn call control on or off. Off by default. Calls run over BlueZ's own hands-free
-profile, which needs \fBbluetoothd --experimental\fR -- the same flag notification
-mirroring requires. Control only: the call audio stays on the iPhone. See
-\fIdocs/BLUETOOTH.md\fR.
+Turn call control on or off. Off by default. Calls run over whichever stack holds the
+hands-free profile: BlueZ's own, which needs \fBbluetoothd --experimental\fR -- the same
+flag notification mirroring requires -- and carries no audio, or PipeWire's, which carries
+the call audio as well. Neither is installed by Tether and call control is unavailable,
+not broken, when there is no stack holding the profile. See \fIdocs/BLUETOOTH.md\fR.
+.TP
+\fB\-\-bt-call-audio\fR \fIon\fR|\fIoff\fR
+Play call audio on this computer, or leave it on the iPhone. Only PipeWire carries the
+voice link, so this reports a refusal when BlueZ holds the profile. \fIoff\fR gates the
+next voice link rather than moving a call already in progress.
 .TP
 \fB\-\-bt-adapter\fR \fIhciN\fR|\fIauto\fR
 Choose which Bluetooth controller to use, by \fIhciN\fR or by address. Defaults to

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -178,6 +178,12 @@ msgid ""
 msgstr ""
 "Zapnout nebo vypnout ovládání hovorů. Hovory jdou přes Bluetooth hands-free; "
 "zvuk zůstává v iPhonu."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1142,7 +1148,12 @@ msgstr "iPhone nepřipojil hands-free k tomuto počítači."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Připojování ke službě hands-free iPhonu."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Hovory se ovládají zde; zvuk se přehrává v iPhonu."
 
@@ -1157,6 +1168,11 @@ msgstr "Nebyl uveden žádný hovor."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Tento hovor už není aktivní."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Hovory se ovládají zde; zvuk se přehrává v iPhonu."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1282,6 +1298,11 @@ msgstr "Neznámý volající"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Přijmout"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Přesunout zvuk sem"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2050,9 +2071,6 @@ msgstr "Spárujte zařízení a synchronizujte schránku po síti"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Zvuk hovoru přesunut do tohoto počítače."
-
-#~ msgid "Take audio here"
-#~ msgstr "Přesunout zvuk sem"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -180,6 +180,12 @@ msgid ""
 msgstr ""
 "Anrufsteuerung ein- oder ausschalten. Anrufe laufen über Bluetooth Hands-"
 "Free; der Ton bleibt auf dem iPhone."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1166,7 +1172,12 @@ msgstr "Das iPhone hat Hands-Free nicht mit diesem Computer verbunden."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Verbindung zum Hands-Free-Dienst des iPhones wird aufgebaut."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr ""
 "Anrufe werden hier gesteuert; der Ton wird auf dem iPhone wiedergegeben."
@@ -1182,6 +1193,12 @@ msgstr "Kein Anruf angegeben."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Dieser Anruf ist nicht mehr aktiv."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr ""
+"Anrufe werden hier gesteuert; der Ton wird auf dem iPhone wiedergegeben."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1308,6 +1325,11 @@ msgstr "Unbekannter Anrufer"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Annehmen"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Audio hierher holen"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2096,9 +2118,6 @@ msgstr ""
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Anrufaudio auf diesen Computer verlegt."
-
-#~ msgid "Take audio here"
-#~ msgstr "Audio hierher holen"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -180,6 +180,12 @@ msgid ""
 msgstr ""
 "Activar o desactivar el control de llamadas. Las llamadas usan el manos "
 "libres Bluetooth; el audio se queda en el iPhone."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1157,7 +1163,12 @@ msgstr "El iPhone no ha conectado el manos libres a este equipo."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Conectando con el servicio manos libres del iPhone."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Las llamadas se controlan aquí; el audio se reproduce en el iPhone."
 
@@ -1172,6 +1183,11 @@ msgstr "No se indicó ninguna llamada."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Esa llamada ya no está activa."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Las llamadas se controlan aquí; el audio se reproduce en el iPhone."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1299,6 +1315,11 @@ msgstr "Llamante desconocido"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Responder"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Traer el audio aquí"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2080,9 +2101,6 @@ msgstr "Empareje dispositivos y sincronice el portapapeles a través de la red"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Audio de la llamada pasado a este equipo."
-
-#~ msgid "Take audio here"
-#~ msgstr "Traer el audio aquí"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -183,6 +183,12 @@ msgid ""
 msgstr ""
 "Activer ou désactiver la gestion des appels. Les appels passent par le mode "
 "mains libres Bluetooth ; l'audio reste sur l'iPhone."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1164,7 +1170,12 @@ msgstr "L'iPhone n'a pas connecté le mode mains libres à cet ordinateur."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Connexion au service mains libres de l'iPhone."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Les appels se pilotent ici ; l'audio est diffusé sur l'iPhone."
 
@@ -1179,6 +1190,11 @@ msgstr "Aucun appel indiqué."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Cet appel n'est plus actif."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Les appels se pilotent ici ; l'audio est diffusé sur l'iPhone."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1306,6 +1322,11 @@ msgstr "Appelant inconnu"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Répondre"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Prendre l'audio ici"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2091,9 +2112,6 @@ msgstr "Appairez des appareils et synchronisez le presse-papiers sur le réseau"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Audio de l'appel transféré vers cet ordinateur."
-
-#~ msgid "Take audio here"
-#~ msgstr "Prendre l'audio ici"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -181,6 +181,12 @@ msgid ""
 msgstr ""
 "Attivare o disattivare il controllo delle chiamate. Le chiamate usano il "
 "vivavoce Bluetooth; l'audio resta sull'iPhone."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1157,7 +1163,12 @@ msgstr "L'iPhone non ha collegato il vivavoce a questo computer."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Connessione al servizio vivavoce dell'iPhone."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Le chiamate si controllano qui; l'audio viene riprodotto sull'iPhone."
 
@@ -1172,6 +1183,11 @@ msgstr "Nessuna chiamata indicata."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Quella chiamata non è più attiva."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Le chiamate si controllano qui; l'audio viene riprodotto sull'iPhone."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1297,6 +1313,11 @@ msgstr "Chiamante sconosciuto"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Rispondi"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Porta l'audio qui"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2083,9 +2104,6 @@ msgstr "Accoppia dispositivi e sincronizza gli appunti sulla rete"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Audio della chiamata spostato su questo computer."
-
-#~ msgid "Take audio here"
-#~ msgstr "Porta l'audio qui"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -179,6 +179,12 @@ msgid ""
 msgstr ""
 "通話操作をオンまたはオフにします。通話は Bluetooth ハンズフリー経由で、音声"
 "は iPhone に残ります。"
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1131,7 +1137,12 @@ msgstr "iPhone がこのコンピューターにハンズフリーを接続し�
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "iPhone のハンズフリーサービスに接続しています。"
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "通話はここで操作し、音声は iPhone で再生されます。"
 
@@ -1146,6 +1157,11 @@ msgstr "通話が指定されていません。"
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "その通話はもう有効ではありません。"
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "通話はここで操作し、音声は iPhone で再生されます。"
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1272,6 +1288,11 @@ msgstr "不明な発信者"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "応答"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "音声をここに移す"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2043,9 +2064,6 @@ msgstr "デバイスをペアリングし、ネットワーク越しにクリッ
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "通話音声をこのコンピューターに移しました。"
-
-#~ msgid "Take audio here"
-#~ msgstr "音声をここに移す"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -178,6 +178,12 @@ msgid ""
 msgstr ""
 "통화 제어를 켜거나 끕니다. 통화는 Bluetooth 핸즈프리를 사용하며 오디오는 "
 "iPhone에 남습니다."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1119,7 +1125,12 @@ msgstr "iPhone이 이 컴퓨터에 핸즈프리를 연결하지 않았습니다.
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "iPhone의 핸즈프리 서비스에 연결하는 중입니다."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "통화는 여기서 제어하고 오디오는 iPhone에서 재생됩니다."
 
@@ -1134,6 +1145,11 @@ msgstr "통화를 지정하지 않았습니다."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "그 통화는 더 이상 활성 상태가 아닙니다."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "통화는 여기서 제어하고 오디오는 iPhone에서 재생됩니다."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1259,6 +1275,11 @@ msgstr "알 수 없는 발신자"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "받기"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "오디오 가져오기"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2017,9 +2038,6 @@ msgstr "기기를 페어링하고 네트워크를 통해 클립보드를 동기�
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "통화 오디오를 이 컴퓨터로 옮겼습니다."
-
-#~ msgid "Take audio here"
-#~ msgstr "오디오 가져오기"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -180,6 +180,12 @@ msgid ""
 msgstr ""
 "Oproepbediening in- of uitschakelen. Oproepen lopen via Bluetooth-handsfree; "
 "het geluid blijft op de iPhone."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1151,7 +1157,12 @@ msgstr "De iPhone heeft handsfree niet met deze computer verbonden."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Verbinden met de handsfree-dienst van de iPhone."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Oproepen worden hier bediend; het geluid speelt op de iPhone."
 
@@ -1166,6 +1177,11 @@ msgstr "Geen oproep opgegeven."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Die oproep is niet meer actief."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Oproepen worden hier bediend; het geluid speelt op de iPhone."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1292,6 +1308,11 @@ msgstr "Onbekende beller"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Beantwoorden"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Audio hierheen halen"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2069,9 +2090,6 @@ msgstr "Apparaten koppelen en het klembord over het netwerk synchroniseren"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Oproepaudio naar deze computer verplaatst."
-
-#~ msgid "Take audio here"
-#~ msgstr "Audio hierheen halen"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -180,6 +180,12 @@ msgid ""
 msgstr ""
 "Włącz lub wyłącz sterowanie połączeniami. Połączenia idą przez zestaw "
 "głośnomówiący Bluetooth; dźwięk zostaje na iPhonie."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1152,7 +1158,12 @@ msgstr "iPhone nie połączył zestawu głośnomówiącego z tym komputerem."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Łączenie z usługą zestawu głośnomówiącego iPhone’a."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Połączeniami sterujesz tutaj; dźwięk odtwarzany jest na iPhonie."
 
@@ -1167,6 +1178,11 @@ msgstr "Nie wskazano połączenia."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "To połączenie nie jest już aktywne."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Połączeniami sterujesz tutaj; dźwięk odtwarzany jest na iPhonie."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1293,6 +1309,11 @@ msgstr "Nieznany numer"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Odbierz"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Przenieś dźwięk tutaj"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2070,9 +2091,6 @@ msgstr "Sparuj urządzenia i synchronizuj schowek przez sieć"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Dźwięk połączenia przeniesiony na ten komputer."
-
-#~ msgid "Take audio here"
-#~ msgstr "Przenieś dźwięk tutaj"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -180,6 +180,12 @@ msgid ""
 msgstr ""
 "Ativar ou desativar o controle de chamadas. As chamadas usam o viva-voz "
 "Bluetooth; o áudio fica no iPhone."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1152,7 +1158,12 @@ msgstr "O iPhone não conectou o viva-voz a este computador."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Conectando ao serviço viva-voz do iPhone."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "As chamadas são controladas aqui; o áudio toca no iPhone."
 
@@ -1167,6 +1178,11 @@ msgstr "Nenhuma chamada indicada."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Essa chamada não está mais ativa."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "As chamadas são controladas aqui; o áudio toca no iPhone."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1293,6 +1309,11 @@ msgstr "Chamador desconhecido"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Atender"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Trazer o áudio para cá"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2069,9 +2090,6 @@ msgstr "Pareie dispositivos e sincronize a área de transferência pela rede"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Áudio da chamada movido para este computador."
-
-#~ msgid "Take audio here"
-#~ msgstr "Trazer o áudio para cá"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -180,6 +180,12 @@ msgid ""
 msgstr ""
 "Включить или выключить управление вызовами. Вызовы идут через Bluetooth "
 "Hands-Free; звук остаётся на iPhone."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1151,7 +1157,12 @@ msgstr "iPhone не подключил Hands-Free к этому компьюте
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Подключение к службе Hands-Free на iPhone."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Вызовами управляют отсюда; звук воспроизводится на iPhone."
 
@@ -1166,6 +1177,11 @@ msgstr "Вызов не указан."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Этот вызов уже не активен."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Вызовами управляют отсюда; звук воспроизводится на iPhone."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1292,6 +1308,11 @@ msgstr "Неизвестный абонент"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Ответить"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Перевести звук сюда"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2071,9 +2092,6 @@ msgstr "Создавайте пары устройств и синхронизи
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Звук вызова переведён на этот компьютер."
-
-#~ msgid "Take audio here"
-#~ msgstr "Перевести звук сюда"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -180,6 +180,12 @@ msgid ""
 msgstr ""
 "Slå på eller av samtalsstyrning. Samtal går via Bluetooth-handsfree; ljudet "
 "stannar på iPhone."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1139,7 +1145,12 @@ msgstr "iPhone har inte anslutit handsfree till den här datorn."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Ansluter till iPhones handsfree-tjänst."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Samtal styrs härifrån; ljudet spelas upp på iPhone."
 
@@ -1154,6 +1165,11 @@ msgstr "Inget samtal angivet."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Det samtalet är inte längre aktivt."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Samtal styrs härifrån; ljudet spelas upp på iPhone."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1279,6 +1295,11 @@ msgstr "Okänd uppringare"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Svara"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Ta ljudet hit"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2050,9 +2071,6 @@ msgstr "Parkoppla enheter och synkronisera urklipp över nätverket"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Samtalsljudet flyttat till den här datorn."
-
-#~ msgid "Take audio here"
-#~ msgstr "Ta ljudet hit"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: tether 0.2.25\n"
+"Project-Id-Version: tether 0.2.26\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -168,6 +168,12 @@ msgstr ""
 msgid ""
 "Turn call control on or off. Calls run over Bluetooth Hands-Free; the audio "
 "stays on the iPhone."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -1025,7 +1031,12 @@ msgstr ""
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr ""
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr ""
 
@@ -1039,6 +1050,10 @@ msgstr ""
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
 msgstr ""
 
 #: src/core/src/bluetooth/telephony.cpp
@@ -1158,6 +1173,10 @@ msgstr ""
 
 #: src/gtk/calls_view.cpp
 msgid "Answer"
+msgstr ""
+
+#: src/gtk/calls_view.cpp
+msgid "Audio here"
 msgstr ""
 
 #: src/gtk/calls_view.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -179,6 +179,12 @@ msgid ""
 msgstr ""
 "Çağrı denetimini aç veya kapat. Çağrılar Bluetooth eller serbest üzerinden "
 "gider; ses iPhone’da kalır."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1138,7 +1144,12 @@ msgstr "iPhone eller serbest bağlantısını bu bilgisayara kurmadı."
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "iPhone’un eller serbest hizmetine bağlanılıyor."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Çağrılar buradan yönetilir; ses iPhone’da çalar."
 
@@ -1153,6 +1164,11 @@ msgstr "Çağrı belirtilmedi."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Bu çağrı artık etkin değil."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Çağrılar buradan yönetilir; ses iPhone’da çalar."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1278,6 +1294,11 @@ msgstr "Bilinmeyen arayan"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Yanıtla"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Sesi buraya al"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2047,9 +2068,6 @@ msgstr "Aygıtları eşleştirin ve panoyu ağ üzerinden eşzamanlayın"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Çağrı sesi bu bilgisayara taşındı."
-
-#~ msgid "Take audio here"
-#~ msgstr "Sesi buraya al"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -181,6 +181,12 @@ msgid ""
 msgstr ""
 "Увімкнути або вимкнути керування викликами. Виклики йдуть через Bluetooth "
 "Hands-Free; звук залишається на iPhone."
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1150,7 +1156,12 @@ msgstr "iPhone не підключив Hands-Free до цього комп’ю�
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "Підключення до служби Hands-Free на iPhone."
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "Викликами керують звідси; звук відтворюється на iPhone."
 
@@ -1165,6 +1176,11 @@ msgstr "Виклик не вказано."
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "Цей виклик уже не активний."
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "Викликами керують звідси; звук відтворюється на iPhone."
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1291,6 +1307,11 @@ msgstr "Невідомий абонент"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "Відповісти"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "Перевести звук сюди"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -2069,9 +2090,6 @@ msgstr "Створюйте пари пристроїв і синхронізуй
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "Звук виклику переведено на цей комп’ютер."
-
-#~ msgid "Take audio here"
-#~ msgstr "Перевести звук сюди"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-05 13:35-0700\n"
+"POT-Creation-Date: 2026-09-06 13:50-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -173,6 +173,12 @@ msgid ""
 "Turn call control on or off. Calls run over Bluetooth Hands-Free; the audio "
 "stays on the iPhone."
 msgstr "开启或关闭通话控制。通话通过蓝牙免提进行，音频保留在 iPhone 上。"
+
+#: src/cli/main.cpp
+msgid ""
+"Play call audio on this computer, or leave it on the iPhone. Needs PipeWire "
+"to be the stack holding Hands-Free; off applies from the next call."
+msgstr ""
 
 #: src/cli/main.cpp
 msgid "Print a redacted Bluetooth report for a bug report."
@@ -1090,7 +1096,12 @@ msgstr "iPhone 尚未与本机建立免提连接。"
 msgid "Connecting to the iPhone's Hands-Free service."
 msgstr "正在连接 iPhone 的免提服务。"
 
-#: src/core/src/bluetooth/telephony.cpp src/gtk/calls_view.cpp
+#: src/core/src/bluetooth/telephony.cpp
+msgid ""
+"PipeWire is handling Hands-Free, so the call audio can play on this computer."
+msgstr ""
+
+#: src/core/src/bluetooth/telephony.cpp
 msgid "Calls are controlled here; the audio plays on the iPhone."
 msgstr "通话在此控制，音频在 iPhone 上播放。"
 
@@ -1105,6 +1116,11 @@ msgstr "未指定通话。"
 #: src/core/src/bluetooth/telephony.cpp
 msgid "That call is no longer active."
 msgstr "该通话已不再有效。"
+
+#: src/core/src/bluetooth/telephony.cpp
+#, fuzzy
+msgid "This computer is not carrying the call audio; it plays on the iPhone."
+msgstr "通话在此控制，音频在 iPhone 上播放。"
 
 #: src/core/src/bluetooth/telephony.cpp
 msgid "Unknown call action."
@@ -1229,6 +1245,11 @@ msgstr "未知来电者"
 #: src/gtk/calls_view.cpp
 msgid "Answer"
 msgstr "接听"
+
+#: src/gtk/calls_view.cpp
+#, fuzzy
+msgid "Audio here"
+msgstr "将音频转到本机"
 
 #: src/gtk/calls_view.cpp
 msgid "Decline"
@@ -1972,9 +1993,6 @@ msgstr "配对设备并通过网络同步剪贴板"
 
 #~ msgid "Call audio moved to this computer."
 #~ msgstr "通话音频已转到本机。"
-
-#~ msgid "Take audio here"
-#~ msgstr "将音频转到本机"
 
 #~ msgid ""
 #~ "Play the call through this computer's speakers and microphone. Handing it "

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -216,6 +216,9 @@ static const Opt kOptions[] = {
     {"--bt-hangup", N_("Hang up every call.")},
     {"--bt-calls-enable <on|off>",
      N_("Turn call control on or off. Calls run over Bluetooth Hands-Free; the audio stays on the iPhone.")},
+    {"--bt-call-audio <on|off>",
+     N_("Play call audio on this computer, or leave it on the iPhone. Needs PipeWire to be the stack holding "
+        "Hands-Free; off applies from the next call.")},
     {"--bt-diagnostics", N_("Print a redacted Bluetooth report for a bug report.")},
     {"--install-extension-host",
      N_("Install the browser and mail extension's native messaging manifests for this user. Needed only for "
@@ -594,7 +597,8 @@ static int print_bt_connection(tether::Client& client) {
     // Null while call control is off, which is the common case.
     const nlohmann::json calls = resp.value("calls", nlohmann::json());
     std::string call_state = yn(calls.is_object() && calls.value("available", false));
-    if (calls.is_object() && calls.value("available", false)) {
+    // PipeWire's gateway reports no cellular indicators :(
+    if (calls.is_object() && calls.value("available", false) && calls.value("indicators", true)) {
         // Carrier and signal come from the phone over HFP.
         const std::string carrier = calls.value("operator", "");
         call_state += "  [" + (carrier.empty() ? std::string(_("no carrier")) : carrier) +
@@ -988,6 +992,10 @@ int main(int argc, char* argv[]) {
         } else if (arg == "--bt-hangup") {
             action = "bt_call_action";
             arg_val = "hangup_all";
+        } else if (arg == "--bt-call-audio") {
+            action = "bt_call_action";
+            const std::string value = i + 1 < argc ? argv[++i] : "";
+            arg_val = value == "off" ? "audio_phone" : "audio_here";
         } else if (arg == "--bt-call") {
             action = "bt_call";
             if (i + 1 < argc && argv[i + 1][0] != '-')

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(tether STATIC
     src/bluetooth/ancs/client.cpp
     src/bluetooth/groups.cpp
     src/bluetooth/telephony.cpp
+    src/bluetooth/telephony_pipewire.cpp
     src/bluetooth/connection.cpp
     src/bluetooth/diagnostics.cpp
     src/wayland.cpp

--- a/src/core/include/tether/bluetooth/bearer_supervisor.hpp
+++ b/src/core/include/tether/bluetooth/bearer_supervisor.hpp
@@ -27,6 +27,10 @@ namespace tether::bluetooth {
     // so a blip must not reset discovery, while a genuine loss still clears.
     inline constexpr int ANCS_BEARER_GRACE_SECONDS = 30;
 
+    // How long BR/EDR may be up with no hands-free profile before the bearer is
+    // cycled once to make BlueZ connect it.
+    inline constexpr int HFP_ABSENT_SECONDS = 20;
+
     // How long an LE link may read connected while the phone offers no ANCS
     // service before the solicitation goes back on air over it. Long enough for
     // GATT discovery on a freshly opened link, which runs to about a minute.
@@ -59,6 +63,11 @@ namespace tether::bluetooth {
         virtual bool le_connect_outstanding() const = 0;
         // Whether the ANCS solicitation is registered AND BlueZ is advertising.
         virtual bool solicitation_on_air() const = 0;
+
+        // Whether BlueZ exports a telephony object for the device.
+        virtual bool telephony_present() const = 0;
+        // Drops the BR/EDR bearer on its own, leaving LE up. Never Device1.Disconnect().
+        virtual bool disconnect_classic(std::string& err) = 0;
     };
 
     struct BearerStatus {
@@ -105,15 +114,19 @@ namespace tether::bluetooth {
         void reset();
 
         void set_ancs_enabled(bool enabled);
+        void set_calls_enabled(bool enabled);
         const BearerStatus& status() const { return status_; }
 
     private:
         BearerOps& ops_;
         bool ancs_enabled_ = true;
+        bool calls_enabled_ = false;
 
         BearerStatus status_;
         int classic_failures_ = 0;
         bool le_dial_spent_ = false;
+        bool hfp_cycle_spent_ = false;
+        int64_t telephony_absent_since_ = -1;
         int64_t classic_connected_since_ = -1;
         int64_t le_down_since_ = -1;
         // Whether the solicitation has been observed on air since LE went down.

--- a/src/core/include/tether/bluetooth/config.hpp
+++ b/src/core/include/tether/bluetooth/config.hpp
@@ -30,8 +30,8 @@ namespace tether::bluetooth {
         bool ancs_content_enabled = true;
         // Group replies are off until deliberately enabled
         bool group_messages_enabled = false;
-        // Call control over HFP. Needs the hfp_hf role in bluez5.roles and
-        // PipeWire's telephony D-Bus service, neither of which Tether installs.
+        // Call control over HFP, through whichever stack owns the profile:
+        // BlueZ's own hfp, or PipeWire's, which also works with call audio.
         bool calls_enabled = false;
         // When off, supervision runs against no device, so the daemon stops re-dialling
         bool enabled = true;

--- a/src/core/include/tether/bluetooth/telephony.hpp
+++ b/src/core/include/tether/bluetooth/telephony.hpp
@@ -2,12 +2,17 @@
 
 #include "tether/bluetooth/objects.hpp"
 
+#include <gio/gio.h>
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <utility>
 #include <vector>
 
 // Call control over Bluetooth Hands-Free, in the HF role: this machine is the
-// car kit and the iPhone is the audio gateway.
+// car kit and the iPhone is the audio gateway. Two stacks can own that profile.
+// BlueZ's own hands-free profile and PipeWire's, so the phone is reached
+// through whichever one has it, and only the bus addressing differs.
 namespace tether::bluetooth {
 
     class BluezMonitor;
@@ -19,16 +24,55 @@ namespace tether::bluetooth {
     nlohmann::json to_json(const std::vector<Call>& calls);
     nlohmann::json to_json(const Telephony& gateway);
 
-    // iPhone's audio gateway.
+    struct TelephonyIds {
+        // as in the status payload.
+        const char* name;
+        const char* bus;
+        const char* gateway_iface;
+        // null if stack has no call audio
+        const char* transport_iface;
+        const char* call_iface;
+        bool dial_uri;
+        bool indicators;
+    };
+
+    // What a stack's Dial() takes, built from an already normalized number.
+    // BlueZ wants a URI, PipeWire formats the bare number into ATD itself, so
+    // handing it a URI would put "ATDtel:+15555550123;" on the RFCOMM link.
+    std::string dial_argument(const TelephonyIds& ids, const std::string& number);
+
+    struct TelephonySnapshot {
+        Telephony gateway;
+        std::vector<Call> calls;
+        std::string audio_state;
+    };
+
+    // A stack that can serve the configured phone's calls.
+    class TelephonySource {
+    public:
+        virtual ~TelephonySource() = default;
+
+        virtual TelephonyIds ids() const = 0;
+        // Null while the stack is unreachable.
+        virtual GDBusConnection* connection() const = 0;
+        // An empty gateway path means this stack is not serving the address.
+        virtual TelephonySnapshot snapshot() const = 0;
+    };
+
+    // The iPhone's audio gateway. Sources are consulted in order and the first with a gateway wins.
     class TelephonyClient {
     public:
-        TelephonyClient(BluezMonitor& monitor, std::string address);
+        TelephonyClient(std::vector<std::unique_ptr<TelephonySource>> sources, std::string address);
 
         TelephonyClient(const TelephonyClient&) = delete;
         TelephonyClient& operator=(const TelephonyClient&) = delete;
 
         // Whether the phone has HFP connected and the gateway is usable.
         bool available() const;
+
+        // Whether any stack is serving the phone, including one still bringing
+        // the service level connection up. Presence, not readiness.
+        bool present() const;
 
         nlohmann::json status() const;
         nlohmann::json calls() const;
@@ -37,19 +81,41 @@ namespace tether::bluetooth {
         bool dial(const std::string& number, std::string& err);
 
         // action: answer, hangup, hangup_all, swap, hold_and_answer,
-        // release_and_answer, release_and_swap, multiparty.
-        // `path` is the call for answer and hangup, and is ignored otherwise.
+        // release_and_answer, release_and_swap, multiparty, audio_here,
+        // audio_phone. `path` is the call for answer and hangup, and is ignored
+        // otherwise.
         bool call_action(const std::string& path, const std::string& action, std::string& err);
 
         bool send_tones(const std::string& tones, std::string& err);
 
     private:
-        // The gateway for the configured address, or an empty Telephony.
-        Telephony gateway() const;
-        bool invoke(const std::string& path, const char* iface, const char* method, GVariant* args, std::string& err);
+        // The serving source and its snapshot or null for none.
+        std::pair<TelephonySource*, TelephonySnapshot> pick() const;
 
-        BluezMonitor* monitor_;
+        bool invoke(TelephonySource& source,
+                    const std::string& path,
+                    const char* iface,
+                    const char* method,
+                    GVariant* args,
+                    std::string& err);
+
+        std::vector<std::unique_ptr<TelephonySource>> sources_;
         std::string address_;
     };
+
+    // bluez's hfp on the system bus. No call audio.
+    std::unique_ptr<TelephonySource> make_bluez_source(BluezMonitor& monitor, std::string address);
+
+    // pipewire's, on the session bus. Carries the call audio as well.
+    std::unique_ptr<TelephonySource> make_pipewire_source(std::string address);
+
+    // Every source this machine could have, in preference order.
+    std::unique_ptr<TelephonyClient> make_telephony_client(BluezMonitor& monitor, std::string address);
+
+    // Decodes a GetManagedObjects payload from org.pipewire.Telephony into the
+    // gateway matching `address`.
+    TelephonySnapshot parse_pipewire_telephony(GVariant* objects, const std::string& address);
+
+    std::vector<Call> parse_pipewire_calls(GVariant* objects, const std::string& gateway_path);
 
 } // namespace tether::bluetooth

--- a/src/core/include/tether/crypto.hpp
+++ b/src/core/include/tether/crypto.hpp
@@ -27,6 +27,8 @@ namespace tether {
         static std::string get_peer_fingerprint(SSL* ssl);
         static std::string generate_fingerprint(X509* cert);
 
+        void reset_for_tests();
+
     private:
         Crypto() = default;
         ~Crypto();

--- a/src/core/src/bluetooth/bearer_supervisor.cpp
+++ b/src/core/src/bluetooth/bearer_supervisor.cpp
@@ -78,8 +78,12 @@ namespace tether::bluetooth {
 
     void BearerSupervisor::set_ancs_enabled(bool enabled) { ancs_enabled_ = enabled; }
 
+    void BearerSupervisor::set_calls_enabled(bool enabled) { calls_enabled_ = enabled; }
+
     void BearerSupervisor::reset() {
+        // hfp_cycle_spent_ deliberately survives
         classic_failures_ = 0;
+        telephony_absent_since_ = -1;
         le_down_since_ = -1;
         solicited_since_le_down_ = false;
         classic_connected_since_ = -1;
@@ -186,7 +190,22 @@ namespace tether::bluetooth {
             return !(status_ == previous);
         }
 
-        // Classic is up. LE is only worth attempting once the ACL has settled.
+        // Classic is up.
+        if (calls_enabled_ && !ops_.telephony_present()) {
+            if (telephony_absent_since_ < 0)
+                telephony_absent_since_ = now;
+            if (!hfp_cycle_spent_ && now - telephony_absent_since_ >= HFP_ABSENT_SECONDS) {
+                hfp_cycle_spent_ = true;
+                std::string err;
+                if (!ops_.disconnect_classic(err))
+                    debug::log(WARN, "bluetooth: BR/EDR cycle for hands-free failed ({})", err);
+            }
+        } else {
+            telephony_absent_since_ = -1;
+            hfp_cycle_spent_ = false;
+        }
+
+        // LE is only worth attempting once the ACL has settled.
         if (!ancs_enabled_) {
             status_.reason = _("Connected. Notification mirroring is disabled.");
             return !(status_ == previous);

--- a/src/core/src/bluetooth/connection.cpp
+++ b/src/core/src/bluetooth/connection.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <ctime>
+#include <functional>
 #include <gio/gio.h>
 #include <mutex>
 #include <thread>
@@ -372,7 +373,11 @@ namespace tether::bluetooth {
                 return le_->pending;
             }
 
+            void set_telephony_probe(std::function<bool()> probe) { telephony_probe_ = std::move(probe); }
+
             bool telephony_present() const override {
+                if (telephony_probe_)
+                    return telephony_probe_();
                 auto device = lookup();
                 return device && monitor_.snapshot().find_telephony(device->path) != nullptr;
             }
@@ -521,6 +526,7 @@ namespace tether::bluetooth {
 
             BluezMonitor& monitor_;
             std::string address_;
+            std::function<bool()> telephony_probe_;
         };
 
         // OBEX sessions live on the session bus, not the system bus.
@@ -1146,7 +1152,7 @@ namespace tether::bluetooth {
 
         std::shared_ptr<TelephonyClient> client;
         if (wanted)
-            client = std::make_shared<TelephonyClient>(*monitor, address);
+            client = make_telephony_client(*monitor, address);
         {
             std::lock_guard<std::mutex> lock(telephony_mutex);
             telephony = std::move(client);
@@ -1277,6 +1283,10 @@ namespace tether::bluetooth {
             }
         }
         state_->bearer_ops = std::make_unique<BluezBearerOps>(*state_->monitor, address);
+        state_->bearer_ops->set_telephony_probe([state = state_.get()] {
+            auto client = state->calls_client();
+            return client && client->present();
+        });
         state_->profile_ops = std::make_unique<ObexProfileOps>(address);
         state_->bearers = std::make_unique<BearerSupervisor>(*state_->bearer_ops, ancs_effective);
         state_->profiles = std::make_unique<ProfileSupervisor>(*state_->profile_ops);

--- a/src/core/src/bluetooth/connection.cpp
+++ b/src/core/src/bluetooth/connection.cpp
@@ -372,6 +372,26 @@ namespace tether::bluetooth {
                 return le_->pending;
             }
 
+            bool telephony_present() const override {
+                auto device = lookup();
+                return device && monitor_.snapshot().find_telephony(device->path) != nullptr;
+            }
+
+            bool disconnect_classic(std::string& err) override {
+                auto device = lookup();
+                if (!device) {
+                    err = "device not present";
+                    return false;
+                }
+                // Only the per-bearer call: Device1.Disconnect() would take the
+                // LE half and the ANCS subscription riding on it.
+                if (!device->has_classic_bearer) {
+                    err = "no BR/EDR bearer";
+                    return false;
+                }
+                return call(device->path, IFACE_BEARER_BREDR, "Disconnect", err);
+            }
+
             bool solicitation_on_air() const override {
                 if (!ancs_solicitation_active())
                     return false;
@@ -1122,6 +1142,7 @@ namespace tether::bluetooth {
         if (wanted == calls_enabled)
             return;
         calls_enabled = wanted;
+        bearers->set_calls_enabled(wanted);
 
         std::shared_ptr<TelephonyClient> client;
         if (wanted)

--- a/src/core/src/bluetooth/telephony.cpp
+++ b/src/core/src/bluetooth/telephony.cpp
@@ -14,6 +14,7 @@ namespace tether::bluetooth {
         constexpr const char* BLUEZ_NAME = "org.bluez";
         constexpr const char* IFACE_TELEPHONY = "org.bluez.Telephony1";
         constexpr const char* IFACE_CALL = "org.bluez.Call1";
+        constexpr const char* IFACE_PROPS = "org.freedesktop.DBus.Properties";
 
         constexpr int CALL_TIMEOUT_MS = 10000;
 
@@ -92,41 +93,96 @@ namespace tether::bluetooth {
         return j;
     }
 
-    TelephonyClient::TelephonyClient(BluezMonitor& monitor, std::string address)
-        : monitor_(&monitor), address_(std::move(address)) {}
+    namespace {
 
-    Telephony TelephonyClient::gateway() const {
-        const BluezObjects objects = monitor_->snapshot();
-        for (const auto& device : objects.devices) {
-            if (!iequals(device.address, address_))
-                continue;
-            if (const Telephony* found = objects.find_telephony(device.path))
-                return *found;
-        }
-        return {};
+        class BluezSource : public TelephonySource {
+        public:
+            BluezSource(BluezMonitor& monitor, std::string address)
+                : monitor_(&monitor), address_(std::move(address)) {}
+
+            TelephonyIds ids() const override {
+                return {"bluez", BLUEZ_NAME, IFACE_TELEPHONY, nullptr, IFACE_CALL, true, true};
+            }
+
+            GDBusConnection* connection() const override { return monitor_->connection(); }
+
+            TelephonySnapshot snapshot() const override {
+                const BluezObjects objects = monitor_->snapshot();
+                for (const auto& device : objects.devices) {
+                    if (!iequals(device.address, address_))
+                        continue;
+                    if (const Telephony* found = objects.find_telephony(device.path))
+                        return {*found, objects.calls_for(found->path), {}};
+                }
+                return {};
+            }
+
+        private:
+            BluezMonitor* monitor_;
+            std::string address_;
+        };
+
+    } // namespace
+
+    std::string dial_argument(const TelephonyIds& ids, const std::string& number) {
+        return ids.dial_uri ? "tel:" + number : number;
     }
 
-    bool TelephonyClient::available() const { return gateway().ready(); }
+    std::unique_ptr<TelephonySource> make_bluez_source(BluezMonitor& monitor, std::string address) {
+        return std::make_unique<BluezSource>(monitor, std::move(address));
+    }
+
+    std::unique_ptr<TelephonyClient> make_telephony_client(BluezMonitor& monitor, std::string address) {
+        std::vector<std::unique_ptr<TelephonySource>> sources;
+        sources.push_back(make_bluez_source(monitor, address));
+        sources.push_back(make_pipewire_source(address));
+        return std::make_unique<TelephonyClient>(std::move(sources), std::move(address));
+    }
+
+    TelephonyClient::TelephonyClient(std::vector<std::unique_ptr<TelephonySource>> sources, std::string address)
+        : sources_(std::move(sources)), address_(std::move(address)) {}
+
+    std::pair<TelephonySource*, TelephonySnapshot> TelephonyClient::pick() const {
+        for (const auto& source : sources_) {
+            TelephonySnapshot snap = source->snapshot();
+            if (!snap.gateway.path.empty())
+                return {source.get(), std::move(snap)};
+        }
+        return {nullptr, {}};
+    }
+
+    bool TelephonyClient::available() const { return pick().second.gateway.ready(); }
+
+    bool TelephonyClient::present() const { return pick().first != nullptr; }
 
     nlohmann::json TelephonyClient::status() const {
-        const Telephony gw = gateway();
-        nlohmann::json j = to_json(gw);
+        const auto [source, snap] = pick();
+        nlohmann::json j = to_json(snap.gateway);
         j["address"] = address_;
-        j["calls"] = monitor_->snapshot().calls_for(gw.path).size();
-        if (gw.path.empty())
+        j["calls"] = snap.calls.size();
+        j["backend"] = source ? source->ids().name : "";
+        j["indicators"] = !source || source->ids().indicators;
+        j["audio"] = snap.audio_state;
+        if (!source)
             j["reason"] = _("The iPhone has not connected Hands-Free to this computer.");
-        else if (!gw.ready())
+        else if (!snap.gateway.ready())
             j["reason"] = _("Connecting to the iPhone's Hands-Free service.");
+        else if (source->ids().transport_iface)
+            j["reason"] = _("PipeWire is handling Hands-Free, so the call audio can play on this computer.");
         else
             j["reason"] = _("Calls are controlled here; the audio plays on the iPhone.");
         return j;
     }
 
-    nlohmann::json TelephonyClient::calls() const { return to_json(monitor_->snapshot().calls_for(gateway().path)); }
+    nlohmann::json TelephonyClient::calls() const { return to_json(pick().second.calls); }
 
-    bool TelephonyClient::invoke(
-        const std::string& path, const char* iface, const char* method, GVariant* args, std::string& err) {
-        GDBusConnection* conn = monitor_->connection();
+    bool TelephonyClient::invoke(TelephonySource& source,
+                                 const std::string& path,
+                                 const char* iface,
+                                 const char* method,
+                                 GVariant* args,
+                                 std::string& err) {
+        GDBusConnection* conn = source.connection();
         if (!conn || path.empty()) {
             // Consumes the floating reference the caller built.
             if (args)
@@ -137,7 +193,7 @@ namespace tether::bluetooth {
 
         GError* error = nullptr;
         GVariant* reply = g_dbus_connection_call_sync(conn,
-                                                      BLUEZ_NAME,
+                                                      source.ids().bus,
                                                       path.c_str(),
                                                       iface,
                                                       method,
@@ -163,13 +219,27 @@ namespace tether::bluetooth {
             err = _("Not a dialable number.");
             return false;
         }
-        const std::string uri = "tel:" + dialable;
-        return invoke(gateway().path, IFACE_TELEPHONY, "Dial", g_variant_new("(s)", uri.c_str()), err);
+        const auto [source, snap] = pick();
+        if (!source) {
+            err = _("The iPhone has not connected Hands-Free to this computer.");
+            return false;
+        }
+        const std::string argument = dial_argument(source->ids(), dialable);
+        return invoke(*source,
+                      snap.gateway.path,
+                      source->ids().gateway_iface,
+                      "Dial",
+                      g_variant_new("(s)", argument.c_str()),
+                      err);
     }
 
     bool TelephonyClient::call_action(const std::string& path, const std::string& action, std::string& err) {
-        const Telephony gw = gateway();
-        const std::vector<Call> live = monitor_->snapshot().calls_for(gw.path);
+        const auto [source, snap] = pick();
+        if (!source) {
+            err = _("The iPhone has not connected Hands-Free to this computer.");
+            return false;
+        }
+        const std::vector<Call>& live = snap.calls;
 
         if (action == "answer" || action == "hangup") {
             std::string target = path;
@@ -183,7 +253,25 @@ namespace tether::bluetooth {
                 err = _("That call is no longer active.");
                 return false;
             }
-            return invoke(target, IFACE_CALL, action == "answer" ? "Answer" : "Hangup", nullptr, err);
+            return invoke(
+                *source, target, source->ids().call_iface, action == "answer" ? "Answer" : "Hangup", nullptr, err);
+        }
+
+        if (action == "audio_here" || action == "audio_phone") {
+            const char* transport = source->ids().transport_iface;
+            if (!transport) {
+                err = _("This computer is not carrying the call audio; it plays on the iPhone.");
+                return false;
+            }
+            const bool to_phone = action == "audio_phone";
+            if (!invoke(*source,
+                        snap.gateway.path,
+                        IFACE_PROPS,
+                        "Set",
+                        g_variant_new("(ssv)", transport, "RejectSCO", g_variant_new_boolean(to_phone)),
+                        err))
+                return false;
+            return to_phone || invoke(*source, snap.gateway.path, transport, "Activate", nullptr, err);
         }
 
         static const std::pair<const char*, const char*> gateway_actions[] = {
@@ -196,7 +284,7 @@ namespace tether::bluetooth {
         };
         for (const auto& [name, method] : gateway_actions)
             if (action == name)
-                return invoke(gw.path, IFACE_TELEPHONY, method, nullptr, err);
+                return invoke(*source, snap.gateway.path, source->ids().gateway_iface, method, nullptr, err);
 
         err = _("Unknown call action.");
         return false;
@@ -209,7 +297,17 @@ namespace tether::bluetooth {
             err = _("Not a DTMF sequence.");
             return false;
         }
-        return invoke(gateway().path, IFACE_TELEPHONY, "SendTones", g_variant_new("(s)", tones.c_str()), err);
+        const auto [source, snap] = pick();
+        if (!source) {
+            err = _("The iPhone has not connected Hands-Free to this computer.");
+            return false;
+        }
+        return invoke(*source,
+                      snap.gateway.path,
+                      source->ids().gateway_iface,
+                      "SendTones",
+                      g_variant_new("(s)", tones.c_str()),
+                      err);
     }
 
 } // namespace tether::bluetooth

--- a/src/core/src/bluetooth/telephony_pipewire.cpp
+++ b/src/core/src/bluetooth/telephony_pipewire.cpp
@@ -1,0 +1,236 @@
+#include "tether/bluetooth/telephony.hpp"
+#include "tether/log.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <mutex>
+
+// PipeWire's hands-free implementation, on the session bus. It owns the same
+// profile BlueZ's does and carries the call audio as well, so a phone that
+// connected Hands-Free to PipeWire is reachable only here.
+namespace tether::bluetooth {
+
+    namespace {
+
+        constexpr const char* PW_NAME = "org.pipewire.Telephony";
+        constexpr const char* PW_ROOT = "/org/pipewire/Telephony";
+        constexpr const char* PW_GATEWAY = "org.pipewire.Telephony.AudioGateway1";
+        constexpr const char* PW_TRANSPORT = "org.pipewire.Telephony.AudioGatewayTransport1";
+        constexpr const char* PW_CALL = "org.pipewire.Telephony.Call1";
+        constexpr const char* IFACE_OBJECT_MANAGER = "org.freedesktop.DBus.ObjectManager";
+
+        constexpr int CALL_TIMEOUT_MS = 5000;
+        // How long to leave the session bus alone after finding no service there.
+        constexpr int DORMANT_SECONDS = 30;
+
+        bool iequals(const std::string& a, const std::string& b) {
+            return a.size() == b.size() &&
+                   std::equal(a.begin(), a.end(), b.begin(), [](unsigned char x, unsigned char y) {
+                       return std::tolower(x) == std::tolower(y);
+                   });
+        }
+
+        // /org/pipewire/Telephony/ag0/call1 -> the owning gateway.
+        std::string parent_path(const std::string& path) {
+            const size_t slash = path.rfind('/');
+            return slash == std::string::npos || slash == 0 ? std::string{} : path.substr(0, slash);
+        }
+
+        std::string string_prop(GVariant* props, const char* key) {
+            GVariant* value = g_variant_lookup_value(props, key, G_VARIANT_TYPE_STRING);
+            if (!value)
+                return {};
+            std::string out = g_variant_get_string(value, nullptr);
+            g_variant_unref(value);
+            return out;
+        }
+
+        bool bool_prop(GVariant* props, const char* key) {
+            GVariant* value = g_variant_lookup_value(props, key, G_VARIANT_TYPE_BOOLEAN);
+            if (!value)
+                return false;
+            const bool out = g_variant_get_boolean(value);
+            g_variant_unref(value);
+            return out;
+        }
+
+        // The interface dictionary for one object, or null when absent.
+        GVariant* interface_props(GVariant* interfaces, const char* iface) {
+            return g_variant_lookup_value(interfaces, iface, G_VARIANT_TYPE_VARDICT);
+        }
+
+        Call read_call(const std::string& path, GVariant* props) {
+            Call call;
+            call.path = path;
+            call.telephony_path = parent_path(path);
+            call.number = string_prop(props, "LineIdentification");
+            call.name = string_prop(props, "Name");
+            call.incoming_line = string_prop(props, "IncomingLine");
+            // Passed through unmapped, as the BlueZ side does.
+            call.state = string_prop(props, "State");
+            call.multiparty = bool_prop(props, "Multiparty");
+            return call;
+        }
+
+        class PipewireSource : public TelephonySource {
+        public:
+            explicit PipewireSource(std::string address) : address_(std::move(address)) {}
+
+            ~PipewireSource() override {
+                if (conn_)
+                    g_object_unref(conn_);
+            }
+
+            TelephonyIds ids() const override {
+                return {"pipewire", PW_NAME, PW_GATEWAY, PW_TRANSPORT, PW_CALL, false, false};
+            }
+
+            GDBusConnection* connection() const override {
+                std::lock_guard<std::mutex> lock(mutex_);
+                return ensure_locked();
+            }
+
+            TelephonySnapshot snapshot() const override {
+                std::lock_guard<std::mutex> lock(mutex_);
+                if (std::chrono::steady_clock::now() < next_try_)
+                    return {};
+
+                GVariant* objects = managed_objects_locked(PW_ROOT);
+                if (!objects)
+                    return {};
+
+                TelephonySnapshot snap = parse_pipewire_telephony(objects, address_);
+                g_variant_unref(objects);
+
+                // Measured on pipewire 1.6.8: root manager has only the gateways, even during a call, and each gateway
+                // keeps its calls in an object manager of its own.
+                if (!snap.gateway.path.empty()) {
+                    if (GVariant* nested = managed_objects_locked(snap.gateway.path.c_str())) {
+                        snap.calls = parse_pipewire_calls(nested, snap.gateway.path);
+                        g_variant_unref(nested);
+                    }
+                }
+                return snap;
+            }
+
+        private:
+            GDBusConnection* ensure_locked() const {
+                if (conn_)
+                    return conn_;
+                GError* error = nullptr;
+                conn_ = g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, &error);
+                if (!conn_) {
+                    debug::log(DEBUG, "telephony: session bus unavailable ({})", error ? error->message : "unknown");
+                    g_clear_error(&error);
+                    next_try_ = std::chrono::steady_clock::now() + std::chrono::seconds(DORMANT_SECONDS);
+                }
+                return conn_;
+            }
+
+            GVariant* managed_objects_locked(const char* path) const {
+                GDBusConnection* conn = ensure_locked();
+                if (!conn)
+                    return nullptr;
+
+                GError* error = nullptr;
+                GVariant* reply = g_dbus_connection_call_sync(conn,
+                                                              PW_NAME,
+                                                              path,
+                                                              IFACE_OBJECT_MANAGER,
+                                                              "GetManagedObjects",
+                                                              nullptr,
+                                                              G_VARIANT_TYPE("(a{oa{sa{sv}}})"),
+                                                              G_DBUS_CALL_FLAGS_NONE,
+                                                              CALL_TIMEOUT_MS,
+                                                              nullptr,
+                                                              &error);
+                if (!reply) {
+                    // Nothing is publishing the service, which is the normal
+                    // state on a machine where BlueZ owns hands-free.
+                    if (error && error->domain == G_DBUS_ERROR &&
+                        (error->code == G_DBUS_ERROR_SERVICE_UNKNOWN || error->code == G_DBUS_ERROR_NAME_HAS_NO_OWNER))
+                        next_try_ = std::chrono::steady_clock::now() + std::chrono::seconds(DORMANT_SECONDS);
+                    g_clear_error(&error);
+                    return nullptr;
+                }
+
+                next_try_ = std::chrono::steady_clock::time_point{};
+                GVariant* objects = g_variant_get_child_value(reply, 0);
+                g_variant_unref(reply);
+                return objects;
+            }
+
+            std::string address_;
+            mutable std::mutex mutex_;
+            mutable GDBusConnection* conn_ = nullptr;
+            mutable std::chrono::steady_clock::time_point next_try_{};
+        };
+
+    } // namespace
+
+    TelephonySnapshot parse_pipewire_telephony(GVariant* objects, const std::string& address) {
+        TelephonySnapshot snap;
+        if (!objects)
+            return snap;
+
+        GVariantIter iter;
+        const char* path = nullptr;
+        GVariant* interfaces = nullptr;
+
+        g_variant_iter_init(&iter, objects);
+        while (g_variant_iter_loop(&iter, "{&o@a{sa{sv}}}", &path, &interfaces)) {
+            GVariant* props = interface_props(interfaces, PW_GATEWAY);
+            if (!props)
+                continue;
+            const std::string gateway_address = string_prop(props, "Address");
+            g_variant_unref(props);
+            if (!iequals(gateway_address, address))
+                continue;
+
+            snap.gateway.path = path;
+            snap.gateway.device_path = parent_path(path);
+            snap.gateway.state = "connected";
+            if (GVariant* transport = interface_props(interfaces, PW_TRANSPORT)) {
+                snap.audio_state = string_prop(transport, "State");
+                g_variant_unref(transport);
+            }
+            g_variant_unref(interfaces);
+            break;
+        }
+
+        if (!snap.gateway.path.empty())
+            snap.calls = parse_pipewire_calls(objects, snap.gateway.path);
+        return snap;
+    }
+
+    std::vector<Call> parse_pipewire_calls(GVariant* objects, const std::string& gateway_path) {
+        std::vector<Call> calls;
+        if (!objects || gateway_path.empty())
+            return calls;
+
+        GVariantIter iter;
+        const char* path = nullptr;
+        GVariant* interfaces = nullptr;
+
+        g_variant_iter_init(&iter, objects);
+        while (g_variant_iter_loop(&iter, "{&o@a{sa{sv}}}", &path, &interfaces)) {
+            GVariant* props = interface_props(interfaces, PW_CALL);
+            if (!props)
+                continue;
+            const std::string call_path = path;
+            // Scoped by parentage, so a second phone's calls stay its own.
+            if (parent_path(call_path) == gateway_path)
+                calls.push_back(read_call(call_path, props));
+            g_variant_unref(props);
+        }
+
+        std::sort(calls.begin(), calls.end(), [](const Call& a, const Call& b) { return a.path < b.path; });
+        return calls;
+    }
+
+    std::unique_ptr<TelephonySource> make_pipewire_source(std::string address) {
+        return std::make_unique<PipewireSource>(std::move(address));
+    }
+
+} // namespace tether::bluetooth

--- a/src/core/src/crypto.cpp
+++ b/src/core/src/crypto.cpp
@@ -27,6 +27,25 @@ namespace tether {
             SSL_CTX_free(client_ctx_);
     }
 
+    void Crypto::reset_for_tests() {
+        std::lock_guard<std::mutex> lock(hosts_mutex_);
+        if (server_ctx_) {
+            SSL_CTX_free(server_ctx_);
+            server_ctx_ = nullptr;
+        }
+        if (client_ctx_) {
+            SSL_CTX_free(client_ctx_);
+            client_ctx_ = nullptr;
+        }
+        known_hosts_.clear();
+        hosts_mtime_ = {};
+        hosts_loaded_ = false;
+        cert_path_.clear();
+        key_path_.clear();
+        hosts_path_.clear();
+        my_fingerprint_.clear();
+    }
+
     SSL_CTX* Crypto::get_server_context() { return server_ctx_; }
     SSL_CTX* Crypto::get_client_context() { return client_ctx_; }
 

--- a/src/gtk/calls_view.cpp
+++ b/src/gtk/calls_view.cpp
@@ -19,6 +19,7 @@ namespace tether::ui {
             GtkWidget* network_label = nullptr;
             bool visible = false;
             bool available = false;
+            bool audio_routable = false;
         };
 
         CallsState g_calls;
@@ -45,6 +46,8 @@ namespace tether::ui {
         }
 
         void on_answer_clicked(GtkButton* button, gpointer) { send_action("answer", button_path(button)); }
+
+        void on_audio_here_clicked(GtkButton*, gpointer) { send_action("audio_here", ""); }
 
         void on_hangup_clicked(GtkButton* button, gpointer) { send_action("hangup", button_path(button)); }
 
@@ -86,6 +89,8 @@ namespace tether::ui {
         // What HFP reports about the phone's cellular link.
         std::string network_text(const nlohmann::json& calls) {
             if (!calls.is_object())
+                return {};
+            if (!calls.value("indicators", true))
                 return {};
             std::string out = calls.value("operator", "");
             if (!calls.value("service", false))
@@ -135,9 +140,6 @@ namespace tether::ui {
             if (!name.empty() && !number.empty())
                 secondary += secondary.empty() ? number : "  -  " + number;
 
-            if (call.value("connected", false))
-                secondary += std::string("\n") + _("Calls are controlled here; the audio plays on the iPhone.");
-
             GtkWidget* secondary_label = gtk_label_new(secondary.c_str());
             gtk_label_set_xalign(GTK_LABEL(secondary_label), 0.0);
             gtk_style_context_add_class(gtk_widget_get_style_context(secondary_label), "muted");
@@ -151,6 +153,13 @@ namespace tether::ui {
                 g_signal_connect(answer, "clicked", G_CALLBACK(on_answer_clicked), nullptr);
                 gtk_widget_set_valign(answer, GTK_ALIGN_CENTER);
                 gtk_box_pack_start(GTK_BOX(box), answer, FALSE, FALSE, 0);
+            }
+
+            if (call.value("connected", false) && g_calls.audio_routable) {
+                GtkWidget* audio = gtk_button_new_with_label(_("Audio here"));
+                g_signal_connect(audio, "clicked", G_CALLBACK(on_audio_here_clicked), nullptr);
+                gtk_widget_set_valign(audio, GTK_ALIGN_CENTER);
+                gtk_box_pack_start(GTK_BOX(box), audio, FALSE, FALSE, 0);
             }
 
             if (state != "disconnected") {
@@ -209,6 +218,8 @@ namespace tether::ui {
             set_text(g_calls.network_label, g_calls.available ? network_text(calls) : "");
 
             const std::string reason = calls.is_object() ? calls.value("reason", "") : "";
+            const std::string audio = calls.is_object() ? calls.value("audio", "") : "";
+            g_calls.audio_routable = !audio.empty() && audio != "active";
             set_text(g_calls.status_label,
                      g_calls.available
                          ? std::string(_("No calls.")) + (reason.empty() ? "" : "\n" + reason)

--- a/test/test_bluetooth_supervisor.cpp
+++ b/test/test_bluetooth_supervisor.cpp
@@ -61,6 +61,19 @@ namespace {
         // about an adapter that will not advertise clears this.
         bool on_air = true;
         bool solicitation_on_air() const override { return on_air; }
+
+        // Hands-free connected, as the bus shows it. Tests about the BR/EDR
+        // cycle clear this.
+        bool telephony = true;
+        int classic_disconnects = 0;
+
+        bool telephony_present() const override { return telephony; }
+
+        bool disconnect_classic(std::string&) override {
+            ++classic_disconnects;
+            classic = false;
+            return true;
+        }
     };
 
     class FakeProfiles : public ProfileOps {
@@ -902,4 +915,67 @@ TEST(BearerSupervisor, NamesTheHostWhenObexIsUpAndClassicKeepsRefusing) {
     EXPECT_NE(sup.status().reason.find("offers the iPhone no profile"), std::string::npos);
     EXPECT_EQ(sup.status().reason.find("keeps refusing"), std::string::npos)
         << "blamed the phone while it was serving messages and contacts";
+}
+
+// A phone-initiated reconnect brings BR/EDR up without hands-free, and nothing
+// in BlueZ retries it. One bearer cycle is the remedy, and it must stay one: the
+// drop it causes runs back through reset(), which is where a naive flag clears
+// and the cycle repeats forever.
+TEST(BearerSupervisor, CyclesClassicOnceWhenHandsFreeIsAbsent) {
+    FakeBearer ops;
+    ops.telephony = false;
+    BearerSupervisor sup(ops, true);
+    sup.set_calls_enabled(true);
+
+    sup.tick(0); // connects Classic
+    sup.tick(1);
+    EXPECT_EQ(ops.classic_disconnects, 0) << "cycled before the grace window elapsed";
+
+    sup.tick(1 + HFP_ABSENT_SECONDS - 1);
+    EXPECT_EQ(ops.classic_disconnects, 0);
+
+    sup.tick(1 + HFP_ABSENT_SECONDS);
+    EXPECT_EQ(ops.classic_disconnects, 1);
+
+    // The link the cycle dropped comes back, still with no hands-free.
+    sup.reset();
+    for (int64_t now = 1 + HFP_ABSENT_SECONDS; now <= 4 * HFP_ABSENT_SECONDS; ++now)
+        sup.tick(now);
+    EXPECT_EQ(ops.classic_disconnects, 1) << "hands-free never arrived, so the phone must be asked only once";
+}
+
+// Once hands-free is connected the cycle is armed again, so the next reconnect
+// that comes up without it is recovered too.
+TEST(BearerSupervisor, ArmsAnotherCycleAfterHandsFreeConnects) {
+    FakeBearer ops;
+    ops.telephony = false;
+    BearerSupervisor sup(ops, true);
+    sup.set_calls_enabled(true);
+
+    sup.tick(0);
+    sup.tick(1);
+    sup.tick(1 + HFP_ABSENT_SECONDS);
+    EXPECT_EQ(ops.classic_disconnects, 1);
+
+    ops.telephony = true;
+    sup.reset();
+    sup.tick(100); // reconnects Classic
+    sup.tick(101); // Classic up with hands-free on it: arms the next cycle
+
+    ops.telephony = false;
+    sup.tick(102);
+    sup.tick(102 + HFP_ABSENT_SECONDS);
+    EXPECT_EQ(ops.classic_disconnects, 2);
+}
+
+// Cycling BR/EDR costs the OBEX sessions on top of it, so it must never happen
+// for a feature the user has switched off.
+TEST(BearerSupervisor, NeverCyclesClassicWhenCallsAreDisabled) {
+    FakeBearer ops;
+    ops.telephony = false;
+    BearerSupervisor sup(ops, true);
+
+    for (int64_t now = 0; now <= 4 * HFP_ABSENT_SECONDS; ++now)
+        sup.tick(now);
+    EXPECT_EQ(ops.classic_disconnects, 0);
 }

--- a/test/test_bluetooth_supervisor.cpp
+++ b/test/test_bluetooth_supervisor.cpp
@@ -979,3 +979,17 @@ TEST(BearerSupervisor, NeverCyclesClassicWhenCallsAreDisabled) {
         sup.tick(now);
     EXPECT_EQ(ops.classic_disconnects, 0);
 }
+
+// When PipeWire owns hands-free, a telephony object exists on its bus and the
+// link is healthy. Cycling BR/EDR would drop the OBEX sessions to recover
+// something that is not missing.
+TEST(BearerSupervisor, NeverCyclesClassicWhileHandsFreeIsPresent) {
+    FakeBearer ops;
+    ops.telephony = true;
+    BearerSupervisor sup(ops, true);
+    sup.set_calls_enabled(true);
+
+    for (int64_t now = 0; now <= 4 * HFP_ABSENT_SECONDS; ++now)
+        sup.tick(now);
+    EXPECT_EQ(ops.classic_disconnects, 0);
+}

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -1,10 +1,10 @@
-#include <gtest/gtest.h>
-#include <tether/crypto.hpp>
-#include <filesystem>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
-#include <sstream>
+#include <gtest/gtest.h>
 #include <iostream>
+#include <sstream>
+#include <tether/crypto.hpp>
 #include <unistd.h>
 
 class CryptoTest : public ::testing::Test {
@@ -13,11 +13,14 @@ protected:
         setenv("HOME", home_.c_str(), 1);
         std::filesystem::remove_all(home_);
         std::filesystem::create_directories(home_);
+        // Crypto caches its contexts and paths, and init() short-circuits on them.
+        // Without this every test after the first runs against a config directory
+        // that SetUp deleted: the writes fail and the assertions that read from
+        // disk pass against nothing.
+        tether::Crypto::instance().reset_for_tests();
     }
 
-    void TearDown() override {
-        std::filesystem::remove_all(home_);
-    }
+    void TearDown() override { std::filesystem::remove_all(home_); }
 
     const std::filesystem::path home_ =
         std::filesystem::temp_directory_path() / ("tether-tests-" + std::to_string(getpid()));
@@ -79,7 +82,9 @@ TEST_F(CryptoTest, RemoveKnownHost) {
     // Idempotent, and the removal survives a reload from disk.
     EXPECT_FALSE(tether::Crypto::instance().remove_known_host("doomed_fp"));
 
-    std::ifstream iff(home_ / ".config/tether/known_hosts.json");
+    const auto hosts = home_ / ".config/tether/known_hosts.json";
+    ASSERT_TRUE(std::filesystem::exists(hosts)) << "nothing was written, so the check below proves nothing";
+    std::ifstream iff(hosts);
     std::stringstream on_disk;
     on_disk << iff.rdbuf();
     EXPECT_EQ(on_disk.str().find("doomed_fp"), std::string::npos);

--- a/test/test_telephony.cpp
+++ b/test/test_telephony.cpp
@@ -250,3 +250,195 @@ TEST(Telephony, SerializesTheGatewayForClients) {
     EXPECT_EQ(j["battery"], 4);
     EXPECT_FALSE(j["roaming"]);
 }
+
+namespace {
+
+    // Recorded from pipewire 1.6.8 during a live call. The root manager reports
+    // the gateways alone -- no calls, even with one active.
+    constexpr const char* PIPEWIRE_ROOT = R"({
+      '/org/pipewire/Telephony/ag1': {
+        'org.pipewire.Telephony.AudioGateway1': {
+          'Address': <'60:57:C8:30:6A:F7'>,
+          'SpeakerVolume': <byte 15>,
+          'MicrophoneVolume': <byte 15>
+        },
+        'org.pipewire.Telephony.AudioGatewayTransport1': {
+          'Codec': <byte 2>, 'State': <'active'>, 'RejectSCO': <false>
+        }
+      },
+      '/org/pipewire/Telephony/ag2': {
+        'org.pipewire.Telephony.AudioGateway1': { 'Address': <'AA:BB:CC:DD:EE:FF'> }
+      }
+    })";
+
+    // ...and each gateway keeps its calls in an object manager of its own, whose
+    // reply carries no gateway at all. Recorded from the same call.
+    constexpr const char* PIPEWIRE_GATEWAY_CALLS = R"({
+      '/org/pipewire/Telephony/ag1/call1': {
+        'org.pipewire.Telephony.Call1': {
+          'LineIdentification': <'18002662278'>,
+          'IncomingLine': <''>,
+          'Name': <''>,
+          'Multiparty': <false>,
+          'State': <'active'>
+        }
+      },
+      '/org/pipewire/Telephony/ag2/call1': {
+        'org.pipewire.Telephony.Call1': { 'LineIdentification': <'+15555559999'>, 'State': <'incoming'> }
+      }
+    })";
+
+    // A source under the test's control, so TelephonyClient can be driven with
+    // no bus at all.
+    class FakeSource : public TelephonySource {
+    public:
+        TelephonySnapshot snap;
+        TelephonyIds identity{"fake", "org.example", "org.example.Gateway1", nullptr, "org.example.Call1", true, true};
+
+        TelephonyIds ids() const override { return identity; }
+        // Null stands for "reachable but nothing to talk to", which is what
+        // every invoke() in these tests should refuse on.
+        GDBusConnection* connection() const override { return nullptr; }
+        TelephonySnapshot snapshot() const override { return snap; }
+    };
+
+    std::unique_ptr<FakeSource> gateway_source(const char* path, const char* state = "connected") {
+        auto source = std::make_unique<FakeSource>();
+        source->snap.gateway.path = path;
+        source->snap.gateway.state = state;
+        return source;
+    }
+
+    std::unique_ptr<TelephonyClient> client_of(std::vector<std::unique_ptr<TelephonySource>> sources) {
+        return std::make_unique<TelephonyClient>(std::move(sources), "60:57:C8:30:6A:F7");
+    }
+
+} // namespace
+
+TEST(PipewireTelephony, MatchesTheGatewayByAddress) {
+    Payload payload(PIPEWIRE_ROOT);
+    const TelephonySnapshot snap = parse_pipewire_telephony(payload.v, "60:57:c8:30:6a:f7");
+
+    EXPECT_EQ(snap.gateway.path, "/org/pipewire/Telephony/ag1") << "address match must be case-insensitive";
+    EXPECT_TRUE(snap.gateway.ready()) << "a registered gateway means the service level connection is up";
+    EXPECT_EQ(snap.audio_state, "active");
+}
+
+// The reply that carries the gateway carries no calls, so reading the call list
+// from it is how the Hang up button goes missing.
+TEST(PipewireTelephony, RootManagerCarriesNoCalls) {
+    Payload payload(PIPEWIRE_ROOT);
+    const TelephonySnapshot snap = parse_pipewire_telephony(payload.v, "60:57:C8:30:6A:F7");
+    EXPECT_TRUE(snap.calls.empty());
+}
+
+// The gateway's own manager has the calls and no gateway to match an address
+// against, so they are collected by parentage instead.
+TEST(PipewireTelephony, ScopesCallsToTheirOwnGateway) {
+    Payload payload(PIPEWIRE_GATEWAY_CALLS);
+    const std::vector<Call> calls = parse_pipewire_calls(payload.v, "/org/pipewire/Telephony/ag1");
+
+    ASSERT_EQ(calls.size(), 1u) << "the other phone's call must not appear here";
+    EXPECT_EQ(calls.front().number, "18002662278");
+    EXPECT_TRUE(calls.front().connected());
+    EXPECT_EQ(calls.front().path, "/org/pipewire/Telephony/ag1/call1");
+    EXPECT_EQ(calls.front().telephony_path, "/org/pipewire/Telephony/ag1");
+}
+
+TEST(PipewireTelephony, CallsNeedAGatewayToBelongTo) {
+    Payload payload(PIPEWIRE_GATEWAY_CALLS);
+    EXPECT_TRUE(parse_pipewire_calls(payload.v, "").empty());
+    EXPECT_TRUE(parse_pipewire_calls(payload.v, "/org/pipewire/Telephony/ag9").empty());
+}
+
+// A phone PipeWire is not serving must read as absent, never as "the only
+// gateway there is" -- that would answer calls on someone else's phone.
+TEST(PipewireTelephony, UnknownAddressYieldsNoGateway) {
+    Payload payload(PIPEWIRE_ROOT);
+    const TelephonySnapshot snap = parse_pipewire_telephony(payload.v, "11:22:33:44:55:66");
+
+    EXPECT_TRUE(snap.gateway.path.empty());
+    EXPECT_TRUE(snap.calls.empty());
+    EXPECT_TRUE(snap.audio_state.empty());
+}
+
+// The indicators BlueZ reports have no PipeWire equivalent. They must stay at
+// their defaults rather than being invented.
+TEST(PipewireTelephony, ReportsNoCellularIndicators) {
+    Payload payload(PIPEWIRE_ROOT);
+    const TelephonySnapshot snap = parse_pipewire_telephony(payload.v, "60:57:C8:30:6A:F7");
+
+    EXPECT_TRUE(snap.gateway.operator_name.empty());
+    EXPECT_EQ(snap.gateway.signal, 0);
+    EXPECT_EQ(snap.gateway.battery, 0);
+    EXPECT_FALSE(snap.gateway.service);
+}
+
+TEST(PipewireTelephony, EmptyPayloadIsNotAFailure) {
+    Payload payload("@a{oa{sa{sv}}} {}");
+    const TelephonySnapshot snap = parse_pipewire_telephony(payload.v, "60:57:C8:30:6A:F7");
+    EXPECT_TRUE(snap.gateway.path.empty());
+}
+
+// Order in the source vector is the whole selection policy: BlueZ carries the
+// cellular indicators, so it wins wherever it has the profile.
+TEST(TelephonyClientSources, PrefersTheFirstSourceWithAGateway) {
+    std::vector<std::unique_ptr<TelephonySource>> sources;
+    sources.push_back(gateway_source("/org/bluez/hci0/dev_X/telephony0"));
+    sources.push_back(gateway_source("/org/pipewire/Telephony/ag0"));
+    const auto client = client_of(std::move(sources));
+
+    EXPECT_EQ(client->status().value("path", ""), "/org/bluez/hci0/dev_X/telephony0");
+    EXPECT_TRUE(client->available());
+}
+
+TEST(TelephonyClientSources, FallsThroughToTheNextSource) {
+    std::vector<std::unique_ptr<TelephonySource>> sources;
+    sources.push_back(std::make_unique<FakeSource>());
+    auto pipewire = gateway_source("/org/pipewire/Telephony/ag0");
+    pipewire->identity = {"pipewire", "org.pipewire.Telephony", "g", "t", "c", false, false};
+    sources.push_back(std::move(pipewire));
+    const auto client = client_of(std::move(sources));
+
+    const nlohmann::json status = client->status();
+    EXPECT_EQ(status.value("backend", ""), "pipewire");
+    EXPECT_FALSE(status.value("indicators", true)) << "PipeWire reports no indicators, and must say so";
+}
+
+// With no source serving, the payload must read exactly as it did before a
+// second stack existed.
+TEST(TelephonyClientSources, NoSourceReadsAsUnavailable) {
+    std::vector<std::unique_ptr<TelephonySource>> sources;
+    sources.push_back(std::make_unique<FakeSource>());
+    const auto client = client_of(std::move(sources));
+
+    const nlohmann::json status = client->status();
+    EXPECT_FALSE(client->available());
+    EXPECT_FALSE(status.value("available", true));
+    EXPECT_EQ(status.value("backend", "unset"), "");
+    EXPECT_TRUE(status.value("indicators", false)) << "an absent gateway must not claim indicators are missing";
+    EXPECT_TRUE(client->calls().empty());
+}
+
+// Moving the audio is only meaningful where the stack carries it. BlueZ opens
+// no voice link at all, and must say that rather than "unknown action".
+TEST(TelephonyClientSources, AudioActionIsRefusedWithoutATransport) {
+    std::vector<std::unique_ptr<TelephonySource>> sources;
+    sources.push_back(gateway_source("/org/bluez/hci0/dev_X/telephony0"));
+    const auto client = client_of(std::move(sources));
+
+    std::string err;
+    EXPECT_FALSE(client->call_action("", "audio_here", err));
+    EXPECT_NE(err.find("iPhone"), std::string::npos);
+    EXPECT_EQ(err.find("Unknown"), std::string::npos);
+}
+
+// The one place a silent wire-format bug could hide: BlueZ's Dial takes a URI,
+// PipeWire's takes the bare number and builds the AT command itself.
+TEST(TelephonyClientSources, DialArgumentMatchesTheStack) {
+    const TelephonyIds bluez{"bluez", "org.bluez", "g", nullptr, "c", true, true};
+    const TelephonyIds pipewire{"pipewire", "org.pipewire.Telephony", "g", "t", "c", false, false};
+
+    EXPECT_EQ(dial_argument(bluez, "+15555550123"), "tel:+15555550123");
+    EXPECT_EQ(dial_argument(pipewire, "+15555550123"), "+15555550123");
+}


### PR DESCRIPTION
After excruciating trial-and-error, this "progressively enhances" call support to pipewire's native if it is available on the system. This allows call audio on Linux. Otherwise continue using bluez's generic.