### PR TITLE
fix: notification UIDs change each ANCS session

### DIFF
--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -2528,3 +2528,72 @@ Not settled: `ServicesResolved` on a live *inbound* LE link, where
 argument that a delivering notify session means discovery completed on that link.
 It has not been captured. Anyone who catches that state should read the property
 and record it here.
+
+### 2026-09-07 - The replay dedupe outlived the UIDs it was deduping
+
+| | |
+|---|---|
+| Controller | MediaTek `usb:v0E8Dp0717`, HCI version 13 |
+| BlueZ | 5.87 with `--experimental` |
+| Phone | iPhone 15 Pro, iOS 26 |
+
+With the LE link finally staying up, notifications stopped arriving, and
+dismissing one from the UI answered:
+
+```
+ancs: control point write failed: GDBus.Error:org.bluez.Error.Failed: Operation failed with ATT error: 0xa2
+```
+
+`0xa2` is ANCS **Invalid Parameter** in Apple's control point error range
+(`0xa0` Unknown Command, `0xa1` Invalid Command, `0xa2` Invalid Parameter,
+`0xa3` Action Failed): the NotificationUID does not name anything on the phone.
+The daemon log shows the boundary exactly -- `Not connected` while LE was down at
+21:37, then every write answering `0xa2` from 21:55 once it was back.
+
+**ANCS UIDs are scoped to the connection.** The retained list made that plain:
+
+```
+uid=9   Pokémon GO   Raid Invitation ...
+uid=29  Pokémon GO   Raid Invitation ...   <- the same notification, next session
+uid=3   Wallet       Apple Card
+uid=12  Google       ...
+```
+
+Eight notifications carrying uids 3, 9, 12, 13, 16, 17, 18 and 29 -- small
+counters that restart low each session, with one notification present twice under
+two of them.
+
+`NotificationRegistry::seen_` is commented "UIDs seen this session", and nothing
+made that true. `clear()` is the only thing that empties it, and `set_device()`
+calls it only when the bond is a *different phone*. Deliberately so: the comment
+there explains that wiping the registry on a blip would empty the notification
+list and the phone's replay would then be suppressed as pre-existing, so nothing
+would come back. That reasoning is right about the notifications and wrong about
+the dedupe, and the two live in the same object.
+
+So `seen_` accumulated every UID from every session, and `classify()` --
+`seen_.count(event.uid) ? Ignore : Fetch` -- read a genuinely new notification
+landing on a recycled counter as a replay and dropped it before any fetch. Each
+reconnect saturates more of the low range. That is a phone that quietly stops
+mirroring, with a healthy `ancs_ready: true` above it.
+
+The same session boundary explains the dismissal: the list holds UIDs the phone
+retired, and `PerformNotificationAction` on one of them can only answer `0xa2`.
+
+Split the two lifetimes:
+
+- `begin_session()` clears `seen_` and bumps a session counter, called for every
+  new LE session. What is on screen is untouched, so the blip behaviour the
+  earlier comment protects is unchanged.
+- `Notification::session` records which session issued a stored UID.
+  `perform_action()` on a stale one retires the desktop copy and never writes to
+  the control point -- the phone's copy is unreachable by that UID, and retiring
+  the local one is what dismissing it asked for.
+
+The full `clear()` still runs, still only for a genuinely different phone.
+
+Worth separating from the diagnosis: this bug is older than the LE work above and
+was largely invisible behind it. A link that came back only after someone toggled
+Bluetooth on the phone rotated sessions rarely; one that reconnects on its own
+rotates them constantly, and the stale dedupe fills up in hours. Fixing the link
+is what surfaced it.

--- a/src/core/include/tether/bluetooth/ancs/notifications.hpp
+++ b/src/core/include/tether/bluetooth/ancs/notifications.hpp
@@ -24,6 +24,7 @@ namespace tether::bluetooth::ancs {
         bool silent = false;
         bool has_positive_action = false;
         bool has_negative_action = false;
+        uint64_t session = 0;
 
         bool operator==(const Notification&) const = default;
     };
@@ -50,6 +51,8 @@ namespace tether::bluetooth::ancs {
         void remember(const SourceEvent& event);
         void forget(uint32_t uid);
         void clear();
+        void begin_session();
+        uint64_t session() const { return session_; }
 
         void store(const Notification& notification);
         // Applies a display name resolved after the notifications were stored.
@@ -61,8 +64,8 @@ namespace tether::bluetooth::ancs {
         size_t size() const { return notifications_.size(); }
 
     private:
-        // UIDs seen this session, to recognize a replay.
         std::map<uint32_t, int64_t> seen_;
+        uint64_t session_ = 0;
         std::map<uint32_t, Notification> notifications_;
         std::vector<uint32_t> order_;
     };

--- a/src/core/src/bluetooth/ancs/client.cpp
+++ b/src/core/src/bluetooth/ancs/client.cpp
@@ -556,10 +556,14 @@ namespace tether::bluetooth::ancs {
         // A new LE session replays the phone's backlog, so the next batch of
         // pre-existing notifications is a sync rather than news.
         state_->initial_sync = true;
-        if (!same_device) {
-            state_->app_names.clear();
+        {
             std::lock_guard<std::mutex> lock(state_->registry_mutex);
-            state_->registry.clear();
+            if (same_device) {
+                state_->registry.begin_session();
+            } else {
+                state_->app_names.clear();
+                state_->registry.clear();
+            }
         }
         {
             std::lock_guard<std::mutex> lock(state_->inbox);
@@ -589,6 +593,16 @@ namespace tether::bluetooth::ancs {
     }
 
     bool AncsClient::perform_action(uint32_t uid, ActionId action) {
+        {
+            std::lock_guard<std::mutex> lock(state_->registry_mutex);
+            const Notification* stored = state_->registry.find(uid);
+            if (stored && stored->session != state_->registry.session()) {
+                state_->registry.forget(uid);
+                if (state_->on_withdraw)
+                    state_->on_withdraw(uid);
+                return true;
+            }
+        }
         if (!state_->ready)
             return false;
         // The sequencer belongs to tick()'s thread; handing it a request from a

--- a/src/core/src/bluetooth/ancs/notifications.cpp
+++ b/src/core/src/bluetooth/ancs/notifications.cpp
@@ -64,6 +64,11 @@ namespace tether::bluetooth::ancs {
         order_.erase(std::remove(order_.begin(), order_.end(), uid), order_.end());
     }
 
+    void NotificationRegistry::begin_session() {
+        seen_.clear();
+        ++session_;
+    }
+
     void NotificationRegistry::clear() {
         seen_.clear();
         notifications_.clear();
@@ -74,6 +79,7 @@ namespace tether::bluetooth::ancs {
         if (!notifications_.count(notification.uid))
             order_.push_back(notification.uid);
         notifications_[notification.uid] = notification;
+        notifications_[notification.uid].session = session_;
 
         while (order_.size() > MAX_RETAINED) {
             const uint32_t oldest = order_.front();

--- a/test/test_ancs_notifications.cpp
+++ b/test/test_ancs_notifications.cpp
@@ -94,6 +94,44 @@ TEST(AncsRegistry, RenameAppIgnoresEmptyArguments) {
     EXPECT_EQ(registry.find(1)->app_name, "Instagram");
 }
 
+// Measured on a live phone: ANCS UIDs are per-connection counters that restart
+// low on every LE session -- eight retained notifications carried uids 3, 9, 12,
+// 13, 16, 17, 18 and 29, with one notification present twice under 9 and 29. A
+// dedupe set carried across the session boundary therefore reads a genuinely new
+// notification as a replay and drops it, which is a phone that has stopped
+// mirroring for no visible reason.
+TEST(AncsRegistry, ANewSessionStopsRecycledUidsReadingAsReplays) {
+    NotificationRegistry registry;
+
+    SourceEvent first;
+    first.uid = 9;
+    EXPECT_EQ(registry.classify(first, false), Decision::Fetch);
+    registry.remember(first);
+    EXPECT_EQ(registry.classify(first, false), Decision::Ignore) << "same session, same uid: a replay";
+
+    registry.begin_session();
+
+    SourceEvent recycled;
+    recycled.uid = 9; // a different notification, same counter value
+    EXPECT_EQ(registry.classify(recycled, false), Decision::Fetch)
+        << "a recycled uid from a new session was dropped as a replay";
+}
+
+// The dedupe reset must not empty the notification list: an LE blip shows up as
+// the device path dropping and returning, and wiping the list there would clear
+// the UI on every flap.
+TEST(AncsRegistry, ANewSessionKeepsWhatIsOnScreen) {
+    NotificationRegistry registry;
+    registry.store(make(9, "com.burbn.instagram"));
+    const uint64_t before = registry.session();
+
+    registry.begin_session();
+
+    ASSERT_NE(registry.find(9), nullptr) << "a session change emptied the list";
+    EXPECT_EQ(registry.find(9)->session, before) << "the stored copy must keep the session that issued its uid";
+    EXPECT_NE(registry.session(), before);
+}
+
 TEST(AncsRegistry, RecentIsOrderedByDeliveryTime) {
     NotificationRegistry registry;
     // Stored in the order iOS replayed them, which bears no relation to when the


### PR DESCRIPTION
Causing notifications to be missed because IDs decrease.