### PR TITLE
feat: airpods handoff and continuity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
 | **iOS App** | ✅ Stable |
 | **Browser Extension** | ✅ Stable |
 | **Mail Extension** | ✅ Stable |
-| **Messages (SMS/iMessage)** | 🧪 Beta |
+| **Messages (SMS/iMessage)** | ✅ Stable |
 | **Notification Mirroring** | 🧪 Beta |
-| **Phone Calls** | 🧪 Alpha |
-| **TOTP/OTP Vault** | 🗓️ Planning |
+| **Phone Calls** (PipeWire only) | 🧪 Alpha |
+| **AirPods** | 🧪 Alpha |
 
 ### Clipboard Sync
 Text copied on your Linux desktop appears instantly on your iPhone, and vice versa.

--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -10,6 +10,7 @@ Bluetooth accessory. No iOS-side code is involved.
 | Contacts, for sender names | **PBAP** (Phonebook Access Profile) via `obexd` | BR/EDR | OBEX client |
 | Notifications from any app | **ANCS** (Apple Notification Center Service) | BLE / GATT | GATT central |
 | Phone calls, place + answer | **HFP** (Hands-Free Profile) via BlueZ | BR/EDR | Hands-free unit |
+| AirPods battery, buds + case | **AAP** (Apple Accessory Protocol) | BR/EDR / L2CAP | L2CAP client |
 
 The Tether iOS app is unrelated to these features and just keeps handling clipboard sync and file transfer over TCP + mTLS.
 
@@ -476,9 +477,69 @@ the narrower check; it rules out the `*`/`#` supplementary-service codes deliber
   the PBAP address book by number. A network that refuses caller ID sends the literal
   `withheld`, which is shown as unknown and never offered to redial.
 
+## AirPods
+
+Battery for the buds and the case, in the Devices list and from `tether --bt-airpods`.
+Read-only: no ANC, ear detection or stem control yet.
+
+It is the one feature here that does not go through BlueZ. AirPods report battery over
+Apple's Accessory Protocol on an L2CAP channel, PSM `0x1001`, the same source an iPhone
+uses. `src/core/src/bluetooth/airpods.cpp` opens it directly and is the only raw
+Bluetooth socket in the tree; the kernel's L2CAP constants and address struct are
+declared there rather than pulled in from bluez-libs, which the rest of the build does
+not need. No root and no capabilities: PSM `0x1001` is above the privileged range.
+
+BlueZ is still what says *which* device to open: `Device1.Modalias` starting
+`bluetooth:v004c` plus an A2DP sink UUID, falling back to a name containing "airpod"
+because Modalias is absent until SDP has been read once. The name alone is not enough —
+AirPods can be renamed to anything — and the vendor id alone is not either, since an
+iPhone is the same vendor.
+
+### The wire protocol
+
+Three packets on connect, in order, then read. All three are required: without
+set-features, or with anything but the five-`FF` request, no notification ever arrives.
+
+```
+handshake              00000400010002000000000000000000
+set-features           040004004d00d700000000000000
+request-notifications  040004000f00ffffffffff
+```
+
+A battery notification is `04 00 04 00 04 00 [count]` followed by `count` five-byte
+entries, `[component] 01 [level] [status] 01`. Components are Right `0x02`, Left `0x04`,
+Case `0x08`. Status `0x04` means the component is not reporting — a bud in the case, a
+shut case — which is shown as unknown, never as 0%. A notification carries only what
+changed, so anything it leaves out keeps its previous level.
+
+The constants come from librepods `linux/airpods_packets.h`. The prose
+`docs/AAP Definitions.md` in the same repository disagrees with the header and is wrong.
+
+`DeviceID = bluetooth:004C:0000:0000` in `/etc/bluetooth/main.conf` is **not** needed for
+this. It is what makes the machine present itself to the buds as Apple hardware, and
+reading battery does not require that.
+
+### The channel takes one client
+
+This is the failure worth knowing about. A second client on PSM `0x1001` — and an
+established channel that has silently died — makes `connect()` block **indefinitely and
+report nothing**. There is no error to log and no timeout of its own, so the naive
+symptom is a connected device whose battery never arrives and a daemon that looks idle.
+
+So the socket is non-blocking and every wait has a deadline: 8s to open the channel, 8s
+for the first notification, then 5 minutes of silence before the channel is recycled.
+Three attempts in a row that reach a deadline having delivered nothing are reported as
+`busy` rather than retried quietly, because the remedy is to stop the other program and
+nothing in the log would otherwise say so.
+
+Anything else on the machine speaking AAP is such a program: LibrePods, AirPods Center,
+a status-bar widget that reads battery itself. Only one of them can hold the channel.
+
 ## Conflicts
 
 The iPhone serves one MAP session at a time. Any other program on any machine holding it will block Tether.
+
+Only one program per machine can hold an AirPods AAP channel. See "AirPods" above.
 
 ## Known limits
 
@@ -533,6 +594,8 @@ checks the daemon does not make.
 | The link reads down forever with `br-connection-unknown`, while messages, contacts and notifications all work | This computer offers the iPhone no BR/EDR profile to connect to, and BlueZ only reports a link up while some local profile is connected | Nothing. Tether no longer waits on that link -- see 2026-08-23 below. Call support does not change this: BlueZ's hands-free profile is not one of the local profiles BlueZ counts |
 | The iPhone's audio moves to the computer when Tether connects | The machine advertises itself as a Bluetooth speaker/headset, and iOS routes to it. Not caused by Tether beyond bringing the link up | See "Keeping the phone's audio on the phone" below |
 | `tether --bt-calls` reports call control off | PipeWire took the profile *and* its telephony D-Bus service is off, the iPhone reconnected on its own and never opened hands-free, or `bluetoothd` is running without `--experimental` | Either give BlueZ the profile by dropping `hfp_hf` from `bluez5.roles`, or set `bluez5.telephony-dbus-service = true` and let Tether drive PipeWire's gateway -- see "Calls". The daemon cycles the BR/EDR bearer once per outage for the second cause; confirm with `busctl --system tree org.bluez \| grep telephony` and `busctl --user tree org.pipewire.Telephony` |
+| AirPods are listed but the battery stays blank, and the row says another program is using the channel | The AAP channel takes one client, and something else has it | Stop the other AirPods program (LibrePods, AirPods Center, a status-bar widget that reads battery). Nothing else releases it |
+| AirPods do not appear in the Devices list at all | They are not connected, or BlueZ has never read their SDP record so there is no Modalias and the name does not contain "airpod" | Connect them, then `tether --bt-devices` -- the row carries an `airpods` flag when Tether recognizes them |
 | Calls work but the audio is on the iPhone | Working as designed. BlueZ signals the call and never opens the voice link, so there is nothing to route here | Nothing. `./scripts/bt-probe.sh --calls` during a call shows the evidence; "Getting the call audio onto the desktop instead" is the trade if you want it |
 | The Calls page is empty after configuring PipeWire for call audio | PipeWire's telephony D-Bus service is off, so neither stack exports anything Tether can read | Set `bluez5.telephony-dbus-service = true` and reconnect. With it on, Tether drives PipeWire's gateway directly and the Calls page works, minus carrier and signal |
 | Configured PipeWire for call audio and the machine is not in the iPhone's audio picker | `a2dp_sink` is missing from `bluez5.roles`. iOS only speaks hands-free to a machine it considers an audio destination | Add `a2dp_sink`, and accept that the phone's music comes here too -- see "Getting the call audio onto the desktop instead" |

--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -571,6 +571,55 @@ because a bus name can be *activatable* rather than running -- `playerctld` usua
 and neither starting a media player to interrogate it nor blocking the Bluetooth reader
 thread on one is acceptable.
 
+### Handing the buds to the phone for a call
+
+Off by default. `tether --bt-airpods-handoff on`, or the checkbox on the AirPods page.
+
+When the iPhone has a call and the AirPods are connected to *this machine*, Tether pauses
+local playback and disconnects them, so the phone can take them. When the call ends it
+reconnects them and resumes what it paused.
+
+**It needs call control**, because the trigger is the iPhone's call state, which comes
+from `org.bluez.Telephony1` or `org.pipewire.Telephony`. With calls off there is no
+gateway and nothing to trigger on, so the checkbox is disabled. See "Calls".
+
+`handoff_action()` is pure and tested. What it refuses to do matters more than what it
+does:
+
+- **Only buds this code disconnected are reconnected.** Buds the user took away by hand
+  stay away.
+- A call while the buds are already on the phone does nothing: there is nothing here to
+  hand over.
+- It never releases twice, which would lose track of what to give back.
+- Playback resumes **only if the buds came back**. Resuming onto the machine's own
+  speakers is not what handing them over asked for.
+
+Handoff and "pause when a bud comes out" both act on the same paused players, and they
+disagree about what a disconnect means. Buds that vanish on their own leave the pause in
+place, because resuming would move the audio to the machine's speakers -- but buds handed
+to the phone are coming back, and their pause has to survive until they do. So the ear
+watcher only drops the pause when handoff is not the one holding them, and handoff claims
+them *before* the disconnect rather than after: the buds go away between those two points,
+and the watcher runs in that gap. Both halves were found on a live call, not in review.
+
+**Handing the buds over gives up the AAP channel, and something else may take it.**
+Observed 2026-09-08: after a call, the buds came back and playback resumed, but battery
+and listening mode stayed empty and the status went to `busy` -- a competing AAP client on
+the same machine had claimed the single-client channel during the window when Tether had
+disconnected them. Nothing is wrong with the buds or the handoff; it is the conflict
+described above, made more likely by the disconnect. Tether keeps retrying and gets the
+channel back whenever the other program lets go.
+
+Reclaim is bounded: a settle delay, then three attempts, then it gives up and forgets
+them. The phone does not drop the buds the instant a call ends, and retrying forever
+would fight it for them. Releasing is synchronous because the phone is ringing now;
+reclaiming runs on its own thread because it has to wait.
+
+**What it does not cover.** Music or video playing on the iPhone is not a call, so
+nothing here reacts to it. Seeing that would mean the machine acting as an A2DP sink for
+the phone and reading `org.bluez.MediaPlayer1`, which is the opposite of "Keeping the
+phone's audio on the phone" below. Not attempted.
+
 The constants come from librepods `linux/airpods_packets.h`. The prose
 `docs/AAP Definitions.md` in the same repository disagrees with the header and is wrong.
 
@@ -656,6 +705,10 @@ checks the daemon does not make.
 | `tether --bt-calls` reports call control off | PipeWire took the profile *and* its telephony D-Bus service is off, the iPhone reconnected on its own and never opened hands-free, or `bluetoothd` is running without `--experimental` | Either give BlueZ the profile by dropping `hfp_hf` from `bluez5.roles`, or set `bluez5.telephony-dbus-service = true` and let Tether drive PipeWire's gateway -- see "Calls". The daemon cycles the BR/EDR bearer once per outage for the second cause; confirm with `busctl --system tree org.bluez \| grep telephony` and `busctl --user tree org.pipewire.Telephony` |
 | AirPods are listed but the battery stays blank, and the row says another program is using the channel | The AAP channel takes one client, and something else has it | Stop the other AirPods program (LibrePods, AirPods Center, a status-bar widget that reads battery). Nothing else releases it |
 | Setting the AirPods listening mode to `off` does nothing, while the other three work | The buds declined it. Apple leaves Off out of the noise-control rotation by default on Pro models, and there is no refusal to report | Add Off to the rotation on the phone, under Settings > Bluetooth > (i) > Noise Control. Tether keeps showing the mode the buds are actually in |
+| The AirPods handoff checkbox is greyed out | Handoff triggers on the iPhone's call state, and call control is off | Turn on calls first: `tether --bt-calls-enable on`, or the Calls page |
+| A call started but the AirPods stayed on this computer | They were not connected here when it started, or handoff is off | Nothing to do in the first case. Otherwise `tether --bt-airpods-handoff on` |
+| The AirPods came back after a call but playback did not resume | Fixed. Disconnecting the buds for the call used to clear the remembered players, so there was nothing left to resume | Nothing. Press play on an older build |
+| The AirPods did not come back after a call | The phone still had them after three attempts, so Tether gave up rather than fight it | Reconnect them from the phone or the Devices list. Playback is deliberately left paused |
 | Playback does not pause when a bud comes out | Pause on removal is off, which is the default | Set it on the AirPods page, or `tether --bt-airpods-pause one-removed` |
 | Playback pauses on removal but never resumes | Something else paused or stopped it in between, so the pause is no longer Tether's to undo. Or the buds disconnected, which deliberately leaves it paused | Press play. Both are working as designed |
 | AirPods do not appear in the Devices list at all | They are not connected, or BlueZ has never read their SDP record so there is no Modalias and the name does not contain "airpod" | Connect them, then `tether --bt-devices` -- the row carries an `airpods` flag when Tether recognizes them |

--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -10,7 +10,7 @@ Bluetooth accessory. No iOS-side code is involved.
 | Contacts, for sender names | **PBAP** (Phonebook Access Profile) via `obexd` | BR/EDR | OBEX client |
 | Notifications from any app | **ANCS** (Apple Notification Center Service) | BLE / GATT | GATT central |
 | Phone calls, place + answer | **HFP** (Hands-Free Profile) via BlueZ | BR/EDR | Hands-free unit |
-| AirPods battery + listening mode | **AAP** (Apple Accessory Protocol) | BR/EDR / L2CAP | L2CAP client |
+| AirPods battery, listening mode, in-ear | **AAP** (Apple Accessory Protocol) | BR/EDR / L2CAP | L2CAP client |
 
 The Tether iOS app is unrelated to these features and just keeps handling clipboard sync and file transfer over TCP + mTLS.
 
@@ -479,8 +479,8 @@ the narrower check; it rules out the `*`/`#` supplementary-service codes deliber
 
 ## AirPods
 
-Battery for the buds and the case, and the listening mode, in the Devices list and from
-`tether --bt-airpods`. No ear detection or stem control yet.
+Battery for the buds and the case, the listening mode, and in-ear detection, in the
+Devices list and from `tether --bt-airpods`. No stem control yet.
 
 It is the one feature here that does not go through BlueZ. AirPods report battery over
 Apple's Accessory Protocol on an L2CAP channel, PSM `0x1001`, the same source an iPhone
@@ -536,6 +536,40 @@ and a model with no listening mode at all reports none and the buttons stay disa
 Writes are queued for the reader thread rather than sent from the caller's, because the
 socket belongs to the session and closing it out from under a write is the one race worth
 not having. A queued change does not outlive the channel it was meant for.
+
+### In-ear detection, and pausing
+
+Eight bytes, `04 00 04 00 06 00 [primary] [secondary]`, with `00` in the ear, `01` out of
+it, `02` in the case and anything else unknown.
+
+They are a **primary and a secondary, not a left and a right**, and which bud is which
+moves between them. So nothing here names a side; the count of buds in ears is what the
+policy and the UI use.
+
+Taking a bud out can pause whatever is playing locally, over MPRIS. It is **off by
+default** -- `airpods_pause` in `bluetooth.json`, `never`, `one-removed` or `both-removed`
+-- for the same reason call control is: nothing reaches out and touches the user's session
+until they ask for it. `tether --bt-airpods-pause one-removed`, or the dropdown on the
+AirPods page.
+
+The policy is `ear_media_action()`, kept pure so its awkward cases are settled by tests
+rather than by taking earbuds out repeatedly:
+
+- **The first ear report after connecting is not a transition.** The buds say where they
+  already are as soon as the channel opens, and reading that as a change would pause the
+  music the moment a case is opened near the machine.
+- **Only a pause Tether made is undone.** Playback the user stopped by hand stays stopped.
+- A bud in the case counts the same as a bud out of the ear.
+- **Buds that disconnect entirely leave the pause in place.** Resuming there would move
+  the audio to the machine's own speakers, which is not what taking an earbud out asked
+  for.
+
+MPRIS itself is `src/core/src/mpris.cpp`, a plain session-bus client: `ListNames`, keep
+the `org.mpris.MediaPlayer2.` ones, pause the players reporting `Playing`, remember them,
+play those back. Calls carry `G_DBUS_CALL_FLAGS_NO_AUTO_START` and a one-second timeout,
+because a bus name can be *activatable* rather than running -- `playerctld` usually is --
+and neither starting a media player to interrogate it nor blocking the Bluetooth reader
+thread on one is acceptable.
 
 The constants come from librepods `linux/airpods_packets.h`. The prose
 `docs/AAP Definitions.md` in the same repository disagrees with the header and is wrong.
@@ -622,6 +656,8 @@ checks the daemon does not make.
 | `tether --bt-calls` reports call control off | PipeWire took the profile *and* its telephony D-Bus service is off, the iPhone reconnected on its own and never opened hands-free, or `bluetoothd` is running without `--experimental` | Either give BlueZ the profile by dropping `hfp_hf` from `bluez5.roles`, or set `bluez5.telephony-dbus-service = true` and let Tether drive PipeWire's gateway -- see "Calls". The daemon cycles the BR/EDR bearer once per outage for the second cause; confirm with `busctl --system tree org.bluez \| grep telephony` and `busctl --user tree org.pipewire.Telephony` |
 | AirPods are listed but the battery stays blank, and the row says another program is using the channel | The AAP channel takes one client, and something else has it | Stop the other AirPods program (LibrePods, AirPods Center, a status-bar widget that reads battery). Nothing else releases it |
 | Setting the AirPods listening mode to `off` does nothing, while the other three work | The buds declined it. Apple leaves Off out of the noise-control rotation by default on Pro models, and there is no refusal to report | Add Off to the rotation on the phone, under Settings > Bluetooth > (i) > Noise Control. Tether keeps showing the mode the buds are actually in |
+| Playback does not pause when a bud comes out | Pause on removal is off, which is the default | Set it on the AirPods page, or `tether --bt-airpods-pause one-removed` |
+| Playback pauses on removal but never resumes | Something else paused or stopped it in between, so the pause is no longer Tether's to undo. Or the buds disconnected, which deliberately leaves it paused | Press play. Both are working as designed |
 | AirPods do not appear in the Devices list at all | They are not connected, or BlueZ has never read their SDP record so there is no Modalias and the name does not contain "airpod" | Connect them, then `tether --bt-devices` -- the row carries an `airpods` flag when Tether recognizes them |
 | Calls work but the audio is on the iPhone | Working as designed. BlueZ signals the call and never opens the voice link, so there is nothing to route here | Nothing. `./scripts/bt-probe.sh --calls` during a call shows the evidence; "Getting the call audio onto the desktop instead" is the trade if you want it |
 | The Calls page is empty after configuring PipeWire for call audio | PipeWire's telephony D-Bus service is off, so neither stack exports anything Tether can read | Set `bluez5.telephony-dbus-service = true` and reconnect. With it on, Tether drives PipeWire's gateway directly and the Calls page works, minus carrier and signal |

--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -10,7 +10,7 @@ Bluetooth accessory. No iOS-side code is involved.
 | Contacts, for sender names | **PBAP** (Phonebook Access Profile) via `obexd` | BR/EDR | OBEX client |
 | Notifications from any app | **ANCS** (Apple Notification Center Service) | BLE / GATT | GATT central |
 | Phone calls, place + answer | **HFP** (Hands-Free Profile) via BlueZ | BR/EDR | Hands-free unit |
-| AirPods battery, buds + case | **AAP** (Apple Accessory Protocol) | BR/EDR / L2CAP | L2CAP client |
+| AirPods battery + listening mode | **AAP** (Apple Accessory Protocol) | BR/EDR / L2CAP | L2CAP client |
 
 The Tether iOS app is unrelated to these features and just keeps handling clipboard sync and file transfer over TCP + mTLS.
 
@@ -479,8 +479,8 @@ the narrower check; it rules out the `*`/`#` supplementary-service codes deliber
 
 ## AirPods
 
-Battery for the buds and the case, in the Devices list and from `tether --bt-airpods`.
-Read-only: no ANC, ear detection or stem control yet.
+Battery for the buds and the case, and the listening mode, in the Devices list and from
+`tether --bt-airpods`. No ear detection or stem control yet.
 
 It is the one feature here that does not go through BlueZ. AirPods report battery over
 Apple's Accessory Protocol on an L2CAP channel, PSM `0x1001`, the same source an iPhone
@@ -512,12 +512,38 @@ Case `0x08`. Status `0x04` means the component is not reporting — a bud in the
 shut case — which is shown as unknown, never as 0%. A notification carries only what
 changed, so anything it leaves out keeps its previous level.
 
+### Listening mode
+
+Off, Transparency, Adaptive and Noise Cancellation, set from the AirPods page in the GTK
+app or with `tether --bt-airpods-mode <off|anc|transparency|adaptive>`.
+
+Sent and received on the same 11-byte shape, `04 00 04 00 09 00 0D [mode] 00 00 00`, with
+the mode at offset 7. The wire values are one above the order the modes are usually listed
+in: `01` Off, `02` Noise Cancellation, `03` Transparency, `04` Adaptive.
+
+**A mode the buds decline is simply not applied, and they say nothing about it.** Measured
+2026-09-08 on AirPods Pro: `off` was sent three times and the buds stayed in the previous
+mode, while `anc`, `transparency` and `adaptive` all took effect within a second. Apple
+leaves Off out of the noise-control rotation by default on Pro models, and there is no
+error and no refusal packet -- the only evidence is that the mode notification never
+changes.
+
+So nothing here assumes a write succeeded. The published mode only ever comes from the
+buds' own notification, which they send unprompted on every change including the ones the
+desktop asked for. The GTK buttons snap back to the real mode when a write does not take,
+and a model with no listening mode at all reports none and the buttons stay disabled.
+
+Writes are queued for the reader thread rather than sent from the caller's, because the
+socket belongs to the session and closing it out from under a write is the one race worth
+not having. A queued change does not outlive the channel it was meant for.
+
 The constants come from librepods `linux/airpods_packets.h`. The prose
 `docs/AAP Definitions.md` in the same repository disagrees with the header and is wrong.
 
 `DeviceID = bluetooth:004C:0000:0000` in `/etc/bluetooth/main.conf` is **not** needed for
-this. It is what makes the machine present itself to the buds as Apple hardware, and
-reading battery does not require that.
+any of this. It is what makes the machine present itself to the buds as Apple hardware.
+Reading battery does not require it, and neither does setting the listening mode --
+confirmed 2026-09-08 with the setting absent from `main.conf` on the test machine.
 
 ### The channel takes one client
 
@@ -595,6 +621,7 @@ checks the daemon does not make.
 | The iPhone's audio moves to the computer when Tether connects | The machine advertises itself as a Bluetooth speaker/headset, and iOS routes to it. Not caused by Tether beyond bringing the link up | See "Keeping the phone's audio on the phone" below |
 | `tether --bt-calls` reports call control off | PipeWire took the profile *and* its telephony D-Bus service is off, the iPhone reconnected on its own and never opened hands-free, or `bluetoothd` is running without `--experimental` | Either give BlueZ the profile by dropping `hfp_hf` from `bluez5.roles`, or set `bluez5.telephony-dbus-service = true` and let Tether drive PipeWire's gateway -- see "Calls". The daemon cycles the BR/EDR bearer once per outage for the second cause; confirm with `busctl --system tree org.bluez \| grep telephony` and `busctl --user tree org.pipewire.Telephony` |
 | AirPods are listed but the battery stays blank, and the row says another program is using the channel | The AAP channel takes one client, and something else has it | Stop the other AirPods program (LibrePods, AirPods Center, a status-bar widget that reads battery). Nothing else releases it |
+| Setting the AirPods listening mode to `off` does nothing, while the other three work | The buds declined it. Apple leaves Off out of the noise-control rotation by default on Pro models, and there is no refusal to report | Add Off to the rotation on the phone, under Settings > Bluetooth > (i) > Noise Control. Tether keeps showing the mode the buds are actually in |
 | AirPods do not appear in the Devices list at all | They are not connected, or BlueZ has never read their SDP record so there is no Modalias and the name does not contain "airpod" | Connect them, then `tether --bt-devices` -- the row carries an `airpods` flag when Tether recognizes them |
 | Calls work but the audio is on the iPhone | Working as designed. BlueZ signals the call and never opens the voice link, so there is nothing to route here | Nothing. `./scripts/bt-probe.sh --calls` during a call shows the evidence; "Getting the call audio onto the desktop instead" is the trade if you want it |
 | The Calls page is empty after configuring PipeWire for call audio | PipeWire's telephony D-Bus service is off, so neither stack exports anything Tether can read | Set `bluez5.telephony-dbus-service = true` and reconnect. With it on, Tether drives PipeWire's gateway directly and the Calls page works, minus carrier and signal |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -333,6 +333,36 @@ The two `*_reason` strings are written for display (permission is off or a trans
 `map_error` and `pbap_error` name the classification: `forbidden` means the toggle on the phone is off,
 `busy` means another computer holds the phone's single MAP session.
 
+### AirPods
+
+Battery does not come from BlueZ. It arrives over Apple's AAP protocol on an L2CAP
+channel the daemon opens itself, so it is reported separately from `bt_devices` — whose
+entries only gain an `airpods` boolean saying which device the battery belongs to.
+
+#### `bt_airpods` (Client -> Daemon, answered directly; also Daemon -> Clients)
+**Payload**: `{"command": "bt_airpods"}`
+
+```json
+{
+  "command": "bt_airpods",
+  "address": "AA:BB:CC:DD:EE:FF",
+  "name": "AirPods Pro",
+  "left": 82,
+  "right": 79,
+  "case": 45,
+  "status": "live",
+  "reason": ""
+}
+```
+
+Broadcast when the published state changes, not on a timer. A level of `-1` means the
+component is not reporting — a bud in the case, or a shut case — and is not the same as
+a flat battery. An empty `address` means no AirPods are connected.
+
+`status` is `idle`, `connecting`, `live`, `busy` or `failed`. `busy` means another
+program holds the channel, which allows only one client at a time; `reason` carries the
+sentence to show.
+
 ### Messages
 
 #### `bt_list_threads` (Client -> Daemon, answered directly)

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -380,6 +380,12 @@ them, so `in_ear` carries the count and nothing names a side.
 Whether removing a bud pauses local playback: `never` (the default), `one-removed` or
 `both-removed`. Persisted, and reported back as `airpods_pause` in `bt_status`.
 
+#### `bt_airpods_handoff` (Client -> Daemon)
+**Payload**: `{"command": "bt_airpods_handoff", "enabled": true}`
+
+Whether an iPhone call hands the AirPods to the phone and takes them back after. Off by
+default, needs call control, and reported as `airpods_handoff` in `bt_status`.
+
 #### `bt_airpods_mode` (Client -> Daemon, answered directly)
 **Payload**: `{"command": "bt_airpods_mode", "mode": "transparency"}`
 **Response**: `{"command": "bt_airpods_mode_result", "success": true}`, or `success` false

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -350,6 +350,7 @@ entries only gain an `airpods` boolean saying which device the battery belongs t
   "left": 82,
   "right": 79,
   "case": 45,
+  "anc": "transparency",
   "status": "live",
   "reason": ""
 }
@@ -362,6 +363,22 @@ a flat battery. An empty `address` means no AirPods are connected.
 `status` is `idle`, `connecting`, `live`, `busy` or `failed`. `busy` means another
 program holds the channel, which allows only one client at a time; `reason` carries the
 sentence to show.
+
+`anc` is the listening mode: `off`, `anc`, `transparency`, `adaptive`, or null on a model
+that does not report one. It always reflects what the buds say they are doing, never what
+was last requested.
+
+#### `bt_airpods_mode` (Client -> Daemon, answered directly)
+**Payload**: `{"command": "bt_airpods_mode", "mode": "transparency"}`
+**Response**: `{"command": "bt_airpods_mode_result", "success": true}`, or `success` false
+with a `message`.
+
+Note the name: `bt_set_ancs` elsewhere in this file is Apple Notification Center Service,
+an unrelated feature.
+
+Success means the request reached the buds, not that they applied it. They decline a mode
+they are not configured for and report nothing, so the confirmation is the next
+`bt_airpods` broadcast carrying the mode that is actually in effect.
 
 ### Messages
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -351,6 +351,8 @@ entries only gain an `airpods` boolean saying which device the battery belongs t
   "right": 79,
   "case": 45,
   "anc": "transparency",
+  "ear": {"primary": "in_ear", "secondary": "out_of_ear"},
+  "in_ear": 1,
   "status": "live",
   "reason": ""
 }
@@ -367,6 +369,16 @@ sentence to show.
 `anc` is the listening mode: `off`, `anc`, `transparency`, `adaptive`, or null on a model
 that does not report one. It always reflects what the buds say they are doing, never what
 was last requested.
+
+`ear` is where each bud is: `in_ear`, `out_of_ear`, `in_case` or `unknown`. They are a
+primary and a secondary rather than a left and a right, and which is which moves between
+them, so `in_ear` carries the count and nothing names a side.
+
+#### `bt_airpods_pause` (Client -> Daemon)
+**Payload**: `{"command": "bt_airpods_pause", "mode": "one-removed"}`
+
+Whether removing a bud pauses local playback: `never` (the default), `one-removed` or
+`both-removed`. Persisted, and reported back as `airpods_pause` in `bt_status`.
 
 #### `bt_airpods_mode` (Client -> Daemon, answered directly)
 **Payload**: `{"command": "bt_airpods_mode", "mode": "transparency"}`

--- a/docs/man/man1/tether.1.in
+++ b/docs/man/man1/tether.1.in
@@ -94,6 +94,10 @@ Show AirPods battery, for each bud and the case, and the current listening mode.
 Set the AirPods listening mode. The buds decline a mode they are not configured for
 without reporting an error, so check the result with \fB\-\-bt-airpods\fR.
 .TP
+\fB\-\-bt-airpods-pause\fR \fInever\fR|\fIone-removed\fR|\fIboth-removed\fR
+Pause whatever is playing on this computer when an AirPod is removed, and start it again
+when the buds go back in. Off by default. Only playback Tether paused is resumed.
+.TP
 \fB\-\-bt-pair\fR \fIADDRESS\fR
 Pair with an iPhone over Bluetooth.
 .TP

--- a/docs/man/man1/tether.1.in
+++ b/docs/man/man1/tether.1.in
@@ -98,6 +98,10 @@ without reporting an error, so check the result with \fB\-\-bt-airpods\fR.
 Pause whatever is playing on this computer when an AirPod is removed, and start it again
 when the buds go back in. Off by default. Only playback Tether paused is resumed.
 .TP
+\fB\-\-bt-airpods-handoff\fR \fIon\fR|\fIoff\fR
+Hand the AirPods to the iPhone when it has a call and take them back afterwards. Off by
+default. Requires call control (\fB\-\-bt-calls-enable on\fR).
+.TP
 \fB\-\-bt-pair\fR \fIADDRESS\fR
 Pair with an iPhone over Bluetooth.
 .TP

--- a/docs/man/man1/tether.1.in
+++ b/docs/man/man1/tether.1.in
@@ -87,6 +87,13 @@ List Bluetooth devices known to BlueZ.
 \fB\-\-bt-connection\fR
 Show Bluetooth link and profile connection state.
 .TP
+\fB\-\-bt-airpods\fR
+Show AirPods battery, for each bud and the case, and the current listening mode.
+.TP
+\fB\-\-bt-airpods-mode\fR \fIoff\fR|\fIanc\fR|\fItransparency\fR|\fIadaptive\fR
+Set the AirPods listening mode. The buds decline a mode they are not configured for
+without reporting an error, so check the result with \fB\-\-bt-airpods\fR.
+.TP
 \fB\-\-bt-pair\fR \fIADDRESS\fR
 Pair with an iPhone over Bluetooth.
 .TP

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,5 @@
 src/cli/main.cpp
+src/core/src/bluetooth/airpods.cpp
 src/core/src/bluetooth/bearer_supervisor.cpp
 src/core/src/bluetooth/connection.cpp
 src/core/src/bluetooth/groups.cpp

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -96,8 +96,16 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "Nastavit režim poslechu AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Pozastavit místní přehrávání při vyjmutí AirPodu: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Pozastavit místní přehrávání při vyjmutí AirPodu: never, one-removed, both-"
+"removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Předat AirPods iPhonu během hovoru: on nebo off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -488,8 +496,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Použijte never, one-removed nebo both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Pozastavení při vyjmutí nastaveno na %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Použijte on nebo off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Hovor na iPhonu předá AirPods telefonu a po skončení je vrátí zpět."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "Předávání AirPods je vypnuto."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1836,8 +1857,24 @@ msgid "Both buds are removed"
 msgstr "Jsou vyjmuta obě sluchátka"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Pozastaví vše, co se na tomto počítači přehrává, a znovu to spustí, jakmile si sluchátka nasadíte. Obnoví se pouze přehrávání, které pozastavil Tether."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Pozastaví vše, co se na tomto počítači přehrává, a znovu to spustí, jakmile "
+"si sluchátka nasadíte. Obnoví se pouze přehrávání, které pozastavil Tether."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Hovory"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Předat AirPods iPhonu během hovoru"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Pozastaví přehrávání a odpojí AirPods, aby si je mohl převzít iPhone, a po skončení hovoru je znovu připojí. Vyžaduje ovládání hovorů a platí jen, když jsou sluchátka připojena k tomuto počítači."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1924,10 +1961,6 @@ msgstr "Ukončit"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Zařízení"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Hovory"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -94,6 +94,10 @@ msgstr "Zobrazit baterii AirPods a pouzdra."
 #: src/cli/main.cpp
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "Nastavit režim poslechu AirPods: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Pozastavit místní přehrávání při vyjmutí AirPodu: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -463,6 +467,10 @@ msgid "Case"
 msgstr "Pouzdro"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Nošení"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Nepodařilo se spojit s démonem.\n"
 
@@ -474,6 +482,14 @@ msgstr "Režim poslechu nastaven na %s.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Režim poslechu se nepodařilo nastavit."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Použijte never, one-removed nebo both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Pozastavení při vyjmutí nastaveno na %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1490,6 +1506,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Tato AirPods nehlásí režim poslechu."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Tato AirPods nehlásí, zda jsou nasazena."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Obě sluchátka jsou v uších."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Jedno sluchátko je v uchu."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Žádné sluchátko není v uchu."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Plný režim — zprávy, kontakty a oznámení."
 
@@ -1782,6 +1814,30 @@ msgstr "Hledat zařízení"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Režim poslechu"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Detekce v uchu"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Pozastavit přehrávání, když:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Nikdy"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Je vyjmuto jedno sluchátko"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Jsou vyjmuta obě sluchátka"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Pozastaví vše, co se na tomto počítači přehrává, a znovu to spustí, jakmile si sluchátka nasadíte. Obnoví se pouze přehrávání, které pozastavil Tether."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -90,6 +90,10 @@ msgstr "Zobrazit stav Bluetooth spojení a profilů."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Zobrazit baterii AirPods a pouzdra."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr "Nastavit režim poslechu AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -461,6 +465,15 @@ msgstr "Pouzdro"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Nepodařilo se spojit s démonem.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Režim poslechu nastaven na %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Režim poslechu se nepodařilo nastavit."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1235,6 +1248,14 @@ msgid "Not a DTMF sequence."
 msgstr "Není to sekvence DTMF."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Neznámý režim poslechu."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "Nejsou připojena žádná AirPods."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "Zrcadlení oznámení je již aktivní, není co dělat."
 
@@ -1447,6 +1468,26 @@ msgstr "Bluetooth není na tomto stroji dostupné."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Hledání zařízení v okolí..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Vypnuto"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Propustnost"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Adaptivní"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Potlačení hluku"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Tato AirPods nehlásí režim poslechu."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1737,6 +1778,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Hledat zařízení"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Režim poslechu"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -86,6 +86,10 @@ msgstr "Vypsat Bluetooth zařízení známá BlueZ."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Zobrazit stav Bluetooth spojení a profilů."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Zobrazit baterii AirPods a pouzdra."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -431,6 +435,27 @@ msgstr "Nepodařilo se načíst Bluetooth zařízení od démona.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ nezná žádná Bluetooth zařízení.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Nepodařilo se načíst baterii AirPods z démona.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nejsou připojena žádná AirPods.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Levé"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Pravé"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Pouzdro"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -781,6 +806,18 @@ msgstr "Výběr adaptéru je automatický: první zapnutý.\n"
 msgid "Using controller {}."
 msgstr "Používá se adaptér {}."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Adresu AirPods se nepodařilo přečíst."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Sokety Bluetooth nejsou v tomto systému dostupné."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Kanál AirPods používá jiný program."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -813,7 +850,9 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Tento počítač připnul párování na BR/EDR, což odmítá spojení LE, které iPhone otevírá pro přenos oznámení. Nyní se to ruší; LE by se mělo navázat do minuty. Nic na iPhonu to nezmění a opětovné spárování také ne."
+"Tento počítač připnul párování na BR/EDR, což odmítá spojení LE, které "
+"iPhone otevírá pro přenos oznámení. Nyní se to ruší; LE by se mělo navázat "
+"do minuty. Nic na iPhonu to nezmění a opětovné spárování také ne."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1377,6 +1416,20 @@ msgstr "Démon Tether neběží."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Démon je online"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "L"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "P"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Načítání baterie…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -441,6 +441,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Nepodařilo se načíst baterii AirPods z démona.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "Nejsou připojena žádná AirPods.\n"
 
@@ -2062,6 +2063,7 @@ msgstr "připojeno"
 msgid "not connected"
 msgstr "nepřipojeno"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -90,6 +90,10 @@ msgstr "Zustand von Bluetooth-Verbindung und Profilen anzeigen."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Akkustand der AirPods und des Ladecase anzeigen."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr "AirPods-Hörmodus setzen: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -459,6 +463,15 @@ msgstr "Case"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Der Daemon war nicht erreichbar.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Hörmodus auf %s gesetzt.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Der Hörmodus konnte nicht gesetzt werden."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1264,6 +1277,14 @@ msgid "Not a DTMF sequence."
 msgstr "Keine DTMF-Folge."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Unbekannter Hörmodus."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "Es sind keine AirPods verbunden."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "Die Spiegelung von Mitteilungen ist bereits aktiv, nichts zu tun."
 
@@ -1477,6 +1498,26 @@ msgstr "Bluetooth ist auf diesem Rechner nicht verfügbar."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Suche nach Geräten in der Nähe..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Aus"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Transparenzmodus"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Adaptiv"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Geräuschunterdrückung"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Diese AirPods melden keinen Hörmodus."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1772,6 +1813,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Nach Geräten suchen"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Hörmodus"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -94,6 +94,10 @@ msgstr "Akkustand der AirPods und des Ladecase anzeigen."
 #: src/cli/main.cpp
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "AirPods-Hörmodus setzen: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Lokale Wiedergabe pausieren, wenn ein AirPod herausgenommen wird: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -461,6 +465,10 @@ msgid "Case"
 msgstr "Case"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Getragen"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Der Daemon war nicht erreichbar.\n"
 
@@ -472,6 +480,14 @@ msgstr "Hörmodus auf %s gesetzt.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Der Hörmodus konnte nicht gesetzt werden."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Verwenden Sie never, one-removed oder both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Pause beim Herausnehmen auf %s gesetzt.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1520,6 +1536,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Diese AirPods melden keinen Hörmodus."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Diese AirPods melden nicht, ob sie getragen werden."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Beide Hörer sind eingesetzt."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Ein Hörer ist eingesetzt."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Kein Hörer ist eingesetzt."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Vollmodus — Nachrichten, Kontakte und Mitteilungen."
 
@@ -1817,6 +1849,30 @@ msgstr "Nach Geräten suchen"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Hörmodus"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Trageerkennung"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Wiedergabe pausieren, wenn:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Nie"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Ein Hörer herausgenommen wird"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Beide Hörer herausgenommen werden"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Pausiert alles, was auf diesem Computer läuft, und setzt es fort, sobald die Hörer wieder eingesetzt sind. Nur von Tether pausierte Wiedergabe wird fortgesetzt."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -439,6 +439,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Der Akkustand der AirPods konnte nicht vom Daemon gelesen werden.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "Keine AirPods verbunden.\n"
 
@@ -2108,6 +2109,7 @@ msgstr "verbunden"
 msgid "not connected"
 msgstr "nicht verbunden"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -96,8 +96,16 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "AirPods-Hörmodus setzen: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Lokale Wiedergabe pausieren, wenn ein AirPod herausgenommen wird: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Lokale Wiedergabe pausieren, wenn ein AirPod herausgenommen wird: never, one-"
+"removed, both-removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "AirPods während eines Anrufs an das iPhone übergeben: on oder off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -486,8 +494,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Verwenden Sie never, one-removed oder both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Pause beim Herausnehmen auf %s gesetzt.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Verwenden Sie on oder off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Ein iPhone-Anruf übergibt die AirPods an das Telefon und holt sie danach zurück."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "Die AirPods-Übergabe ist aus."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1871,8 +1892,25 @@ msgid "Both buds are removed"
 msgstr "Beide Hörer herausgenommen werden"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Pausiert alles, was auf diesem Computer läuft, und setzt es fort, sobald die Hörer wieder eingesetzt sind. Nur von Tether pausierte Wiedergabe wird fortgesetzt."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Pausiert alles, was auf diesem Computer läuft, und setzt es fort, sobald die "
+"Hörer wieder eingesetzt sind. Nur von Tether pausierte Wiedergabe wird "
+"fortgesetzt."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Anrufe"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "AirPods während eines Anrufs an das iPhone übergeben"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Pausiert die Wiedergabe und trennt die AirPods, damit das iPhone sie übernehmen kann, und verbindet sie nach dem Anruf wieder. Erfordert Anrufsteuerung und gilt nur, solange die Hörer mit diesem Computer verbunden sind."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1960,10 +1998,6 @@ msgstr "Beenden"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Geräte"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Anrufe"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -86,6 +86,10 @@ msgstr "Die BlueZ bekannten Bluetooth-Geräte auflisten."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Zustand von Bluetooth-Verbindung und Profilen anzeigen."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Akkustand der AirPods und des Ladecase anzeigen."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -429,6 +433,27 @@ msgstr "Die Bluetooth-Geräte konnten nicht vom Daemon gelesen werden.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ sind keine Bluetooth-Geräte bekannt.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Der Akkustand der AirPods konnte nicht vom Daemon gelesen werden.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Keine AirPods verbunden.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Links"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Rechts"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Case"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -789,6 +814,18 @@ msgstr "Die Adapterauswahl ist automatisch: der erste eingeschaltete.\n"
 msgid "Using controller {}."
 msgstr "Adapter {} wird verwendet."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Die AirPods-Adresse konnte nicht gelesen werden."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Bluetooth-Sockets sind auf diesem System nicht verfügbar."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Ein anderes Programm verwendet den AirPods-Kanal."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -821,7 +858,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Dieser Computer hatte die Kopplung auf BR/EDR festgelegt, wodurch die LE-Verbindung abgelehnt wird, die das iPhone für Benachrichtigungen öffnet. Das wird gerade rückgängig gemacht; LE sollte innerhalb einer Minute zustande kommen. Daran ändert weder etwas am iPhone noch ein erneutes Koppeln etwas."
+"Dieser Computer hatte die Kopplung auf BR/EDR festgelegt, wodurch die LE-"
+"Verbindung abgelehnt wird, die das iPhone für Benachrichtigungen öffnet. Das "
+"wird gerade rückgängig gemacht; LE sollte innerhalb einer Minute zustande "
+"kommen. Daran ändert weder etwas am iPhone noch ein erneutes Koppeln etwas."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1406,6 +1446,20 @@ msgstr "Der Tether-Daemon läuft nicht."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Daemon online"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "L"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "R"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Akkustand wird gelesen…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -91,6 +91,12 @@ msgstr "Mostrar el estado del enlace y de los perfiles Bluetooth."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Mostrar la batería de los AirPods y del estuche."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr ""
+"Establecer el modo de escucha de los AirPods: off, anc, transparency, "
+"adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -461,6 +467,15 @@ msgstr "Estuche"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "No se pudo contactar con el daemon.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Modo de escucha establecido en %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "No se pudo establecer el modo de escucha."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1253,6 +1268,14 @@ msgid "Not a DTMF sequence."
 msgstr "No es una secuencia DTMF."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Modo de escucha desconocido."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "No hay AirPods conectados."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr ""
 "La duplicación de notificaciones ya está activa; no hay nada que hacer."
@@ -1468,6 +1491,26 @@ msgstr "Bluetooth no está disponible en este equipo."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Buscando dispositivos cercanos..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Desactivado"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Transparencia"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Adaptativo"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Cancelación de ruido"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Estos AirPods no informan de un modo de escucha."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1762,6 +1805,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Buscar dispositivos"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Modo de escucha"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -97,6 +97,10 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr ""
 "Establecer el modo de escucha de los AirPods: off, anc, transparency, "
 "adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Pausar la reproducción local al quitar un AirPod: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -465,6 +469,10 @@ msgid "Case"
 msgstr "Estuche"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Puestos"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "No se pudo contactar con el daemon.\n"
 
@@ -476,6 +484,14 @@ msgstr "Modo de escucha establecido en %s.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "No se pudo establecer el modo de escucha."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Use never, one-removed o both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Pausa al quitarlos establecida en %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1513,6 +1529,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Estos AirPods no informan de un modo de escucha."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Estos AirPods no informan de si se están llevando puestos."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Ambos auriculares están puestos."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Un auricular está puesto."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Ningún auricular está puesto."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Modo completo — mensajes, contactos y notificaciones."
 
@@ -1809,6 +1841,30 @@ msgstr "Buscar dispositivos"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Modo de escucha"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Detección en el oído"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Pausar la reproducción cuando:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Nunca"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Se quite un auricular"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Se quiten ambos auriculares"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Pausa lo que se esté reproduciendo en este equipo y lo reanuda cuando vuelvas a ponerte los auriculares. Solo se reanuda la reproducción que pausó Tether."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -99,8 +99,16 @@ msgstr ""
 "adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Pausar la reproducción local al quitar un AirPod: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Pausar la reproducción local al quitar un AirPod: never, one-removed, both-"
+"removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Pasar los AirPods al iPhone durante una llamada: on u off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -490,8 +498,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Use never, one-removed o both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Pausa al quitarlos establecida en %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Use on u off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Una llamada en el iPhone pasará los AirPods al teléfono y los recuperará al terminar."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "El traspaso de los AirPods está desactivado."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1863,8 +1884,25 @@ msgid "Both buds are removed"
 msgstr "Se quiten ambos auriculares"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Pausa lo que se esté reproduciendo en este equipo y lo reanuda cuando vuelvas a ponerte los auriculares. Solo se reanuda la reproducción que pausó Tether."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Pausa lo que se esté reproduciendo en este equipo y lo reanuda cuando "
+"vuelvas a ponerte los auriculares. Solo se reanuda la reproducción que pausó "
+"Tether."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Llamadas"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Pasar los AirPods al iPhone durante una llamada"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Pausa la reproducción y desconecta los AirPods para que el iPhone pueda tomarlos, y los vuelve a conectar cuando termina la llamada. Requiere control de llamadas y solo se aplica mientras los auriculares están conectados a este equipo."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1952,10 +1990,6 @@ msgstr "Salir"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Dispositivos"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Llamadas"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -441,6 +441,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "No se pudo leer la batería de los AirPods desde el demonio.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "No hay AirPods conectados.\n"
 
@@ -2095,6 +2096,7 @@ msgstr "conectado"
 msgid "not connected"
 msgstr "no conectado"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -87,6 +87,10 @@ msgstr "Listar los dispositivos Bluetooth conocidos por BlueZ."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Mostrar el estado del enlace y de los perfiles Bluetooth."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Mostrar la batería de los AirPods y del estuche."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -431,6 +435,27 @@ msgstr "No se pudieron leer los dispositivos Bluetooth del daemon.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ no conoce ningún dispositivo Bluetooth.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "No se pudo leer la batería de los AirPods desde el demonio.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "No hay AirPods conectados.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Izq."
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Der."
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Estuche"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -786,6 +811,18 @@ msgstr "La selección de adaptador es automática: el primero encendido.\n"
 msgid "Using controller {}."
 msgstr "Usando el adaptador {}."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "No se pudo leer la dirección de los AirPods."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Los sockets Bluetooth no están disponibles en este sistema."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Otro programa está usando el canal de los AirPods."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -818,7 +855,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Este equipo había fijado el emparejamiento en BR/EDR, lo que rechaza el enlace LE que el iPhone abre para transportar las notificaciones. Se está deshaciendo ahora; LE debería establecerse en menos de un minuto. Nada en el iPhone cambia esto, y volver a emparejar tampoco."
+"Este equipo había fijado el emparejamiento en BR/EDR, lo que rechaza el "
+"enlace LE que el iPhone abre para transportar las notificaciones. Se está "
+"deshaciendo ahora; LE debería establecerse en menos de un minuto. Nada en el "
+"iPhone cambia esto, y volver a emparejar tampoco."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1397,6 +1437,20 @@ msgstr "El daemon de Tether no se está ejecutando."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Daemon conectado"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "I"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "D"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Leyendo la batería…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -99,8 +99,16 @@ msgstr ""
 "Définir le mode d'écoute des AirPods : off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Mettre en pause la lecture locale au retrait d'un AirPods : never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Mettre en pause la lecture locale au retrait d'un AirPods : never, one-"
+"removed, both-removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Confier les AirPods à l'iPhone pendant un appel : on ou off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -493,8 +501,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Utilisez never, one-removed ou both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Pause au retrait réglée sur %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Utilisez on ou off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Un appel sur l'iPhone lui confiera les AirPods et les récupérera ensuite."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "Le transfert des AirPods est désactivé."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1870,8 +1891,25 @@ msgid "Both buds are removed"
 msgstr "Les deux écouteurs sont retirés"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Met en pause ce qui est lu sur cet ordinateur et le relance quand les écouteurs sont remis en place. Seule la lecture mise en pause par Tether est relancée."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Met en pause ce qui est lu sur cet ordinateur et le relance quand les "
+"écouteurs sont remis en place. Seule la lecture mise en pause par Tether est "
+"relancée."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Appels"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Confier les AirPods à l'iPhone pendant un appel"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Met la lecture en pause et déconnecte les AirPods pour que l'iPhone puisse les prendre, puis les reconnecte à la fin de l'appel. Nécessite la gestion des appels et ne s'applique que tant que les écouteurs sont connectés à cet ordinateur."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1959,10 +1997,6 @@ msgstr "Quitter"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Appareils"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Appels"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -445,6 +445,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Impossible de lire la batterie des AirPods depuis le démon.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "Aucun AirPods connecté.\n"
 
@@ -2105,6 +2106,7 @@ msgstr "connecté"
 msgid "not connected"
 msgstr "non connecté"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -88,6 +88,10 @@ msgstr "Lister les appareils Bluetooth connus de BlueZ."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Afficher l'état du lien et des profils Bluetooth."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Afficher la batterie des AirPods et du boîtier."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -435,6 +439,27 @@ msgstr "Impossible de lire les appareils Bluetooth depuis le démon.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "Aucun appareil Bluetooth connu de BlueZ.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Impossible de lire la batterie des AirPods depuis le démon.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Aucun AirPods connecté.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Gauche"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Droite"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Boîtier"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -791,6 +816,18 @@ msgstr "La sélection de l'adaptateur est automatique : le premier allumé.\n"
 msgid "Using controller {}."
 msgstr "Utilisation de l'adaptateur {}."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Impossible de lire l'adresse des AirPods."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Les sockets Bluetooth ne sont pas disponibles sur ce système."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Un autre programme utilise le canal des AirPods."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -823,7 +860,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Cet ordinateur avait épinglé l'appairage sur BR/EDR, ce qui refuse le lien LE que l'iPhone ouvre pour transporter les notifications. C'est en train d'être corrigé ; le LE devrait s'établir en moins d'une minute. Rien sur l'iPhone n'y change quoi que ce soit, et refaire l'appairage non plus."
+"Cet ordinateur avait épinglé l'appairage sur BR/EDR, ce qui refuse le lien "
+"LE que l'iPhone ouvre pour transporter les notifications. C'est en train "
+"d'être corrigé ; le LE devrait s'établir en moins d'une minute. Rien sur "
+"l'iPhone n'y change quoi que ce soit, et refaire l'appairage non plus."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1405,6 +1445,20 @@ msgstr "Le démon Tether n'est pas lancé."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Démon en ligne"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "G"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "D"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Lecture de la batterie…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -92,6 +92,11 @@ msgstr "Afficher l'état du lien et des profils Bluetooth."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Afficher la batterie des AirPods et du boîtier."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr ""
+"Définir le mode d'écoute des AirPods : off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -465,6 +470,15 @@ msgstr "Boîtier"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Impossible de joindre le démon.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Mode d'écoute réglé sur %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Impossible de régler le mode d'écoute."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1261,6 +1275,14 @@ msgid "Not a DTMF sequence."
 msgstr "Séquence DTMF invalide."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Mode d'écoute inconnu."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "Aucun AirPods connecté."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "La duplication des notifications est déjà active, rien à faire."
 
@@ -1476,6 +1498,26 @@ msgstr "Bluetooth est indisponible sur cette machine."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Recherche d'appareils à proximité..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Désactivé"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Transparence"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Adaptatif"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Réduction de bruit"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Ces AirPods ne signalent pas de mode d'écoute."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1770,6 +1812,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Rechercher des appareils"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Mode d'écoute"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -97,6 +97,10 @@ msgstr "Afficher la batterie des AirPods et du boîtier."
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr ""
 "Définir le mode d'écoute des AirPods : off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Mettre en pause la lecture locale au retrait d'un AirPods : never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -468,6 +472,10 @@ msgid "Case"
 msgstr "Boîtier"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Portés"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Impossible de joindre le démon.\n"
 
@@ -479,6 +487,14 @@ msgstr "Mode d'écoute réglé sur %s.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Impossible de régler le mode d'écoute."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Utilisez never, one-removed ou both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Pause au retrait réglée sur %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1520,6 +1536,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Ces AirPods ne signalent pas de mode d'écoute."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Ces AirPods ne signalent pas s'ils sont portés."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Les deux écouteurs sont en place."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Un écouteur est en place."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Aucun écouteur n'est en place."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Mode complet — messages, contacts et notifications."
 
@@ -1816,6 +1848,30 @@ msgstr "Rechercher des appareils"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Mode d'écoute"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Détection de port"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Mettre en pause la lecture quand :"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Jamais"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Un écouteur est retiré"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Les deux écouteurs sont retirés"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Met en pause ce qui est lu sur cet ordinateur et le relance quand les écouteurs sont remis en place. Seule la lecture mise en pause par Tether est relancée."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -92,6 +92,12 @@ msgstr "Mostra lo stato del collegamento Bluetooth e dei profili."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Mostra la batteria degli AirPods e della custodia."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr ""
+"Imposta la modalità di ascolto degli AirPods: off, anc, transparency, "
+"adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -461,6 +467,15 @@ msgstr "Custodia"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Impossibile raggiungere il daemon.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Modalità di ascolto impostata su %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Impossibile impostare la modalità di ascolto."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1254,6 +1269,14 @@ msgid "Not a DTMF sequence."
 msgstr "Non è una sequenza DTMF."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Modalità di ascolto sconosciuta."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "Nessun AirPods connesso."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "Il mirroring delle notifiche è già attivo, non c'è nulla da fare."
 
@@ -1467,6 +1490,26 @@ msgstr "Bluetooth non è disponibile su questa macchina."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Ricerca di dispositivi nelle vicinanze..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Disattivata"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Trasparenza"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Adattiva"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Cancellazione del rumore"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Questi AirPods non segnalano una modalità di ascolto."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1762,6 +1805,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Cerca dispositivi"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Modalità di ascolto"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -441,6 +441,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Impossibile leggere la batteria degli AirPods dal demone.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "Nessun AirPods connesso.\n"
 
@@ -2096,6 +2097,7 @@ msgstr "connesso"
 msgid "not connected"
 msgstr "non connesso"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -98,6 +98,10 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr ""
 "Imposta la modalità di ascolto degli AirPods: off, anc, transparency, "
 "adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Metti in pausa la riproduzione locale quando un AirPod viene rimosso: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -465,6 +469,10 @@ msgid "Case"
 msgstr "Custodia"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Indossati"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Impossibile raggiungere il daemon.\n"
 
@@ -476,6 +484,14 @@ msgstr "Modalità di ascolto impostata su %s.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Impossibile impostare la modalità di ascolto."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Usa never, one-removed o both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Pausa alla rimozione impostata su %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1512,6 +1528,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Questi AirPods non segnalano una modalità di ascolto."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Questi AirPods non segnalano se sono indossati."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Entrambi gli auricolari sono indossati."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Un auricolare è indossato."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Nessun auricolare è indossato."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Modalità completa — messaggi, contatti e notifiche."
 
@@ -1809,6 +1841,30 @@ msgstr "Cerca dispositivi"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Modalità di ascolto"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Rilevamento nell'orecchio"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Metti in pausa la riproduzione quando:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Mai"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Un auricolare viene rimosso"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Entrambi gli auricolari vengono rimossi"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Mette in pausa ciò che è in riproduzione su questo computer e lo riavvia quando gli auricolari vengono rimessi. Viene ripresa solo la riproduzione messa in pausa da Tether."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -88,6 +88,10 @@ msgstr "Elenca i dispositivi Bluetooth noti a BlueZ."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Mostra lo stato del collegamento Bluetooth e dei profili."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Mostra la batteria degli AirPods e della custodia."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -431,6 +435,27 @@ msgstr "Impossibile leggere i dispositivi Bluetooth dal daemon.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "Nessun dispositivo Bluetooth noto a BlueZ.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Impossibile leggere la batteria degli AirPods dal demone.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nessun AirPods connesso.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Sinistro"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Destro"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Custodia"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -786,6 +811,18 @@ msgstr "La selezione dell'adattatore è automatica: il primo acceso.\n"
 msgid "Using controller {}."
 msgstr "Uso dell'adattatore {}."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Impossibile leggere l'indirizzo degli AirPods."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "I socket Bluetooth non sono disponibili su questo sistema."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Un altro programma sta usando il canale degli AirPods."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -818,7 +855,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Questo computer aveva bloccato l'associazione su BR/EDR, il che rifiuta il collegamento LE che l'iPhone apre per trasportare le notifiche. Ora viene annullato; LE dovrebbe attivarsi entro un minuto. Nulla sull'iPhone cambia questo, e nemmeno rifare l'associazione."
+"Questo computer aveva bloccato l'associazione su BR/EDR, il che rifiuta il "
+"collegamento LE che l'iPhone apre per trasportare le notifiche. Ora viene "
+"annullato; LE dovrebbe attivarsi entro un minuto. Nulla sull'iPhone cambia "
+"questo, e nemmeno rifare l'associazione."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1396,6 +1436,20 @@ msgstr "Il daemon di Tether non è in esecuzione."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Daemon online"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "S"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "D"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Lettura della batteria…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -100,8 +100,16 @@ msgstr ""
 "adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Metti in pausa la riproduzione locale quando un AirPod viene rimosso: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Metti in pausa la riproduzione locale quando un AirPod viene rimosso: never, "
+"one-removed, both-removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Passa gli AirPods all'iPhone durante una chiamata: on oppure off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -490,8 +498,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Usa never, one-removed o both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Pausa alla rimozione impostata su %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Usa on oppure off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Una chiamata sull'iPhone gli passerà gli AirPods e li riprenderà al termine."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "Il passaggio degli AirPods è disattivato."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1863,8 +1884,25 @@ msgid "Both buds are removed"
 msgstr "Entrambi gli auricolari vengono rimossi"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Mette in pausa ciò che è in riproduzione su questo computer e lo riavvia quando gli auricolari vengono rimessi. Viene ripresa solo la riproduzione messa in pausa da Tether."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Mette in pausa ciò che è in riproduzione su questo computer e lo riavvia "
+"quando gli auricolari vengono rimessi. Viene ripresa solo la riproduzione "
+"messa in pausa da Tether."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Chiamate"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Passa gli AirPods all'iPhone durante una chiamata"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Mette in pausa la riproduzione e disconnette gli AirPods perché l'iPhone possa prenderli, poi li riconnette al termine della chiamata. Richiede il controllo delle chiamate e si applica solo mentre gli auricolari sono connessi a questo computer."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1951,10 +1989,6 @@ msgstr "Esci"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Dispositivi"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Chiamate"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -95,6 +95,10 @@ msgstr "AirPods とケースのバッテリーを表示します。"
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr ""
 "AirPods のリスニングモードを設定します: off, anc, transparency, adaptive。"
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "AirPod を外したときにローカル再生を一時停止します: never, one-removed, both-removed。"
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -454,6 +458,10 @@ msgid "Case"
 msgstr "ケース"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "装着"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "デーモンに接続できませんでした。\n"
 
@@ -465,6 +473,14 @@ msgstr "リスニングモードを %s に設定しました。\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "リスニングモードを設定できませんでした。"
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "never、one-removed、both-removed のいずれかを指定してください。\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "取り外し時の一時停止を %s に設定しました。\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1483,6 +1499,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "この AirPods はリスニングモードを報告しません。"
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "この AirPods は装着状態を報告しません。"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "両方のイヤホンを装着しています。"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "片方のイヤホンを装着しています。"
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "イヤホンを装着していません。"
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "フルモード — メッセージ、連絡先、通知。"
 
@@ -1775,6 +1807,30 @@ msgstr "デバイスを検索"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "リスニングモード"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "装着検出"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "再生を一時停止する条件:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "しない"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "片方を外したとき"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "両方を外したとき"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "このコンピュータで再生中のものを一時停止し、イヤホンを装着し直すと再開します。Tether が一時停止した再生のみを再開します。"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -90,6 +90,11 @@ msgstr "Bluetooth リンクとプロファイルの接続状態を表示しま�
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "AirPods とケースのバッテリーを表示します。"
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr ""
+"AirPods のリスニングモードを設定します: off, anc, transparency, adaptive。"
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -451,6 +456,15 @@ msgstr "ケース"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "デーモンに接続できませんでした。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "リスニングモードを %s に設定しました。\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "リスニングモードを設定できませんでした。"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1227,6 +1241,14 @@ msgid "Not a DTMF sequence."
 msgstr "DTMF シーケンスではありません。"
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "不明なリスニングモードです。"
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "AirPods が接続されていません。"
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "通知のミラーリングはすでに有効です。操作は不要です。"
 
@@ -1439,6 +1461,26 @@ msgstr "このマシンでは Bluetooth を利用できません。"
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "近くのデバイスを検索しています..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "オフ"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "外部音取り込み"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "アダプティブ"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "ノイズキャンセリング"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "この AirPods はリスニングモードを報告しません。"
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1729,6 +1771,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "デバイスを検索"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "リスニングモード"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -97,8 +97,16 @@ msgstr ""
 "AirPods のリスニングモードを設定します: off, anc, transparency, adaptive。"
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "AirPod を外したときにローカル再生を一時停止します: never, one-removed, both-removed。"
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"AirPod を外したときにローカル再生を一時停止します: never, one-removed, both-"
+"removed。"
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "通話中に AirPods を iPhone へ渡します: on または off。"
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -479,8 +487,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "never、one-removed、both-removed のいずれかを指定してください。\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "取り外し時の一時停止を %s に設定しました。\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "on または off を指定してください。\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "iPhone の通話で AirPods を iPhone に渡し、終了後に戻します。"
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "AirPods の受け渡しはオフです。"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1829,8 +1850,24 @@ msgid "Both buds are removed"
 msgstr "両方を外したとき"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "このコンピュータで再生中のものを一時停止し、イヤホンを装着し直すと再開します。Tether が一時停止した再生のみを再開します。"
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"このコンピュータで再生中のものを一時停止し、イヤホンを装着し直すと再開しま"
+"す。Tether が一時停止した再生のみを再開します。"
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "通話"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "通話中に AirPods を iPhone へ渡す"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "再生を一時停止して AirPods を切断し、iPhone が使えるようにします。通話が終わると再接続します。通話制御が必要で、イヤホンがこのコンピュータに接続されている間だけ適用されます。"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1917,10 +1954,6 @@ msgstr "終了"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "デバイス"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "通話"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -86,6 +86,10 @@ msgstr "BlueZ が認識している Bluetooth デバイスを一覧表示しま�
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Bluetooth リンクとプロファイルの接続状態を表示します。"
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "AirPods とケースのバッテリーを表示します。"
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -421,6 +425,27 @@ msgstr "デーモンから Bluetooth デバイスを読み取れませんでし�
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ が認識している Bluetooth デバイスはありません。\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "デーモンから AirPods のバッテリーを読み取れませんでした。\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "AirPods は接続されていません。\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "左"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "右"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "ケース"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -770,6 +795,18 @@ msgstr ""
 msgid "Using controller {}."
 msgstr "アダプタ {} を使用します。"
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "AirPods のアドレスを読み取れませんでした。"
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "このシステムでは Bluetooth ソケットを利用できません。"
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "別のプログラムが AirPods のチャンネルを使用しています。"
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -802,7 +839,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"このコンピュータがペアリングを BR/EDR に固定していたため、iPhone が通知を運ぶために開く LE リンクが拒否されています。現在それを解除しています。LE は 1 分以内に接続するはずです。iPhone 側で変えられることはなく、ペアリングし直しても変わりません。"
+"このコンピュータがペアリングを BR/EDR に固定していたため、iPhone が通知を運ぶ"
+"ために開く LE リンクが拒否されています。現在それを解除しています。LE は 1 分"
+"以内に接続するはずです。iPhone 側で変えられることはなく、ペアリングし直しても"
+"変わりません。"
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1368,6 +1408,20 @@ msgstr "Tether デーモンが動作していません。"
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "デーモンはオンライン"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "左"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "右"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "バッテリーを読み取り中…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -431,6 +431,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "デーモンから AirPods のバッテリーを読み取れませんでした。\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "AirPods は接続されていません。\n"
 
@@ -2060,6 +2061,7 @@ msgstr "接続済み"
 msgid "not connected"
 msgstr "未接続"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -93,6 +93,10 @@ msgstr "AirPods 및 케이스 배터리를 표시합니다."
 #: src/cli/main.cpp
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "AirPods 청취 모드를 설정합니다: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "AirPod을 뺐을 때 로컬 재생을 일시정지합니다: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -451,6 +455,10 @@ msgid "Case"
 msgstr "케이스"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "착용"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "데몬에 연결하지 못했습니다.\n"
 
@@ -462,6 +470,14 @@ msgstr "청취 모드를 %s(으)로 설정했습니다.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "청취 모드를 설정할 수 없습니다."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "never, one-removed 또는 both-removed 중에서 선택하세요.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "제거 시 일시정지를 %s(으)로 설정했습니다.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1465,6 +1481,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "이 AirPods는 청취 모드를 보고하지 않습니다."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "이 AirPods는 착용 여부를 보고하지 않습니다."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "양쪽 이어버드를 착용 중입니다."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "한쪽 이어버드를 착용 중입니다."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "이어버드를 착용하지 않았습니다."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "전체 모드 — 메시지, 연락처, 알림."
 
@@ -1753,6 +1785,30 @@ msgstr "기기 검색"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "청취 모드"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "착용 감지"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "재생을 일시정지할 때:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "안 함"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "한쪽을 뺐을 때"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "양쪽을 뺐을 때"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "이 컴퓨터에서 재생 중인 것을 일시정지하고, 이어버드를 다시 착용하면 재생을 재개합니다. Tether가 일시정지한 재생만 재개됩니다."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -95,8 +95,16 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "AirPods 청취 모드를 설정합니다: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "AirPod을 뺐을 때 로컬 재생을 일시정지합니다: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"AirPod을 뺐을 때 로컬 재생을 일시정지합니다: never, one-removed, both-"
+"removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "통화 중에 AirPods를 iPhone에 넘깁니다: on 또는 off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -476,8 +484,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "never, one-removed 또는 both-removed 중에서 선택하세요.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "제거 시 일시정지를 %s(으)로 설정했습니다.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "on 또는 off를 사용하세요.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "iPhone 통화 시 AirPods를 전화기에 넘기고 통화가 끝나면 다시 가져옵니다."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "AirPods 전환이 꺼져 있습니다."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1807,8 +1828,24 @@ msgid "Both buds are removed"
 msgstr "양쪽을 뺐을 때"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "이 컴퓨터에서 재생 중인 것을 일시정지하고, 이어버드를 다시 착용하면 재생을 재개합니다. Tether가 일시정지한 재생만 재개됩니다."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"이 컴퓨터에서 재생 중인 것을 일시정지하고, 이어버드를 다시 착용하면 재생을 재"
+"개합니다. Tether가 일시정지한 재생만 재개됩니다."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "통화"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "통화 중에 AirPods를 iPhone에 넘기기"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "재생을 일시정지하고 AirPods 연결을 끊어 iPhone이 사용할 수 있게 한 뒤, 통화가 끝나면 다시 연결합니다. 통화 제어가 필요하며 이어버드가 이 컴퓨터에 연결되어 있을 때만 적용됩니다."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1894,10 +1931,6 @@ msgstr "종료"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "기기"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "통화"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -85,6 +85,10 @@ msgstr "BlueZ가 알고 있는 Bluetooth 기기를 나열합니다."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Bluetooth 링크와 프로파일의 연결 상태를 표시합니다."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "AirPods 및 케이스 배터리를 표시합니다."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -419,6 +423,27 @@ msgstr "데몬에서 Bluetooth 기기를 읽지 못했습니다.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ가 알고 있는 Bluetooth 기기가 없습니다.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "데몬에서 AirPods 배터리를 읽을 수 없습니다.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "연결된 AirPods가 없습니다.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "왼쪽"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "오른쪽"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "케이스"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -763,6 +788,18 @@ msgstr "어댑터 선택은 자동입니다. 전원이 켜진 첫 번째 어댑�
 msgid "Using controller {}."
 msgstr "어댑터 {}을(를) 사용합니다."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "AirPods 주소를 읽을 수 없습니다."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "이 시스템에서는 Bluetooth 소켓을 사용할 수 없습니다."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "다른 프로그램이 AirPods 채널을 사용 중입니다."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -794,7 +831,9 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"이 컴퓨터가 페어링을 BR/EDR로 고정해 두어, iPhone이 알림을 전달하려고 여는 LE 링크가 거부되고 있습니다. 지금 되돌리는 중이며, LE는 1분 이내에 연결될 것입니다. iPhone에서 바꿀 수 있는 것은 없으며, 다시 페어링해도 마찬가지입니다."
+"이 컴퓨터가 페어링을 BR/EDR로 고정해 두어, iPhone이 알림을 전달하려고 여는 "
+"LE 링크가 거부되고 있습니다. 지금 되돌리는 중이며, LE는 1분 이내에 연결될 것"
+"입니다. iPhone에서 바꿀 수 있는 것은 없으며, 다시 페어링해도 마찬가지입니다."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1352,6 +1391,20 @@ msgstr "Tether 데몬이 실행 중이 아닙니다."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "데몬 온라인"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "좌"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "우"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "배터리를 읽는 중…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -89,6 +89,10 @@ msgstr "Bluetooth 링크와 프로파일의 연결 상태를 표시합니다."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "AirPods 및 케이스 배터리를 표시합니다."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr "AirPods 청취 모드를 설정합니다: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -449,6 +453,15 @@ msgstr "케이스"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "데몬에 연결하지 못했습니다.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "청취 모드를 %s(으)로 설정했습니다.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "청취 모드를 설정할 수 없습니다."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1213,6 +1226,14 @@ msgid "Not a DTMF sequence."
 msgstr "DTMF 시퀀스가 아닙니다."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "알 수 없는 청취 모드입니다."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "연결된 AirPods가 없습니다."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "알림 미러링이 이미 활성 상태입니다. 할 일이 없습니다."
 
@@ -1422,6 +1443,26 @@ msgstr "이 컴퓨터에서는 Bluetooth를 사용할 수 없습니다."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "근처 기기를 검색하는 중..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "끔"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "주변음 허용"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "적응형"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "노이즈 캔슬링"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "이 AirPods는 청취 모드를 보고하지 않습니다."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1708,6 +1749,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "기기 검색"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "청취 모드"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -429,6 +429,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "데몬에서 AirPods 배터리를 읽을 수 없습니다.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "연결된 AirPods가 없습니다.\n"
 
@@ -2033,6 +2034,7 @@ msgstr "연결됨"
 msgid "not connected"
 msgstr "연결 안 됨"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -86,6 +86,10 @@ msgstr "Bluetooth-apparaten tonen die BlueZ kent."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Status van de Bluetooth-verbinding en van de profielen tonen."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Accu van de AirPods en de case tonen."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -429,6 +433,27 @@ msgstr "Kon de Bluetooth-apparaten niet van de daemon lezen.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ kent geen Bluetooth-apparaten.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Kon de accu van de AirPods niet uitlezen via de daemon.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Geen AirPods verbonden.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Links"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Rechts"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Case"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -779,6 +804,18 @@ msgstr "Adapterkeuze is automatisch: de eerste ingeschakelde.\n"
 msgid "Using controller {}."
 msgstr "Adapter {} wordt gebruikt."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Het adres van de AirPods kon niet worden gelezen."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Bluetooth-sockets zijn niet beschikbaar op dit systeem."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Een ander programma gebruikt het AirPods-kanaal."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -811,7 +848,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Deze computer had de koppeling vastgezet op BR/EDR, waardoor de LE-verbinding die de iPhone opent voor meldingen wordt geweigerd. Dat wordt nu ongedaan gemaakt; LE zou binnen een minuut tot stand moeten komen. Niets op de iPhone verandert dit, en opnieuw koppelen ook niet."
+"Deze computer had de koppeling vastgezet op BR/EDR, waardoor de LE-"
+"verbinding die de iPhone opent voor meldingen wordt geweigerd. Dat wordt nu "
+"ongedaan gemaakt; LE zou binnen een minuut tot stand moeten komen. Niets op "
+"de iPhone verandert dit, en opnieuw koppelen ook niet."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1388,6 +1428,20 @@ msgstr "De Tether-daemon draait niet."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Daemon online"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "L"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "R"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Accu uitlezen…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -439,6 +439,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Kon de accu van de AirPods niet uitlezen via de daemon.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "Geen AirPods verbonden.\n"
 
@@ -2080,6 +2081,7 @@ msgstr "verbonden"
 msgid "not connected"
 msgstr "niet verbonden"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -97,8 +97,16 @@ msgstr ""
 "De luistermodus van de AirPods instellen: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Lokale weergave pauzeren wanneer een AirPod wordt uitgenomen: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Lokale weergave pauzeren wanneer een AirPod wordt uitgenomen: never, one-"
+"removed, both-removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "De AirPods tijdens een gesprek aan de iPhone geven: on of off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -487,8 +495,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Gebruik never, one-removed of both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Pauzeren bij uitnemen ingesteld op %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Gebruik on of off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Een gesprek op de iPhone geeft de AirPods aan de telefoon en haalt ze daarna terug."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "AirPods-overdracht staat uit."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1851,8 +1872,24 @@ msgid "Both buds are removed"
 msgstr "Beide oordopjes worden uitgenomen"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Pauzeert wat er op deze computer speelt en start het weer wanneer de oordopjes terug in gaan. Alleen weergave die Tether pauzeerde wordt hervat."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Pauzeert wat er op deze computer speelt en start het weer wanneer de "
+"oordopjes terug in gaan. Alleen weergave die Tether pauzeerde wordt hervat."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Oproepen"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "De AirPods tijdens een gesprek aan de iPhone geven"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Pauzeert de weergave en verbreekt de verbinding met de AirPods zodat de iPhone ze kan overnemen, en verbindt ze na het gesprek weer. Vereist gespreksbediening en geldt alleen zolang de oordopjes met deze computer verbonden zijn."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1939,10 +1976,6 @@ msgstr "Afsluiten"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Apparaten"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Oproepen"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -95,6 +95,10 @@ msgstr "Accu van de AirPods en de case tonen."
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr ""
 "De luistermodus van de AirPods instellen: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Lokale weergave pauzeren wanneer een AirPod wordt uitgenomen: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -462,6 +466,10 @@ msgid "Case"
 msgstr "Case"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Gedragen"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Kon de daemon niet bereiken.\n"
 
@@ -473,6 +481,14 @@ msgstr "Luistermodus ingesteld op %s.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "De luistermodus kon niet worden ingesteld."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Gebruik never, one-removed of both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Pauzeren bij uitnemen ingesteld op %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1503,6 +1519,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Deze AirPods melden geen luistermodus."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Deze AirPods melden niet of ze gedragen worden."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Beide oordopjes zijn in."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Eén oordopje is in."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Geen enkel oordopje is in."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Volledige modus — berichten, contacten en meldingen."
 
@@ -1797,6 +1829,30 @@ msgstr "Zoek apparaten"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Luistermodus"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Draagdetectie"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Weergave pauzeren wanneer:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Nooit"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Eén oordopje wordt uitgenomen"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Beide oordopjes worden uitgenomen"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Pauzeert wat er op deze computer speelt en start het weer wanneer de oordopjes terug in gaan. Alleen weergave die Tether pauzeerde wordt hervat."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -90,6 +90,11 @@ msgstr "Status van de Bluetooth-verbinding en van de profielen tonen."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Accu van de AirPods en de case tonen."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr ""
+"De luistermodus van de AirPods instellen: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -459,6 +464,15 @@ msgstr "Case"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Kon de daemon niet bereiken.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Luistermodus ingesteld op %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "De luistermodus kon niet worden ingesteld."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1245,6 +1259,14 @@ msgid "Not a DTMF sequence."
 msgstr "Geen DTMF-reeks."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Onbekende luistermodus."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "Er zijn geen AirPods verbonden."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "Het spiegelen van meldingen is al actief, niets te doen."
 
@@ -1459,6 +1481,26 @@ msgstr "Bluetooth is niet beschikbaar op deze machine."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Zoeken naar apparaten in de buurt..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Uit"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Transparantie"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Adaptief"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Ruisonderdrukking"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Deze AirPods melden geen luistermodus."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1751,6 +1793,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Zoek apparaten"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Luistermodus"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -95,6 +95,10 @@ msgstr "Pokaż poziom baterii AirPods i etui."
 #: src/cli/main.cpp
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "Ustaw tryb słuchania AirPods: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Wstrzymaj lokalne odtwarzanie po wyjęciu AirPoda: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -466,6 +470,10 @@ msgid "Case"
 msgstr "Etui"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Noszone"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Nie udało się połączyć z demonem.\n"
 
@@ -477,6 +485,14 @@ msgstr "Tryb słuchania ustawiony na %s.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Nie można ustawić trybu słuchania."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Użyj never, one-removed lub both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Wstrzymanie przy wyjęciu ustawione na %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1504,6 +1520,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Te AirPods nie zgłaszają trybu słuchania."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Te AirPods nie zgłaszają, czy są noszone."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Obie słuchawki są w uszach."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Jedna słuchawka jest w uchu."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Żadna słuchawka nie jest w uchu."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Tryb pełny — wiadomości, kontakty i powiadomienia."
 
@@ -1797,6 +1829,30 @@ msgstr "Szukaj urządzeń"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Tryb słuchania"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Wykrywanie w uchu"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Wstrzymaj odtwarzanie, gdy:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Nigdy"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Wyjęta zostanie jedna słuchawka"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Wyjęte zostaną obie słuchawki"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Wstrzymuje to, co jest odtwarzane na tym komputerze, i uruchamia ponownie, gdy słuchawki wrócą do uszu. Wznawiane jest tylko odtwarzanie wstrzymane przez Tether."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -87,6 +87,10 @@ msgstr "Wypisz urządzenia Bluetooth znane BlueZ."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Pokaż stan połączenia Bluetooth i profili."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Pokaż poziom baterii AirPods i etui."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -434,6 +438,27 @@ msgstr "Nie udało się odczytać urządzeń Bluetooth od demona.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ nie zna żadnych urządzeń Bluetooth.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Nie można odczytać poziomu baterii AirPods z demona.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nie podłączono żadnych AirPods.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Lewa"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Prawa"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Etui"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -785,6 +810,18 @@ msgstr "Wybór adaptera jest automatyczny: pierwszy włączony.\n"
 msgid "Using controller {}."
 msgstr "Używany adapter: {}."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Nie można odczytać adresu AirPods."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Gniazda Bluetooth są niedostępne w tym systemie."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Inny program używa kanału AirPods."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -817,7 +854,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Ten komputer przypiął powiązanie do BR/EDR, co odrzuca połączenie LE otwierane przez iPhone'a do przesyłania powiadomień. Właśnie jest to cofane; LE powinno pojawić się w ciągu minuty. Nic w iPhonie tego nie zmieni, ponowne parowanie również nie."
+"Ten komputer przypiął powiązanie do BR/EDR, co odrzuca połączenie LE "
+"otwierane przez iPhone'a do przesyłania powiadomień. Właśnie jest to cofane; "
+"LE powinno pojawić się w ciągu minuty. Nic w iPhonie tego nie zmieni, "
+"ponowne parowanie również nie."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1390,6 +1430,20 @@ msgstr "Demon Tether nie działa."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Demon online"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "L"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "P"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Odczytywanie baterii…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -91,6 +91,10 @@ msgstr "Pokaż stan połączenia Bluetooth i profili."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Pokaż poziom baterii AirPods i etui."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr "Ustaw tryb słuchania AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -464,6 +468,15 @@ msgstr "Etui"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Nie udało się połączyć z demonem.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Tryb słuchania ustawiony na %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Nie można ustawić trybu słuchania."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1248,6 +1261,14 @@ msgid "Not a DTMF sequence."
 msgstr "To nie jest sekwencja DTMF."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Nieznany tryb słuchania."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "Nie podłączono żadnych AirPods."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "Kopiowanie powiadomień jest już aktywne, nie ma nic do zrobienia."
 
@@ -1461,6 +1482,26 @@ msgstr "Bluetooth jest niedostępny na tej maszynie."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Wyszukiwanie urządzeń w pobliżu..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Wyłączony"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Przepuszczanie dźwięku"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Adaptacyjny"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Redukcja szumów"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Te AirPods nie zgłaszają trybu słuchania."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1752,6 +1793,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Szukaj urządzeń"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Tryb słuchania"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -97,8 +97,16 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "Ustaw tryb słuchania AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Wstrzymaj lokalne odtwarzanie po wyjęciu AirPoda: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Wstrzymaj lokalne odtwarzanie po wyjęciu AirPoda: never, one-removed, both-"
+"removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Przekaż AirPods do iPhone’a na czas rozmowy: on lub off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -491,8 +499,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Użyj never, one-removed lub both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Wstrzymanie przy wyjęciu ustawione na %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Użyj on lub off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Rozmowa na iPhonie przekaże mu AirPods, a po jej zakończeniu odbierze je z powrotem."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "Przekazywanie AirPods jest wyłączone."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1851,8 +1872,25 @@ msgid "Both buds are removed"
 msgstr "Wyjęte zostaną obie słuchawki"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Wstrzymuje to, co jest odtwarzane na tym komputerze, i uruchamia ponownie, gdy słuchawki wrócą do uszu. Wznawiane jest tylko odtwarzanie wstrzymane przez Tether."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Wstrzymuje to, co jest odtwarzane na tym komputerze, i uruchamia ponownie, "
+"gdy słuchawki wrócą do uszu. Wznawiane jest tylko odtwarzanie wstrzymane "
+"przez Tether."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Połączenia"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Przekaż AirPods do iPhone’a na czas rozmowy"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Wstrzymuje odtwarzanie i rozłącza AirPods, aby iPhone mógł je przejąć, a po zakończeniu rozmowy łączy je ponownie. Wymaga obsługi połączeń i działa tylko wtedy, gdy słuchawki są połączone z tym komputerem."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1939,10 +1977,6 @@ msgstr "Zakończ"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Urządzenia"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Połączenia"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -444,6 +444,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Nie można odczytać poziomu baterii AirPods z demona.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "Nie podłączono żadnych AirPods.\n"
 
@@ -2083,6 +2084,7 @@ msgstr "połączono"
 msgid "not connected"
 msgstr "nie połączono"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -91,6 +91,11 @@ msgstr "Mostrar o estado do enlace Bluetooth e dos perfis."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Mostrar a bateria dos AirPods e do estojo."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr ""
+"Definir o modo de escuta dos AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -459,6 +464,15 @@ msgstr "Estojo"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Não foi possível alcançar o daemon.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Modo de escuta definido como %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Não foi possível definir o modo de escuta."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1249,6 +1263,14 @@ msgid "Not a DTMF sequence."
 msgstr "Não é uma sequência DTMF."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Modo de escuta desconhecido."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "Nenhum AirPods conectado."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "O espelhamento de notificações já está ativo; nada a fazer."
 
@@ -1462,6 +1484,26 @@ msgstr "O Bluetooth está indisponível nesta máquina."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Procurando dispositivos por perto..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Desativado"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Transparência"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Adaptativo"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Cancelamento de ruído"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Estes AirPods não informam um modo de escuta."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1754,6 +1796,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Procurar dispositivos"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Modo de escuta"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -96,6 +96,10 @@ msgstr "Mostrar a bateria dos AirPods e do estojo."
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr ""
 "Definir o modo de escuta dos AirPods: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Pausar a reprodução local ao remover um AirPod: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -462,6 +466,10 @@ msgid "Case"
 msgstr "Estojo"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Em uso"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Não foi possível alcançar o daemon.\n"
 
@@ -473,6 +481,14 @@ msgstr "Modo de escuta definido como %s.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Não foi possível definir o modo de escuta."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Use never, one-removed ou both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Pausa ao remover definida como %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1506,6 +1522,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Estes AirPods não informam um modo de escuta."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Estes AirPods não informam se estão sendo usados."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Os dois fones estão colocados."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Um fone está colocado."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Nenhum fone está colocado."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Modo completo — mensagens, contatos e notificações."
 
@@ -1800,6 +1832,30 @@ msgstr "Procurar dispositivos"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Modo de escuta"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Detecção de uso"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Pausar a reprodução quando:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Nunca"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Um fone for removido"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Os dois fones forem removidos"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Pausa o que estiver tocando neste computador e retoma quando os fones voltarem aos ouvidos. Só é retomada a reprodução que o Tether pausou."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -98,8 +98,16 @@ msgstr ""
 "Definir o modo de escuta dos AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Pausar a reprodução local ao remover um AirPod: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Pausar a reprodução local ao remover um AirPod: never, one-removed, both-"
+"removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Passar os AirPods para o iPhone durante uma chamada: on ou off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -487,8 +495,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Use never, one-removed ou both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Pausa ao remover definida como %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Use on ou off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Uma chamada no iPhone passará os AirPods para o telefone e os trará de volta depois."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "A transferência dos AirPods está desativada."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1854,8 +1875,24 @@ msgid "Both buds are removed"
 msgstr "Os dois fones forem removidos"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Pausa o que estiver tocando neste computador e retoma quando os fones voltarem aos ouvidos. Só é retomada a reprodução que o Tether pausou."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Pausa o que estiver tocando neste computador e retoma quando os fones "
+"voltarem aos ouvidos. Só é retomada a reprodução que o Tether pausou."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Chamadas"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Passar os AirPods para o iPhone durante uma chamada"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Pausa a reprodução e desconecta os AirPods para que o iPhone possa assumi-los, e os reconecta quando a chamada termina. Requer controle de chamadas e só se aplica enquanto os fones estiverem conectados a este computador."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1942,10 +1979,6 @@ msgstr "Sair"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Dispositivos"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Chamadas"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -439,6 +439,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Não foi possível ler a bateria dos AirPods do daemon.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "Nenhum AirPods conectado.\n"
 
@@ -2083,6 +2084,7 @@ msgstr "conectado"
 msgid "not connected"
 msgstr "não conectado"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -87,6 +87,10 @@ msgstr "Listar os dispositivos Bluetooth conhecidos pelo BlueZ."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Mostrar o estado do enlace Bluetooth e dos perfis."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Mostrar a bateria dos AirPods e do estojo."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -429,6 +433,27 @@ msgstr "Não foi possível ler os dispositivos Bluetooth no daemon.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "Nenhum dispositivo Bluetooth conhecido pelo BlueZ.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Não foi possível ler a bateria dos AirPods do daemon.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nenhum AirPods conectado.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Esq."
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Dir."
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Estojo"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -782,6 +807,18 @@ msgstr "A seleção de adaptador é automática: o primeiro ligado.\n"
 msgid "Using controller {}."
 msgstr "Usando o adaptador {}."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Não foi possível ler o endereço dos AirPods."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Os sockets Bluetooth não estão disponíveis neste sistema."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Outro programa está usando o canal dos AirPods."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -814,7 +851,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Este computador havia fixado o pareamento em BR/EDR, o que recusa o enlace LE que o iPhone abre para transportar as notificações. Isso está sendo desfeito agora; o LE deve subir em menos de um minuto. Nada no iPhone muda isso, e parear novamente também não."
+"Este computador havia fixado o pareamento em BR/EDR, o que recusa o enlace "
+"LE que o iPhone abre para transportar as notificações. Isso está sendo "
+"desfeito agora; o LE deve subir em menos de um minuto. Nada no iPhone muda "
+"isso, e parear novamente também não."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1391,6 +1431,20 @@ msgstr "O daemon do Tether não está em execução."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Daemon online"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "E"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "D"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Lendo a bateria…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -97,8 +97,16 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "Задать режим прослушивания AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Ставить локальное воспроизведение на паузу при извлечении AirPod: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Ставить локальное воспроизведение на паузу при извлечении AirPod: never, one-"
+"removed, both-removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Передавать AirPods на iPhone во время звонка: on или off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -491,8 +499,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Используйте never, one-removed или both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Пауза при извлечении установлена на %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Используйте on или off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Звонок на iPhone передаст AirPods телефону и вернёт их обратно после завершения."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "Передача AirPods выключена."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1852,8 +1873,25 @@ msgid "Both buds are removed"
 msgstr "Извлечены оба наушника"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Ставит на паузу то, что воспроизводится на этом компьютере, и запускает снова, когда наушники возвращаются в уши. Возобновляется только воспроизведение, поставленное на паузу Tether."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Ставит на паузу то, что воспроизводится на этом компьютере, и запускает "
+"снова, когда наушники возвращаются в уши. Возобновляется только "
+"воспроизведение, поставленное на паузу Tether."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Вызовы"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Передавать AirPods на iPhone во время звонка"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Ставит воспроизведение на паузу и отключает AirPods, чтобы их мог забрать iPhone, а после звонка подключает их обратно. Требуется управление звонками; действует, только пока наушники подключены к этому компьютеру."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1940,10 +1978,6 @@ msgstr "Выйти"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Устройства"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Вызовы"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -444,6 +444,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Не удалось получить заряд AirPods от службы.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "AirPods не подключены.\n"
 
@@ -2084,6 +2085,7 @@ msgstr "подключено"
 msgid "not connected"
 msgstr "не подключено"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -95,6 +95,10 @@ msgstr "Показать заряд AirPods и футляра."
 #: src/cli/main.cpp
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "Задать режим прослушивания AirPods: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Ставить локальное воспроизведение на паузу при извлечении AirPod: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -466,6 +470,10 @@ msgid "Case"
 msgstr "Футляр"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "В ушах"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Не удалось связаться с демоном.\n"
 
@@ -477,6 +485,14 @@ msgstr "Режим прослушивания установлен на %s.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Не удалось задать режим прослушивания."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Используйте never, one-removed или both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Пауза при извлечении установлена на %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1502,6 +1518,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Эти AirPods не сообщают режим прослушивания."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Эти AirPods не сообщают, надеты ли они."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Оба наушника в ушах."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Один наушник в ухе."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Ни один наушник не в ухе."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Полный режим — сообщения, контакты и уведомления."
 
@@ -1798,6 +1830,30 @@ msgstr "Искать устройства"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Режим прослушивания"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Определение в ухе"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Ставить на паузу, когда:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Никогда"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Извлечён один наушник"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Извлечены оба наушника"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Ставит на паузу то, что воспроизводится на этом компьютере, и запускает снова, когда наушники возвращаются в уши. Возобновляется только воспроизведение, поставленное на паузу Tether."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -87,6 +87,10 @@ msgstr "Показать устройства Bluetooth, известные Blue
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Показать состояние соединения Bluetooth и профилей."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Показать заряд AirPods и футляра."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -434,6 +438,27 @@ msgstr "Не удалось прочитать устройства Bluetooth у
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ не знает ни одного устройства Bluetooth.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Не удалось получить заряд AirPods от службы.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "AirPods не подключены.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Левый"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Правый"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Футляр"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -787,6 +812,18 @@ msgstr "Выбор адаптера автоматический: первый �
 msgid "Using controller {}."
 msgstr "Используется адаптер {}."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Не удалось прочитать адрес AirPods."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Сокеты Bluetooth недоступны в этой системе."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Канал AirPods занят другой программой."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -819,7 +856,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Этот компьютер закрепил сопряжение за BR/EDR, из-за чего отклоняется LE-соединение, которое iPhone открывает для передачи уведомлений. Сейчас это отменяется; LE должно установиться в течение минуты. Ничто на iPhone этого не изменит, повторное сопряжение тоже."
+"Этот компьютер закрепил сопряжение за BR/EDR, из-за чего отклоняется LE-"
+"соединение, которое iPhone открывает для передачи уведомлений. Сейчас это "
+"отменяется; LE должно установиться в течение минуты. Ничто на iPhone этого "
+"не изменит, повторное сопряжение тоже."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1388,6 +1428,20 @@ msgstr "Демон Tether не запущен."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Демон в сети"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "Л"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "П"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Чтение заряда…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -91,6 +91,10 @@ msgstr "Показать состояние соединения Bluetooth и п
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Показать заряд AirPods и футляра."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr "Задать режим прослушивания AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -464,6 +468,15 @@ msgstr "Футляр"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Не удалось связаться с демоном.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Режим прослушивания установлен на %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Не удалось задать режим прослушивания."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1246,6 +1259,14 @@ msgid "Not a DTMF sequence."
 msgstr "Это не последовательность DTMF."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Неизвестный режим прослушивания."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "AirPods не подключены."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "Дублирование уведомлений уже активно, делать ничего не нужно."
 
@@ -1459,6 +1480,26 @@ msgstr "Bluetooth недоступен на этой машине."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Поиск устройств поблизости..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Выключено"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Прозрачность"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Адаптивный"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Шумоподавление"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Эти AirPods не сообщают режим прослушивания."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1753,6 +1794,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Искать устройства"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Режим прослушивания"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -97,8 +97,16 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "Ställ in AirPods lyssningsläge: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Pausa lokal uppspelning när en AirPod tas ur: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Pausa lokal uppspelning när en AirPod tas ur: never, one-removed, both-"
+"removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Lämna över AirPods till iPhone under ett samtal: on eller off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -484,8 +492,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Använd never, one-removed eller both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Paus vid urtagning inställd på %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Använd on eller off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Ett samtal på iPhone lämnar över AirPods till telefonen och tar tillbaka dem efteråt."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "Överlämning av AirPods är av."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1833,8 +1854,24 @@ msgid "Both buds are removed"
 msgstr "Båda propparna tas ur"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Pausar det som spelas på den här datorn och startar det igen när propparna sätts i. Endast uppspelning som Tether pausat återupptas."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Pausar det som spelas på den här datorn och startar det igen när propparna "
+"sätts i. Endast uppspelning som Tether pausat återupptas."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Samtal"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Lämna över AirPods till iPhone under ett samtal"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Pausar uppspelningen och kopplar från AirPods så att iPhone kan ta över dem, och ansluter dem igen när samtalet är slut. Kräver samtalsstyrning och gäller bara medan propparna är anslutna till den här datorn."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1922,10 +1959,6 @@ msgstr "Avsluta"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Enheter"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Samtal"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -437,6 +437,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Kunde inte läsa AirPods batterinivå från demonen.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "Inga AirPods anslutna.\n"
 
@@ -2063,6 +2064,7 @@ msgstr "ansluten"
 msgid "not connected"
 msgstr "inte ansluten"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -91,6 +91,10 @@ msgstr "Visa status för Bluetooth-länken och profilerna."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Visa batterinivå för AirPods och etui."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr "Ställ in AirPods lyssningsläge: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -457,6 +461,15 @@ msgstr "Etui"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Kunde inte nå demonen.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Lyssningsläget är inställt på %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Lyssningsläget kunde inte ställas in."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1233,6 +1246,14 @@ msgid "Not a DTMF sequence."
 msgstr "Inte en DTMF-sekvens."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Okänt lyssningsläge."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "Inga AirPods anslutna."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "Spegling av aviseringar är redan aktiv, inget att göra."
 
@@ -1443,6 +1464,26 @@ msgstr "Bluetooth är otillgängligt på den här maskinen."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Söker efter enheter i närheten..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Av"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Genomsläpp"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Adaptivt"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Brusreducering"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "De här AirPods rapporterar inget lyssningsläge."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1734,6 +1775,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Sök efter enheter"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Lyssningsläge"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -87,6 +87,10 @@ msgstr "Lista de Bluetooth-enheter som BlueZ känner till."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Visa status för Bluetooth-länken och profilerna."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Visa batterinivå för AirPods och etui."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -427,6 +431,27 @@ msgstr "Kunde inte läsa Bluetooth-enheterna från demonen.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ känner inte till några Bluetooth-enheter.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Kunde inte läsa AirPods batterinivå från demonen.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Inga AirPods anslutna.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Vänster"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Höger"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Etui"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -778,6 +803,18 @@ msgstr "Adaptervalet är automatiskt: den första påslagna.\n"
 msgid "Using controller {}."
 msgstr "Använder adapter {}."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Kunde inte läsa AirPods-adressen."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Bluetooth-socketar är inte tillgängliga på det här systemet."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Ett annat program använder AirPods-kanalen."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -810,7 +847,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Den här datorn hade låst kopplingen till BR/EDR, vilket avvisar den LE-länk som iPhone öppnar för att bära aviseringar. Det håller på att ångras nu; LE bör komma upp inom en minut. Inget på iPhone ändrar detta, och att koppla om gör det inte heller."
+"Den här datorn hade låst kopplingen till BR/EDR, vilket avvisar den LE-länk "
+"som iPhone öppnar för att bära aviseringar. Det håller på att ångras nu; LE "
+"bör komma upp inom en minut. Inget på iPhone ändrar detta, och att koppla om "
+"gör det inte heller."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1372,6 +1412,20 @@ msgstr "Tether-demonen körs inte."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Demonen är online"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "V"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "H"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Läser batterinivå…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -95,6 +95,10 @@ msgstr "Visa batterinivå för AirPods och etui."
 #: src/cli/main.cpp
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "Ställ in AirPods lyssningsläge: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Pausa lokal uppspelning när en AirPod tas ur: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -459,6 +463,10 @@ msgid "Case"
 msgstr "Etui"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Bärs"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Kunde inte nå demonen.\n"
 
@@ -470,6 +478,14 @@ msgstr "Lyssningsläget är inställt på %s.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Lyssningsläget kunde inte ställas in."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Använd never, one-removed eller both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Paus vid urtagning inställd på %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1486,6 +1502,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "De här AirPods rapporterar inget lyssningsläge."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "De här AirPods rapporterar inte om de bärs."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Båda propparna sitter i."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "En propp sitter i."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Ingen propp sitter i."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Fullt läge — meddelanden, kontakter och aviseringar."
 
@@ -1779,6 +1811,30 @@ msgstr "Sök efter enheter"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Lyssningsläge"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Bärdetektering"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Pausa uppspelning när:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Aldrig"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "En propp tas ur"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Båda propparna tas ur"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Pausar det som spelas på den här datorn och startar det igen när propparna sätts i. Endast uppspelning som Tether pausat återupptas."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether 0.2.27\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -417,6 +421,15 @@ msgstr ""
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -1111,6 +1124,14 @@ msgid "Not a DTMF sequence."
 msgstr ""
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr ""
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr ""
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr ""
 
@@ -1313,6 +1334,26 @@ msgstr ""
 
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
 msgstr ""
 
 #: src/gtk/devices_view.cpp
@@ -1575,6 +1616,10 @@ msgstr ""
 
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
 msgstr ""
 
 #: src/gtk/devices_view.cpp

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether 0.2.27\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,6 +98,10 @@ msgstr ""
 msgid ""
 "Pause local playback when an AirPod is removed: never, one-removed, both-"
 "removed."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -449,6 +453,19 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "Pause on removal set to %s.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid ""
+"An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -1683,6 +1700,21 @@ msgid ""
 "buds go back in. Only playback Tether paused is resumed."
 msgstr ""
 
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid ""
+"Pauses playback and disconnects the AirPods so the iPhone can take them, "
+"then reconnects them when the call ends. Needs call control, and only "
+"applies while the buds are connected to this computer."
+msgstr ""
+
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
 msgstr ""
@@ -1760,10 +1792,6 @@ msgstr ""
 
 #: src/gtk/main.cpp
 msgid "Devices"
-msgstr ""
-
-#: src/gtk/main.cpp
-msgid "Calls"
 msgstr ""
 
 #: src/gtk/main.cpp

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether 0.2.27\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,6 +92,12 @@ msgstr ""
 
 #: src/cli/main.cpp
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -420,6 +426,10 @@ msgid "Case"
 msgstr ""
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr ""
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr ""
 
@@ -430,6 +440,15 @@ msgstr ""
 
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Pause on removal set to %s.\n"
 msgstr ""
 
 #: src/cli/main.cpp
@@ -1357,6 +1376,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr ""
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr ""
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr ""
 
@@ -1620,6 +1655,32 @@ msgstr ""
 
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
 msgstr ""
 
 #: src/gtk/devices_view.cpp

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether 0.2.27\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1890,6 +1890,7 @@ msgstr ""
 msgid "not connected"
 msgstr ""
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether 0.2.27\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,6 +84,10 @@ msgstr ""
 
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -387,6 +391,28 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No AirPods connected.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr ""
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
 msgstr ""
 
 #: src/cli/main.cpp
@@ -719,6 +745,18 @@ msgstr ""
 #: src/cli/main.cpp
 #, c++-format
 msgid "Using controller {}."
+msgstr ""
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr ""
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr ""
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
 msgstr ""
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
@@ -1245,6 +1283,20 @@ msgstr ""
 
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
+msgstr ""
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr ""
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr ""
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
 msgstr ""
 
 #: src/gtk/devices_view.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -438,6 +438,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "AirPods pil durumu arka plan hizmetinden okunamadı.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "Bağlı AirPods yok.\n"
 
@@ -2061,6 +2062,7 @@ msgstr "bağlı"
 msgid "not connected"
 msgstr "bağlı değil"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -95,8 +95,16 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "AirPods dinleme modunu ayarla: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Bir AirPod çıkarıldığında yerel oynatmayı duraklat: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Bir AirPod çıkarıldığında yerel oynatmayı duraklat: never, one-removed, both-"
+"removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Görüşme sırasında AirPods’u iPhone’a devret: on veya off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -485,8 +493,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "never, one-removed veya both-removed kullanın.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Çıkarınca duraklatma %s olarak ayarlandı.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "on veya off kullanın.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "iPhone’daki bir çağrı AirPods’u telefona devreder ve görüşme bitince geri alır."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "AirPods devri kapalı."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1829,8 +1850,24 @@ msgid "Both buds are removed"
 msgstr "Her iki kulaklık da çıkarıldığında"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Bu bilgisayarda çalan her şeyi duraklatır ve kulaklıklar geri takıldığında yeniden başlatır. Yalnızca Tether tarafından duraklatılan oynatma sürdürülür."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Bu bilgisayarda çalan her şeyi duraklatır ve kulaklıklar geri takıldığında "
+"yeniden başlatır. Yalnızca Tether tarafından duraklatılan oynatma sürdürülür."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Çağrılar"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Görüşme sırasında AirPods’u iPhone’a devret"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Oynatmayı duraklatır ve iPhone alabilsin diye AirPods bağlantısını keser, görüşme bitince yeniden bağlar. Çağrı denetimi gerektirir ve yalnızca kulaklıklar bu bilgisayara bağlıyken geçerlidir."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1918,10 +1955,6 @@ msgstr "Çık"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Aygıtlar"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Çağrılar"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -85,6 +85,10 @@ msgstr "BlueZ'in bildiği Bluetooth aygıtlarını listele."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Bluetooth bağlantısının ve profillerin durumunu göster."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "AirPods ve kutu pil durumunu göster."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -428,6 +432,27 @@ msgstr "Bluetooth aygıtları arka plan hizmetinden okunamadı.\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ'in bildiği hiçbir Bluetooth aygıtı yok.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "AirPods pil durumu arka plan hizmetinden okunamadı.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Bağlı AirPods yok.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Sol"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Sağ"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Kutu"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -779,6 +804,18 @@ msgstr "Bağdaştırıcı seçimi otomatik: açık olan ilk bağdaştırıcı.\n
 msgid "Using controller {}."
 msgstr "{} bağdaştırıcısı kullanılıyor."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "AirPods adresi okunamadı."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Bu sistemde Bluetooth soketleri kullanılamıyor."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "AirPods kanalını başka bir program kullanıyor."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -811,7 +848,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Bu bilgisayar eşleşmeyi BR/EDR'ye sabitlemişti; bu da iPhone'un bildirimleri taşımak için açtığı LE bağlantısını reddediyor. Bu şimdi geri alınıyor; LE bir dakika içinde kurulmalı. iPhone'da hiçbir şey bunu değiştirmez, yeniden eşleştirmek de değiştirmez."
+"Bu bilgisayar eşleşmeyi BR/EDR'ye sabitlemişti; bu da iPhone'un bildirimleri "
+"taşımak için açtığı LE bağlantısını reddediyor. Bu şimdi geri alınıyor; LE "
+"bir dakika içinde kurulmalı. iPhone'da hiçbir şey bunu değiştirmez, yeniden "
+"eşleştirmek de değiştirmez."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1372,6 +1412,20 @@ msgstr "Tether arka plan hizmeti çalışmıyor."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Arka plan hizmeti çevrimiçi"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "L"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "R"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Pil durumu okunuyor…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -89,6 +89,10 @@ msgstr "Bluetooth bağlantısının ve profillerin durumunu göster."
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "AirPods ve kutu pil durumunu göster."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr "AirPods dinleme modunu ayarla: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -458,6 +462,15 @@ msgstr "Kutu"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Arka plan hizmetine ulaşılamadı.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Dinleme modu %s olarak ayarlandı.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Dinleme modu ayarlanamadı."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1233,6 +1246,14 @@ msgid "Not a DTMF sequence."
 msgstr "DTMF dizisi değil."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Bilinmeyen dinleme modu."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "Bağlı AirPods yok."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "Bildirim yansıtma zaten etkin, yapılacak bir şey yok."
 
@@ -1443,6 +1464,26 @@ msgstr "Bu makinede Bluetooth kullanılamıyor."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Yakındaki aygıtlar taranıyor..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Kapalı"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Şeffaflık"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Uyarlanabilir"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Gürültü Engelleme"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Bu AirPods bir dinleme modu bildirmiyor."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1730,6 +1771,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Aygıtları tara"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Dinleme modu"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -93,6 +93,10 @@ msgstr "AirPods ve kutu pil durumunu göster."
 #: src/cli/main.cpp
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "AirPods dinleme modunu ayarla: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Bir AirPod çıkarıldığında yerel oynatmayı duraklat: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -460,6 +464,10 @@ msgid "Case"
 msgstr "Kutu"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "Takılı"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Arka plan hizmetine ulaşılamadı.\n"
 
@@ -471,6 +479,14 @@ msgstr "Dinleme modu %s olarak ayarlandı.\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Dinleme modu ayarlanamadı."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "never, one-removed veya both-removed kullanın.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Çıkarınca duraklatma %s olarak ayarlandı.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1486,6 +1502,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Bu AirPods bir dinleme modu bildirmiyor."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Bu AirPods takılı olup olmadığını bildirmiyor."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Her iki kulaklık da takılı."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Bir kulaklık takılı."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Hiçbir kulaklık takılı değil."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Tam kip — mesajlar, kişiler ve bildirimler."
 
@@ -1775,6 +1807,30 @@ msgstr "Aygıtları tara"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Dinleme modu"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Kulakta algılama"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Şu durumda oynatmayı duraklat:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Asla"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Bir kulaklık çıkarıldığında"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Her iki kulaklık da çıkarıldığında"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Bu bilgisayarda çalan her şeyi duraklatır ve kulaklıklar geri takıldığında yeniden başlatır. Yalnızca Tether tarafından duraklatılan oynatma sürdürülür."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -444,6 +444,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Не вдалося отримати заряд AirPods від служби.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "AirPods не під'єднано.\n"
 
@@ -2081,6 +2082,7 @@ msgstr "під'єднано"
 msgid "not connected"
 msgstr "не під'єднано"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -97,6 +97,10 @@ msgstr "Показати заряд AirPods і футляра."
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr ""
 "Задати режим прослуховування AirPods: off, anc, transparency, adaptive."
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "Ставити локальне відтворення на паузу при вийманні AirPod: never, one-removed, both-removed."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -467,6 +471,10 @@ msgid "Case"
 msgstr "Футляр"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "У вухах"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Не вдалося зв'язатися з демоном.\n"
 
@@ -478,6 +486,14 @@ msgstr "Режим прослуховування встановлено на %s
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "Не вдалося задати режим прослуховування."
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "Використовуйте never, one-removed або both-removed.\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "Паузу при вийманні встановлено на %s.\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1501,6 +1517,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "Ці AirPods не повідомляють режим прослуховування."
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "Ці AirPods не повідомляють, чи їх надіто."
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "Обидва навушники у вухах."
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "Один навушник у вусі."
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "Жоден навушник не у вусі."
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "Повний режим — повідомлення, контакти та сповіщення."
 
@@ -1796,6 +1828,30 @@ msgstr "Шукати пристрої"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "Режим прослуховування"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "Виявлення у вусі"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "Ставити на паузу, коли:"
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "Ніколи"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "Вийнято один навушник"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "Вийнято обидва навушники"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "Ставить на паузу те, що відтворюється на цьому комп’ютері, і запускає знову, коли навушники повертаються у вуха. Відновлюється лише відтворення, поставлене на паузу Tether."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -92,6 +92,11 @@ msgstr "Показати стан з'єднання Bluetooth і профілі�
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "Показати заряд AirPods і футляра."
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr ""
+"Задати режим прослуховування AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -464,6 +469,15 @@ msgstr "Футляр"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "Не вдалося зв'язатися з демоном.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "Режим прослуховування встановлено на %s.\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "Не вдалося задати режим прослуховування."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1244,6 +1258,14 @@ msgid "Not a DTMF sequence."
 msgstr "Це не послідовність DTMF."
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "Невідомий режим прослуховування."
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "AirPods не під'єднано."
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "Дублювання сповіщень уже активне, робити нічого не потрібно."
 
@@ -1457,6 +1479,26 @@ msgstr "Bluetooth недоступний на цій машині."
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "Пошук пристроїв поблизу..."
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "Вимкнено"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "Прозорість"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "Адаптивний"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "Шумозаглушення"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "Ці AirPods не повідомляють режим прослуховування."
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1750,6 +1792,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "Шукати пристрої"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "Режим прослуховування"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -99,8 +99,16 @@ msgstr ""
 "Задати режим прослуховування AirPods: off, anc, transparency, adaptive."
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
-msgstr "Ставити локальне відтворення на паузу при вийманні AirPod: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
+msgstr ""
+"Ставити локальне відтворення на паузу при вийманні AirPod: never, one-"
+"removed, both-removed."
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "Передавати AirPods на iPhone під час дзвінка: on або off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -492,8 +500,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "Використовуйте never, one-removed або both-removed.\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "Паузу при вийманні встановлено на %s.\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "Використовуйте on або off.\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "Дзвінок на iPhone передасть йому AirPods і поверне їх після завершення."
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "Передавання AirPods вимкнено."
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1850,8 +1871,25 @@ msgid "Both buds are removed"
 msgstr "Вийнято обидва навушники"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "Ставить на паузу те, що відтворюється на цьому комп’ютері, і запускає знову, коли навушники повертаються у вуха. Відновлюється лише відтворення, поставлене на паузу Tether."
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"Ставить на паузу те, що відтворюється на цьому комп’ютері, і запускає знову, "
+"коли навушники повертаються у вуха. Відновлюється лише відтворення, "
+"поставлене на паузу Tether."
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "Виклики"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "Передавати AirPods на iPhone під час дзвінка"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "Ставить відтворення на паузу й від’єднує AirPods, щоб їх міг забрати iPhone, а після дзвінка під’єднує знову. Потрібне керування дзвінками; діє, лише поки навушники під’єднані до цього комп’ютера."
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1938,10 +1976,6 @@ msgstr "Вийти"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "Пристрої"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "Виклики"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -88,6 +88,10 @@ msgstr "Показати пристрої Bluetooth, відомі BlueZ."
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "Показати стан з'єднання Bluetooth і профілів."
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "Показати заряд AirPods і футляра."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -434,6 +438,27 @@ msgstr "Не вдалося прочитати пристрої Bluetooth у д�
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ не знає жодного пристрою Bluetooth.\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "Не вдалося отримати заряд AirPods від служби.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "AirPods не під'єднано.\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "Лівий"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "Правий"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "Футляр"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -787,6 +812,18 @@ msgstr "Вибір адаптера автоматичний: перший ув�
 msgid "Using controller {}."
 msgstr "Використовується адаптер {}."
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "Не вдалося прочитати адресу AirPods."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "Сокети Bluetooth недоступні в цій системі."
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "Канал AirPods використовує інша програма."
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -819,7 +856,10 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"Цей комп'ютер закріпив спарювання за BR/EDR, через що відхиляється LE-з'єднання, яке iPhone відкриває для передавання сповіщень. Зараз це скасовується; LE має встановитися протягом хвилини. Ніщо на iPhone цього не змінить, повторне спарювання також."
+"Цей комп'ютер закріпив спарювання за BR/EDR, через що відхиляється LE-"
+"з'єднання, яке iPhone відкриває для передавання сповіщень. Зараз це "
+"скасовується; LE має встановитися протягом хвилини. Ніщо на iPhone цього не "
+"змінить, повторне спарювання також."
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1386,6 +1426,20 @@ msgstr "Демон Tether не запущено."
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "Демон у мережі"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "Л"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "П"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "Читання заряду…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:30-0700\n"
+"POT-Creation-Date: 2026-09-08 16:56-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -93,6 +93,10 @@ msgstr "显示 AirPods 和充电盒电量。"
 #: src/cli/main.cpp
 msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "设置 AirPods 聆听模式：off、anc、transparency、adaptive。"
+
+#: src/cli/main.cpp
+msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgstr "取下 AirPod 时暂停本机播放：never、one-removed、both-removed。"
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -443,6 +447,10 @@ msgid "Case"
 msgstr "充电盒"
 
 #: src/cli/main.cpp
+msgid "Worn"
+msgstr "佩戴"
+
+#: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "无法连接到守护进程。\n"
 
@@ -454,6 +462,14 @@ msgstr "聆听模式已设为 %s。\n"
 #: src/cli/main.cpp
 msgid "The listening mode could not be set."
 msgstr "无法设置聆听模式。"
+
+#: src/cli/main.cpp
+msgid "Use never, one-removed or both-removed.\n"
+msgstr "请使用 never、one-removed 或 both-removed。\n"
+
+#: src/cli/main.cpp
+msgid "Pause on removal set to %s.\n"
+msgstr "取下时暂停已设为 %s。\n"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1432,6 +1448,22 @@ msgid "These AirPods do not report a listening mode."
 msgstr "此 AirPods 不报告聆听模式。"
 
 #: src/gtk/devices_view.cpp
+msgid "These AirPods do not report whether they are being worn."
+msgstr "此 AirPods 不报告是否正在佩戴。"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are in."
+msgstr "两只耳机均已佩戴。"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is in."
+msgstr "已佩戴一只耳机。"
+
+#: src/gtk/devices_view.cpp
+msgid "Neither bud is in."
+msgstr "未佩戴耳机。"
+
+#: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
 msgstr "完整模式 —— 信息、通讯录和通知。"
 
@@ -1715,6 +1747,30 @@ msgstr "搜索设备"
 #: src/gtk/devices_view.cpp
 msgid "Listening mode"
 msgstr "聆听模式"
+
+#: src/gtk/devices_view.cpp
+msgid "In-ear detection"
+msgstr "入耳检测"
+
+#: src/gtk/devices_view.cpp
+msgid "Pause playback when:"
+msgstr "暂停播放的时机："
+
+#: src/gtk/devices_view.cpp
+msgid "Never"
+msgstr "从不"
+
+#: src/gtk/devices_view.cpp
+msgid "One bud is removed"
+msgstr "取下一只耳机时"
+
+#: src/gtk/devices_view.cpp
+msgid "Both buds are removed"
+msgstr "取下两只耳机时"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
+msgstr "暂停本机正在播放的内容，并在耳机重新戴上时继续播放。仅恢复由 Tether 暂停的播放。"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:08-0700\n"
+"POT-Creation-Date: 2026-09-08 16:30-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -89,6 +89,10 @@ msgstr "显示蓝牙链路和配置文件的连接状态。"
 #: src/cli/main.cpp
 msgid "Show AirPods and case battery."
 msgstr "显示 AirPods 和充电盒电量。"
+
+#: src/cli/main.cpp
+msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
+msgstr "设置 AirPods 聆听模式：off、anc、transparency、adaptive。"
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -441,6 +445,15 @@ msgstr "充电盒"
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
 msgstr "无法连接到守护进程。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Listening mode set to %s.\n"
+msgstr "聆听模式已设为 %s。\n"
+
+#: src/cli/main.cpp
+msgid "The listening mode could not be set."
+msgstr "无法设置聆听模式。"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1181,6 +1194,14 @@ msgid "Not a DTMF sequence."
 msgstr "不是 DTMF 序列。"
 
 #: src/core/src/net.cpp
+msgid "Unknown listening mode."
+msgstr "未知的聆听模式。"
+
+#: src/core/src/net.cpp src/gtk/devices_view.cpp
+msgid "No AirPods are connected."
+msgstr "未连接 AirPods。"
+
+#: src/core/src/net.cpp
 msgid "Notification mirroring is already active; nothing to do."
 msgstr "通知镜像已在运行，无需操作。"
 
@@ -1389,6 +1410,26 @@ msgstr "这台机器上蓝牙不可用。"
 #: src/gtk/devices_view.cpp
 msgid "Scanning for nearby devices..."
 msgstr "正在搜索附近的设备……"
+
+#: src/gtk/devices_view.cpp
+msgid "Off"
+msgstr "关闭"
+
+#: src/gtk/devices_view.cpp
+msgid "Transparency"
+msgstr "通透模式"
+
+#: src/gtk/devices_view.cpp
+msgid "Adaptive"
+msgstr "自适应"
+
+#: src/gtk/devices_view.cpp
+msgid "Noise Cancellation"
+msgstr "降噪"
+
+#: src/gtk/devices_view.cpp
+msgid "These AirPods do not report a listening mode."
+msgstr "此 AirPods 不报告聆听模式。"
 
 #: src/gtk/devices_view.cpp
 msgid "Full mode — messages, contacts, and notifications."
@@ -1670,6 +1711,10 @@ msgstr ""
 #: src/gtk/devices_view.cpp
 msgid "Scan for devices"
 msgstr "搜索设备"
+
+#: src/gtk/devices_view.cpp
+msgid "Listening mode"
+msgstr "聆听模式"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 16:56-0700\n"
+"POT-Creation-Date: 2026-09-08 17:21-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -95,8 +95,14 @@ msgid "Set the AirPods listening mode: off, anc, transparency, adaptive."
 msgstr "设置 AirPods 聆听模式：off、anc、transparency、adaptive。"
 
 #: src/cli/main.cpp
-msgid "Pause local playback when an AirPod is removed: never, one-removed, both-removed."
+msgid ""
+"Pause local playback when an AirPod is removed: never, one-removed, both-"
+"removed."
 msgstr "取下 AirPod 时暂停本机播放：never、one-removed、both-removed。"
+
+#: src/cli/main.cpp
+msgid "Hand the AirPods to the iPhone during a call: on or off."
+msgstr "通话期间将 AirPods 交给 iPhone：on 或 off。"
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -468,8 +474,21 @@ msgid "Use never, one-removed or both-removed.\n"
 msgstr "请使用 never、one-removed 或 both-removed。\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "Pause on removal set to %s.\n"
 msgstr "取下时暂停已设为 %s。\n"
+
+#: src/cli/main.cpp
+msgid "Use on or off.\n"
+msgstr "请使用 on 或 off。\n"
+
+#: src/cli/main.cpp
+msgid "An iPhone call will hand the AirPods to the phone and take them back after."
+msgstr "iPhone 来电时会将 AirPods 交给手机，通话结束后再取回。"
+
+#: src/cli/main.cpp
+msgid "AirPods handoff is off."
+msgstr "AirPods 交接已关闭。"
 
 #: src/cli/main.cpp
 msgid "Daemon closed the connection before the operation finished.\n"
@@ -1769,8 +1788,24 @@ msgid "Both buds are removed"
 msgstr "取下两只耳机时"
 
 #: src/gtk/devices_view.cpp
-msgid "Pauses whatever is playing on this computer, and starts it again when the buds go back in. Only playback Tether paused is resumed."
-msgstr "暂停本机正在播放的内容，并在耳机重新戴上时继续播放。仅恢复由 Tether 暂停的播放。"
+msgid ""
+"Pauses whatever is playing on this computer, and starts it again when the "
+"buds go back in. Only playback Tether paused is resumed."
+msgstr ""
+"暂停本机正在播放的内容，并在耳机重新戴上时继续播放。仅恢复由 Tether 暂停的播"
+"放。"
+
+#: src/gtk/devices_view.cpp src/gtk/main.cpp
+msgid "Calls"
+msgstr "通话"
+
+#: src/gtk/devices_view.cpp
+msgid "Hand the AirPods to the iPhone during a call"
+msgstr "通话期间将 AirPods 交给 iPhone"
+
+#: src/gtk/devices_view.cpp
+msgid "Pauses playback and disconnects the AirPods so the iPhone can take them, then reconnects them when the call ends. Needs call control, and only applies while the buds are connected to this computer."
+msgstr "暂停播放并断开 AirPods，让 iPhone 可以接管，通话结束后再重新连接。需要通话控制，且仅在耳机连接到本机时生效。"
 
 #: src/gtk/devices_view.cpp
 msgid "Bluetooth needs one-time system setup"
@@ -1855,10 +1890,6 @@ msgstr "退出"
 #: src/gtk/main.cpp
 msgid "Devices"
 msgstr "设备"
-
-#: src/gtk/main.cpp
-msgid "Calls"
-msgstr "通话"
 
 #: src/gtk/main.cpp
 msgid "Start hidden in the system tray"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-07 17:37-0700\n"
+"POT-Creation-Date: 2026-09-08 15:00-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -85,6 +85,10 @@ msgstr "列出 BlueZ 已知的蓝牙设备。"
 #: src/cli/main.cpp
 msgid "Show Bluetooth link and profile connection state."
 msgstr "显示蓝牙链路和配置文件的连接状态。"
+
+#: src/cli/main.cpp
+msgid "Show AirPods and case battery."
+msgstr "显示 AirPods 和充电盒电量。"
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -411,6 +415,27 @@ msgstr "无法从守护进程读取蓝牙设备。\n"
 #, c-format
 msgid "No Bluetooth devices known to BlueZ.\n"
 msgstr "BlueZ 没有已知的蓝牙设备。\n"
+
+#: src/cli/main.cpp
+msgid "Could not read the AirPods battery from the daemon.\n"
+msgstr "无法从守护进程读取 AirPods 电量。\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "未连接 AirPods。\n"
+
+#: src/cli/main.cpp
+msgid "Left"
+msgstr "左"
+
+#: src/cli/main.cpp
+msgid "Right"
+msgstr "右"
+
+#. TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+#: src/cli/main.cpp src/gtk/devices_view.cpp
+msgid "Case"
+msgstr "充电盒"
 
 #: src/cli/main.cpp
 msgid "Could not reach the daemon.\n"
@@ -752,6 +777,18 @@ msgstr "适配器选择为自动：第一个已开启的适配器。\n"
 msgid "Using controller {}."
 msgstr "正在使用适配器 {}。"
 
+#: src/core/src/bluetooth/airpods.cpp
+msgid "The AirPods address could not be read."
+msgstr "无法读取 AirPods 地址。"
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Bluetooth sockets are unavailable on this system."
+msgstr "此系统不支持 Bluetooth 套接字。"
+
+#: src/core/src/bluetooth/airpods.cpp
+msgid "Another program is using the AirPods channel."
+msgstr "另一个程序正在使用 AirPods 通道。"
+
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
 "Messages and contacts are connected. BlueZ reports the Bluetooth link down "
@@ -781,7 +818,9 @@ msgid ""
 "come up within a minute. Nothing on the iPhone changes this and re-pairing "
 "will not either."
 msgstr ""
-"这台电脑此前把配对固定在了 BR/EDR，因而拒绝了 iPhone 为传送通知而打开的 LE 链路。现在正在撤销；LE 应在一分钟内建立。在 iPhone 上做任何操作都改变不了这一点，重新配对也不行。"
+"这台电脑此前把配对固定在了 BR/EDR，因而拒绝了 iPhone 为传送通知而打开的 LE 链"
+"路。现在正在撤销；LE 应在一分钟内建立。在 iPhone 上做任何操作都改变不了这一"
+"点，重新配对也不行。"
 
 #: src/core/src/bluetooth/bearer_supervisor.cpp
 msgid ""
@@ -1319,6 +1358,20 @@ msgstr "Tether 守护进程未在运行。"
 #: src/gtk/daemon_client.cpp
 msgid "Daemon Online"
 msgstr "守护进程在线"
+
+#. TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "L"
+msgstr "左"
+
+#. TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+#: src/gtk/devices_view.cpp
+msgid "R"
+msgstr "右"
+
+#: src/gtk/devices_view.cpp
+msgid "Reading battery…"
+msgstr "正在读取电量…"
 
 #: src/gtk/devices_view.cpp
 msgid "Connected."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 15:00-0700\n"
+"POT-Creation-Date: 2026-09-08 16:08-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -421,6 +421,7 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "无法从守护进程读取 AirPods 电量。\n"
 
 #: src/cli/main.cpp
+#, c-format
 msgid "No AirPods connected.\n"
 msgstr "未连接 AirPods。\n"
 
@@ -1988,6 +1989,7 @@ msgstr "已连接"
 msgid "not connected"
 msgstr "未连接"
 
+#. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
 #. TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
 #: src/gtk/tray.cpp src/gtk/ui_util.cpp
 #, c++-format

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -194,6 +194,7 @@ static const Opt kOptions[] = {
     {"--bt-airpods", N_("Show AirPods and case battery.")},
     {"--bt-airpods-mode", N_("Set the AirPods listening mode: off, anc, transparency, adaptive.")},
     {"--bt-airpods-pause", N_("Pause local playback when an AirPod is removed: never, one-removed, both-removed.")},
+    {"--bt-airpods-handoff", N_("Hand the AirPods to the iPhone during a call: on or off.")},
     {"--bt-threads", N_("List iPhone message conversations.")},
     {"--bt-messages <thread>", N_("Show messages in one conversation.")},
     {"--bt-send <thread> <text>", N_("Reply in one conversation.")},
@@ -575,6 +576,22 @@ static int set_bt_airpods_pause(tether::Client& client, const std::string& mode)
         return 1;
     }
     fprintf(stdout, _("Pause on removal set to %s.\n"), mode.c_str());
+    return 0;
+}
+
+static int set_bt_airpods_handoff(tether::Client& client, const std::string& value) {
+    if (value != "on" && value != "off") {
+        debug::log(ERR, _("Use on or off.\n"));
+        return 1;
+    }
+    if (!client.send(nlohmann::json{{"command", "bt_airpods_handoff"}, {"enabled", value == "on"}}.dump() + "\n")) {
+        debug::log(ERR, _("Could not reach the daemon.\n"));
+        return 1;
+    }
+    fprintf(stdout,
+            "%s\n",
+            value == "on" ? _("An iPhone call will hand the AirPods to the phone and take them back after.")
+                          : _("AirPods handoff is off."));
     return 0;
 }
 
@@ -1035,6 +1052,10 @@ int main(int argc, char* argv[]) {
             action = "bt_airpods_pause";
             if (i + 1 < argc && argv[i + 1][0] != '-')
                 arg_val = argv[++i];
+        } else if (arg == "--bt-airpods-handoff") {
+            action = "bt_airpods_handoff";
+            if (i + 1 < argc && argv[i + 1][0] != '-')
+                arg_val = argv[++i];
         } else if (arg == "--bt-diagnostics") {
             action = "bt_diagnostics";
         } else if (arg == "--bt-threads") {
@@ -1276,6 +1297,8 @@ int main(int argc, char* argv[]) {
         return set_bt_airpods_mode(client, arg_val);
     } else if (action == "bt_airpods_pause") {
         return set_bt_airpods_pause(client, arg_val);
+    } else if (action == "bt_airpods_handoff") {
+        return set_bt_airpods_handoff(client, arg_val);
     } else if (action == "bt_diagnostics") {
         return print_bt_diagnostics(client);
     } else if (action == "bt_threads") {

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -191,6 +191,7 @@ static const Opt kOptions[] = {
     {"--bt-devices", N_("List Bluetooth devices known to BlueZ.")},
     {"--bt-connection", N_("Show Bluetooth link and profile connection state.")},
     {"--bt-airpods", N_("Show AirPods and case battery.")},
+    {"--bt-airpods-mode", N_("Set the AirPods listening mode: off, anc, transparency, adaptive.")},
     {"--bt-threads", N_("List iPhone message conversations.")},
     {"--bt-messages <thread>", N_("Show messages in one conversation.")},
     {"--bt-send <thread> <text>", N_("Reply in one conversation.")},
@@ -527,10 +528,32 @@ static int print_bt_airpods(tether::Client& client) {
     level(_("Right"), "right");
     level(_("Case"), "case");
 
+    if (resp.contains("anc") && resp["anc"].is_string())
+        fprintf(stdout, "  %-6s %s\n", _("Mode"), resp["anc"].get<std::string>().c_str());
+
     const std::string reason = resp.value("reason", "");
     if (!reason.empty())
         fprintf(stdout, "  %s\n", reason.c_str());
     return 0;
+}
+
+static int set_bt_airpods_mode(tether::Client& client, const std::string& mode) {
+    nlohmann::json request;
+    request["command"] = "bt_airpods_mode";
+    request["mode"] = mode;
+    nlohmann::json resp;
+    try {
+        resp = nlohmann::json::parse(client.send_and_wait(request.dump() + "\n"));
+    } catch (const std::exception&) {
+        debug::log(ERR, _("Could not reach the daemon.\n"));
+        return 1;
+    }
+    if (resp.value("success", false)) {
+        fprintf(stdout, _("Listening mode set to %s.\n"), mode.c_str());
+        return 0;
+    }
+    debug::log(ERR, "{}\n", resp.value("message", std::string(_("The listening mode could not be set."))));
+    return 1;
 }
 
 // Pairing takes tens of seconds and reports progress as it goes, so this
@@ -982,6 +1005,10 @@ int main(int argc, char* argv[]) {
             action = "bt_connection";
         } else if (arg == "--bt-airpods") {
             action = "bt_airpods";
+        } else if (arg == "--bt-airpods-mode") {
+            action = "bt_airpods_mode";
+            if (i + 1 < argc && argv[i + 1][0] != '-')
+                arg_val = argv[++i];
         } else if (arg == "--bt-diagnostics") {
             action = "bt_diagnostics";
         } else if (arg == "--bt-threads") {
@@ -1219,6 +1246,8 @@ int main(int argc, char* argv[]) {
         return print_bt_connection(client);
     } else if (action == "bt_airpods") {
         return print_bt_airpods(client);
+    } else if (action == "bt_airpods_mode") {
+        return set_bt_airpods_mode(client, arg_val);
     } else if (action == "bt_diagnostics") {
         return print_bt_diagnostics(client);
     } else if (action == "bt_threads") {

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -190,6 +190,7 @@ static const Opt kOptions[] = {
     {"--bt-status", N_("Show Bluetooth adapter capability and delivery mode.")},
     {"--bt-devices", N_("List Bluetooth devices known to BlueZ.")},
     {"--bt-connection", N_("Show Bluetooth link and profile connection state.")},
+    {"--bt-airpods", N_("Show AirPods and case battery.")},
     {"--bt-threads", N_("List iPhone message conversations.")},
     {"--bt-messages <thread>", N_("Show messages in one conversation.")},
     {"--bt-send <thread> <text>", N_("Reply in one conversation.")},
@@ -484,6 +485,8 @@ static int print_bt_devices(tether::Client& client) {
             add("pbap");
         if (d.value("ancs", false))
             add("ancs");
+        if (d.value("airpods", false))
+            add("airpods");
         if (d.value("preferred_bearer", std::string()) == "bredr" && !d.value("le_connected", false))
             add("pinned-bredr");
 
@@ -494,6 +497,39 @@ static int print_bt_devices(tether::Client& client) {
                 flags.c_str(),
                 d.value("iphone", false) ? "  <- iPhone" : "");
     }
+    return 0;
+}
+
+static int print_bt_airpods(tether::Client& client) {
+    nlohmann::json resp;
+    try {
+        resp = nlohmann::json::parse(client.send_and_wait("{\"command\":\"bt_airpods\"}\n"));
+    } catch (const std::exception&) {
+        debug::log(ERR, _("Could not read the AirPods battery from the daemon.\n"));
+        return 1;
+    }
+
+    if (resp.value("address", "").empty()) {
+        fprintf(stdout, _("No AirPods connected.\n"));
+        return 0;
+    }
+
+    fprintf(stdout, "%s  (%s)\n", resp.value("name", "").c_str(), resp.value("address", "").c_str());
+
+    const auto level = [&](const char* label, const char* key) {
+        const int percent = resp.value(key, -1);
+        if (percent >= 0)
+            fprintf(stdout, "  %-6s %d%%\n", label, percent);
+        else
+            fprintf(stdout, "  %-6s --\n", label);
+    };
+    level(_("Left"), "left");
+    level(_("Right"), "right");
+    level(_("Case"), "case");
+
+    const std::string reason = resp.value("reason", "");
+    if (!reason.empty())
+        fprintf(stdout, "  %s\n", reason.c_str());
     return 0;
 }
 
@@ -944,6 +980,8 @@ int main(int argc, char* argv[]) {
             action = "bt_devices";
         } else if (arg == "--bt-connection") {
             action = "bt_connection";
+        } else if (arg == "--bt-airpods") {
+            action = "bt_airpods";
         } else if (arg == "--bt-diagnostics") {
             action = "bt_diagnostics";
         } else if (arg == "--bt-threads") {
@@ -1179,6 +1217,8 @@ int main(int argc, char* argv[]) {
         return print_bt_devices(client);
     } else if (action == "bt_connection") {
         return print_bt_connection(client);
+    } else if (action == "bt_airpods") {
+        return print_bt_airpods(client);
     } else if (action == "bt_diagnostics") {
         return print_bt_diagnostics(client);
     } else if (action == "bt_threads") {

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <strings.h>
 #include <sys/ioctl.h>
+#include <tether/bluetooth/config.hpp>
 #include <tether/client.hpp>
 #include <tether/core.hpp>
 #include <tether/crypto.hpp>
@@ -192,6 +193,7 @@ static const Opt kOptions[] = {
     {"--bt-connection", N_("Show Bluetooth link and profile connection state.")},
     {"--bt-airpods", N_("Show AirPods and case battery.")},
     {"--bt-airpods-mode", N_("Set the AirPods listening mode: off, anc, transparency, adaptive.")},
+    {"--bt-airpods-pause", N_("Pause local playback when an AirPod is removed: never, one-removed, both-removed.")},
     {"--bt-threads", N_("List iPhone message conversations.")},
     {"--bt-messages <thread>", N_("Show messages in one conversation.")},
     {"--bt-send <thread> <text>", N_("Reply in one conversation.")},
@@ -531,6 +533,13 @@ static int print_bt_airpods(tether::Client& client) {
     if (resp.contains("anc") && resp["anc"].is_string())
         fprintf(stdout, "  %-6s %s\n", _("Mode"), resp["anc"].get<std::string>().c_str());
 
+    if (resp.contains("ear") && resp["ear"].is_object()) {
+        const std::string primary = resp["ear"].value("primary", "unknown");
+        const std::string secondary = resp["ear"].value("secondary", "unknown");
+        if (primary != "unknown" || secondary != "unknown")
+            fprintf(stdout, "  %-6s %s, %s\n", _("Worn"), primary.c_str(), secondary.c_str());
+    }
+
     const std::string reason = resp.value("reason", "");
     if (!reason.empty())
         fprintf(stdout, "  %s\n", reason.c_str());
@@ -554,6 +563,19 @@ static int set_bt_airpods_mode(tether::Client& client, const std::string& mode) 
     }
     debug::log(ERR, "{}\n", resp.value("message", std::string(_("The listening mode could not be set."))));
     return 1;
+}
+
+static int set_bt_airpods_pause(tether::Client& client, const std::string& mode) {
+    if (tether::bluetooth::to_string(tether::bluetooth::pause_mode_from_string(mode)) != mode) {
+        debug::log(ERR, _("Use never, one-removed or both-removed.\n"));
+        return 1;
+    }
+    if (!client.send(nlohmann::json{{"command", "bt_airpods_pause"}, {"mode", mode}}.dump() + "\n")) {
+        debug::log(ERR, _("Could not reach the daemon.\n"));
+        return 1;
+    }
+    fprintf(stdout, _("Pause on removal set to %s.\n"), mode.c_str());
+    return 0;
 }
 
 // Pairing takes tens of seconds and reports progress as it goes, so this
@@ -1009,6 +1031,10 @@ int main(int argc, char* argv[]) {
             action = "bt_airpods_mode";
             if (i + 1 < argc && argv[i + 1][0] != '-')
                 arg_val = argv[++i];
+        } else if (arg == "--bt-airpods-pause") {
+            action = "bt_airpods_pause";
+            if (i + 1 < argc && argv[i + 1][0] != '-')
+                arg_val = argv[++i];
         } else if (arg == "--bt-diagnostics") {
             action = "bt_diagnostics";
         } else if (arg == "--bt-threads") {
@@ -1248,6 +1274,8 @@ int main(int argc, char* argv[]) {
         return print_bt_airpods(client);
     } else if (action == "bt_airpods_mode") {
         return set_bt_airpods_mode(client, arg_val);
+    } else if (action == "bt_airpods_pause") {
+        return set_bt_airpods_pause(client, arg_val);
     } else if (action == "bt_diagnostics") {
         return print_bt_diagnostics(client);
     } else if (action == "bt_threads") {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(tether STATIC
     src/bluetooth/groups.cpp
     src/bluetooth/telephony.cpp
     src/bluetooth/telephony_pipewire.cpp
+    src/bluetooth/airpods.cpp
     src/bluetooth/connection.cpp
     src/bluetooth/diagnostics.cpp
     src/wayland.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(tether STATIC
     src/client.cpp
     src/extension_host.cpp
     src/discovery.cpp
+    src/mpris.cpp
     src/bluetooth/objects.cpp
     src/bluetooth/monitor.cpp
     src/bluetooth/config.cpp

--- a/src/core/include/tether/bluetooth/airpods.hpp
+++ b/src/core/include/tether/bluetooth/airpods.hpp
@@ -21,6 +21,18 @@ namespace tether::bluetooth {
     // Status byte for a component that is not reporting: a bud in the case, or a shut case.
     inline constexpr uint8_t AAP_STATUS_DISCONNECTED = 0x04;
 
+    // Listening mode. The values are the wire bytes, which are one above the
+    // order Apple's own UI lists them in.
+    enum class AncMode : uint8_t {
+        Off = 0x01,
+        NoiseCancellation = 0x02,
+        Transparency = 0x03,
+        Adaptive = 0x04,
+    };
+
+    const char* to_string(AncMode mode);
+    std::optional<AncMode> anc_mode_from_string(const std::string& name);
+
     struct AirPodsBattery {
         // -1 when unknown.
         int left = -1;
@@ -59,6 +71,8 @@ namespace tether::bluetooth {
         std::string address;
         std::string name;
         AirPodsBattery battery;
+        // Unset until the buds report one. Not every model has the feature.
+        std::optional<AncMode> anc;
         AirPodsStatus status = AirPodsStatus::Idle;
         // Written for display, shown verbatim.
         std::string reason;
@@ -74,6 +88,10 @@ namespace tether::bluetooth {
     std::optional<BatteryUpdate> parse_battery(const uint8_t* data, size_t len);
 
     void merge_battery(AirPodsBattery& into, const BatteryUpdate& update);
+
+    // Decodes a listening-mode notification, 11 bytes carrying the mode at offset 7.
+    // Returns no value for anything else, including an out-of-range mode.
+    std::optional<AncMode> parse_anc(const uint8_t* data, size_t len);
 
     // The connected AirPods worth opening a channel to, or null. Only one is
     // returned: the channel is single-client and so is the watcher.
@@ -91,6 +109,11 @@ namespace tether::bluetooth {
         // Points the watcher at a connected device, or stops it when `address` is
         // empty. Cheap to call on every BlueZ snapshot: an unchanged target is a no-op.
         void set_device(const std::string& address, const std::string& name);
+
+        // Asks the buds to switch listening mode. Sent on the open channel, and
+        // dropped if the channel closes before it goes out; the buds answer with a
+        // notification, which is what actually updates the published state.
+        void set_anc(AncMode mode);
 
         AirPodsState state() const;
 

--- a/src/core/include/tether/bluetooth/airpods.hpp
+++ b/src/core/include/tether/bluetooth/airpods.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "tether/bluetooth/config.hpp"
 #include "tether/bluetooth/objects.hpp"
 
 #include <cstdint>
@@ -32,6 +33,21 @@ namespace tether::bluetooth {
 
     const char* to_string(AncMode mode);
     std::optional<AncMode> anc_mode_from_string(const std::string& name);
+
+    // Where a bud is.
+    enum class EarStatus { Unknown, InEar, OutOfEar, InCase };
+
+    const char* to_string(EarStatus status);
+
+    struct EarState {
+        EarStatus primary = EarStatus::Unknown;
+        EarStatus secondary = EarStatus::Unknown;
+
+        int in_ear() const { return (primary == EarStatus::InEar ? 1 : 0) + (secondary == EarStatus::InEar ? 1 : 0); }
+        bool known() const { return primary != EarStatus::Unknown || secondary != EarStatus::Unknown; }
+
+        bool operator==(const EarState&) const = default;
+    };
 
     struct AirPodsBattery {
         // -1 when unknown.
@@ -73,6 +89,7 @@ namespace tether::bluetooth {
         AirPodsBattery battery;
         // Unset until the buds report one. Not every model has the feature.
         std::optional<AncMode> anc;
+        EarState ear;
         AirPodsStatus status = AirPodsStatus::Idle;
         // Written for display, shown verbatim.
         std::string reason;
@@ -89,9 +106,19 @@ namespace tether::bluetooth {
 
     void merge_battery(AirPodsBattery& into, const BatteryUpdate& update);
 
+    // Decodes an ear-detection notification, 8 bytes carrying the primary bud at
+    // offset 6 and the secondary at 7.
+    std::optional<EarState> parse_ear(const uint8_t* data, size_t len);
+
     // Decodes a listening-mode notification, 11 bytes carrying the mode at offset 7.
     // Returns no value for anything else, including an out-of-range mode.
     std::optional<AncMode> parse_anc(const uint8_t* data, size_t len);
+
+    // What an ear-state change should do to local playback.
+    enum class MediaAction { None, Pause, Resume };
+
+    // `holding` is whether the caller has a pause outstanding.
+    MediaAction ear_media_action(const EarState& before, const EarState& after, PauseMode mode, bool holding);
 
     // The connected AirPods worth opening a channel to, or null. Only one is
     // returned: the channel is single-client and so is the watcher.

--- a/src/core/include/tether/bluetooth/airpods.hpp
+++ b/src/core/include/tether/bluetooth/airpods.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "tether/bluetooth/objects.hpp"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+
+namespace tether::bluetooth {
+
+    // Apple's Accessory Protocol, the same channel an iPhone uses.
+    inline constexpr uint16_t AAP_PSM = 0x1001;
+
+    // Components in a battery notification.
+    inline constexpr uint8_t AAP_COMPONENT_RIGHT = 0x02;
+    inline constexpr uint8_t AAP_COMPONENT_LEFT = 0x04;
+    inline constexpr uint8_t AAP_COMPONENT_CASE = 0x08;
+    // Status byte for a component that is not reporting: a bud in the case, or a shut case.
+    inline constexpr uint8_t AAP_STATUS_DISCONNECTED = 0x04;
+
+    struct AirPodsBattery {
+        // -1 when unknown.
+        int left = -1;
+        int right = -1;
+        int case_ = -1;
+
+        bool any() const { return left >= 0 || right >= 0 || case_ >= 0; }
+
+        bool operator==(const AirPodsBattery&) const = default;
+    };
+
+    // One notification has only the components that changed.
+    struct BatteryUpdate {
+        AirPodsBattery levels;
+        bool has_left = false;
+        bool has_right = false;
+        bool has_case = false;
+
+        bool operator==(const BatteryUpdate&) const = default;
+    };
+
+    enum class AirPodsStatus {
+        // No AirPods connected to this machine.
+        Idle,
+        // The channel is opening, or open with no battery packet yet.
+        Connecting,
+        Live,
+        // The channel is single-client and something else holds it.
+        Busy,
+        Failed,
+    };
+
+    const char* to_string(AirPodsStatus status);
+
+    struct AirPodsState {
+        std::string address;
+        std::string name;
+        AirPodsBattery battery;
+        AirPodsStatus status = AirPodsStatus::Idle;
+        // Written for display, shown verbatim.
+        std::string reason;
+
+        bool operator==(const AirPodsState&) const = default;
+    };
+
+    nlohmann::json to_json(const AirPodsState& state);
+
+    // Decodes an AAP battery notification:
+    //   04 00 04 00 04 00 [count] ([component] 01 [level] [status] 01) * count
+    // Returns no value for anything that is not one, including a truncated packet.
+    std::optional<BatteryUpdate> parse_battery(const uint8_t* data, size_t len);
+
+    void merge_battery(AirPodsBattery& into, const BatteryUpdate& update);
+
+    // The connected AirPods worth opening a channel to, or null. Only one is
+    // returned: the channel is single-client and so is the watcher.
+    const Device* find_airpods(const BluezObjects& objects);
+
+    // Keeps an AAP channel open to one set of AirPods and publishes their battery.
+    class AirPodsWatcher {
+    public:
+        explicit AirPodsWatcher(std::function<void(const AirPodsState&)> on_change);
+        ~AirPodsWatcher();
+
+        AirPodsWatcher(const AirPodsWatcher&) = delete;
+        AirPodsWatcher& operator=(const AirPodsWatcher&) = delete;
+
+        // Points the watcher at a connected device, or stops it when `address` is
+        // empty. Cheap to call on every BlueZ snapshot: an unchanged target is a no-op.
+        void set_device(const std::string& address, const std::string& name);
+
+        AirPodsState state() const;
+
+    private:
+        struct Impl;
+        std::unique_ptr<Impl> impl_;
+    };
+
+    extern AirPodsWatcher* g_airpods;
+
+} // namespace tether::bluetooth

--- a/src/core/include/tether/bluetooth/airpods.hpp
+++ b/src/core/include/tether/bluetooth/airpods.hpp
@@ -120,6 +120,16 @@ namespace tether::bluetooth {
     // `holding` is whether the caller has a pause outstanding.
     MediaAction ear_media_action(const EarState& before, const EarState& after, PauseMode mode, bool holding);
 
+    // What an iPhone call should do to AirPods that are connected to this machine.
+    enum class HandoffAction { None, Release, Reclaim };
+
+    // `released` is whether this code is what disconnected them: buds the user
+    // took away by hand are never reclaimed.
+    HandoffAction handoff_action(bool call_active, bool buds_on_linux, bool released, bool enabled);
+
+    // Whether a bt_calls payload describes a call worth handing the buds over for.
+    bool call_wants_audio(const nlohmann::json& calls);
+
     // The connected AirPods worth opening a channel to, or null. Only one is
     // returned: the channel is single-client and so is the watcher.
     const Device* find_airpods(const BluezObjects& objects);

--- a/src/core/include/tether/bluetooth/config.hpp
+++ b/src/core/include/tether/bluetooth/config.hpp
@@ -17,6 +17,12 @@ namespace tether::bluetooth {
     // prompt, so it stays available as a workaround.
     enum class AuthStrategy { ConnectFirst, ExplicitPair };
 
+    // When taking AirPods out should pause whatever is playing locally.
+    enum class PauseMode { Never, OneRemoved, BothRemoved };
+
+    const char* to_string(PauseMode mode);
+    PauseMode pause_mode_from_string(const std::string& value);
+
     // Persisted at ~/.config/tether/bluetooth.json.
     struct Config {
         // Address of the selected iPhone, e.g. "81:71:C8:30:6A:F3".
@@ -42,6 +48,8 @@ namespace tether::bluetooth {
         Retention retention = Retention::Encrypted;
         // Whether the daemon shows desktop popups at all.
         bool desktop_popups_enabled = true;
+        // Whether removing an AirPod pauses local playback.
+        PauseMode airpods_pause = PauseMode::Never;
 
         bool operator==(const Config&) const = default;
     };

--- a/src/core/include/tether/bluetooth/config.hpp
+++ b/src/core/include/tether/bluetooth/config.hpp
@@ -50,6 +50,8 @@ namespace tether::bluetooth {
         bool desktop_popups_enabled = true;
         // Whether removing an AirPod pauses local playback.
         PauseMode airpods_pause = PauseMode::Never;
+        // Whether an iPhone call hands the AirPods to the phone and takes them back after.
+        bool airpods_handoff = false;
 
         bool operator==(const Config&) const = default;
     };

--- a/src/core/include/tether/bluetooth/objects.hpp
+++ b/src/core/include/tether/bluetooth/objects.hpp
@@ -17,6 +17,10 @@ namespace tether::bluetooth {
     inline constexpr const char* UUID_MAP_MNS = "00001133-0000-1000-8000-00805f9b34fb";
     inline constexpr const char* UUID_PBAP_PSE = "0000112f-0000-1000-8000-00805f9b34fb";
     inline constexpr const char* UUID_ANCS = "7905f431-b5ce-4e99-a40f-4b1e122d00d0";
+    inline constexpr const char* UUID_A2DP_SINK = "0000110b-0000-1000-8000-00805f9b34fb";
+
+    // Modalias prefix for Apple's Bluetooth vendor id, shared by every Apple device.
+    inline constexpr const char* MODALIAS_APPLE = "bluetooth:v004c";
 
     inline constexpr uint32_t COD_TARGET = 0x0408;
     inline constexpr uint32_t COD_MASK = 0x1fff;
@@ -54,6 +58,8 @@ namespace tether::bluetooth {
         bool trusted = false;
         bool connected = false;
         std::vector<std::string> uuids;
+        // Device1.Modalias, e.g. "bluetooth:v004Cp200Ed0100". Names the remote's vendor.
+        std::string modalias;
 
         bool ancs_notifying = false;
 
@@ -82,6 +88,8 @@ namespace tether::bluetooth {
         bool supports_pbap() const { return has_uuid(UUID_PBAP_PSE); }
         bool supports_ancs() const { return has_uuid(UUID_ANCS); }
         bool looks_like_iphone() const;
+        // Apple audio gear rather than a phone: AAP battery is worth trying on it.
+        bool looks_like_airpods() const;
 
         bool operator==(const Device&) const = default;
     };

--- a/src/core/include/tether/bluetooth/pairing.hpp
+++ b/src/core/include/tether/bluetooth/pairing.hpp
@@ -64,6 +64,10 @@ namespace tether::bluetooth {
     // so a caller can publish the growing device list.
     bool scan_devices(BluezMonitor& monitor, int seconds, const std::function<void()>& on_tick, std::string& err);
 
+    // Device1.Connect / Device1.Disconnect on a bonded device, by address.
+    bool connect_device(BluezMonitor& monitor, const std::string& address, std::string& err);
+    bool disconnect_device(BluezMonitor& monitor, const std::string& address, std::string& err);
+
     // Puts the ANCS solicitation advertisement back on air without re-pairing.
     // This is what makes iOS reveal its "Show Message Notifications" and
     // "Sync Contacts" toggles, and it expires a few minutes after pairing, so

--- a/src/core/include/tether/mpris.hpp
+++ b/src/core/include/tether/mpris.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tether {
+
+    // Pauses whatever is playing on the desktop and can put it back, over MPRIS on the session bus.
+    class MediaControl {
+    public:
+        MediaControl();
+        ~MediaControl();
+
+        MediaControl(const MediaControl&) = delete;
+        MediaControl& operator=(const MediaControl&) = delete;
+
+        // Pauses every player currently reporting Playing and remembers which
+        // ones, so resume() can put them back. Returns how many were
+        // paused. Does nothing while already holding a pause.
+        size_t pause();
+
+        // Plays what this object paused, then forgets them.
+        size_t resume();
+
+        // Whether anything is currently paused by this object.
+        bool holding() const;
+
+        // Drops the remembered players without touching them.
+        void forget();
+
+        // Bus names of every MPRIS player currently reporting Playing.
+        std::vector<std::string> playing() const;
+
+    private:
+        struct Impl;
+        std::unique_ptr<Impl> impl_;
+    };
+
+} // namespace tether

--- a/src/core/include/tether/mpris.hpp
+++ b/src/core/include/tether/mpris.hpp
@@ -37,4 +37,7 @@ namespace tether {
         std::unique_ptr<Impl> impl_;
     };
 
+    // Set for the daemon's lifetime
+    extern MediaControl* g_media;
+
 } // namespace tether

--- a/src/core/include/tether/net.hpp
+++ b/src/core/include/tether/net.hpp
@@ -41,6 +41,7 @@ namespace tether {
     // Bluetooth state, read from the BluezMonitor snapshot.
     nlohmann::json build_bt_status();
     nlohmann::json build_bt_devices();
+    nlohmann::json build_bt_airpods();
 
     // How many contacts a bt_list_contacts answers with when the caller does not say.
     inline constexpr size_t BT_CONTACTS_DEFAULT_LIMIT = 100;

--- a/src/core/src/bluetooth/airpods.cpp
+++ b/src/core/src/bluetooth/airpods.cpp
@@ -286,6 +286,28 @@ namespace tether::bluetooth {
         return MediaAction::None;
     }
 
+    bool call_wants_audio(const nlohmann::json& calls) {
+        if (!calls.is_array())
+            return false;
+        for (const auto& call : calls) {
+            // Ringing counts: the buds have to be on the phone before it is answered.
+            if (call.value("ringing", false) || call.value("outgoing", false) || call.value("connected", false))
+                return true;
+        }
+        return false;
+    }
+
+    HandoffAction handoff_action(bool call_active, bool buds_on_linux, bool released, bool enabled) {
+        if (!enabled)
+            return HandoffAction::None;
+        if (call_active && buds_on_linux && !released)
+            return HandoffAction::Release;
+        // Only after the call, and only buds this code took away.
+        if (!call_active && released)
+            return HandoffAction::Reclaim;
+        return HandoffAction::None;
+    }
+
     const Device* find_airpods(const BluezObjects& objects) {
         for (const auto& device : objects.devices)
             if (device.connected && device.looks_like_airpods())

--- a/src/core/src/bluetooth/airpods.cpp
+++ b/src/core/src/bluetooth/airpods.cpp
@@ -148,19 +148,21 @@ namespace tether::bluetooth {
     }
 
     nlohmann::json to_json(const AirPodsState& s) {
-        return {
+        nlohmann::json j = {
             {"command", "bt_airpods"},
             {"address", s.address},
             {"name", s.name},
             {"left", s.battery.left},
             {"right", s.battery.right},
             {"case", s.battery.case_},
-            {"anc", s.anc ? nlohmann::json(to_string(*s.anc)) : nlohmann::json()},
             {"ear", {{"primary", to_string(s.ear.primary)}, {"secondary", to_string(s.ear.secondary)}}},
             {"in_ear", s.ear.in_ear()},
             {"status", to_string(s.status)},
             {"reason", s.reason},
         };
+        if (s.anc)
+            j["anc"] = to_string(*s.anc);
+        return j;
     }
 
     const char* to_string(AncMode mode) {

--- a/src/core/src/bluetooth/airpods.cpp
+++ b/src/core/src/bluetooth/airpods.cpp
@@ -69,6 +69,12 @@ namespace tether::bluetooth {
         constexpr uint8_t BATTERY_PREFIX[] = {0x04, 0x00, 0x04, 0x00, 0x04, 0x00};
         constexpr size_t BATTERY_ENTRY_BYTES = 5;
 
+        // Listening mode, sent and received on the same 11-byte:
+        // 04 00 04 00 09 00 0D [mode] 00 00 00
+        constexpr uint8_t ANC_PREFIX[] = {0x04, 0x00, 0x04, 0x00, 0x09, 0x00, 0x0d};
+        constexpr size_t ANC_PACKET_BYTES = 11;
+        constexpr size_t ANC_MODE_OFFSET = 7;
+
         constexpr int CONNECT_TIMEOUT_MS = 8000;
         constexpr int FIRST_PACKET_TIMEOUT_MS = 8000;
         // A channel that has gone quiet this long is recycled.
@@ -145,9 +151,42 @@ namespace tether::bluetooth {
             {"left", s.battery.left},
             {"right", s.battery.right},
             {"case", s.battery.case_},
+            {"anc", s.anc ? nlohmann::json(to_string(*s.anc)) : nlohmann::json()},
             {"status", to_string(s.status)},
             {"reason", s.reason},
         };
+    }
+
+    const char* to_string(AncMode mode) {
+        switch (mode) {
+        case AncMode::Off:
+            return "off";
+        case AncMode::NoiseCancellation:
+            return "anc";
+        case AncMode::Transparency:
+            return "transparency";
+        case AncMode::Adaptive:
+            return "adaptive";
+        }
+        return "off";
+    }
+
+    std::optional<AncMode> anc_mode_from_string(const std::string& name) {
+        for (AncMode mode : {AncMode::Off, AncMode::NoiseCancellation, AncMode::Transparency, AncMode::Adaptive})
+            if (name == to_string(mode))
+                return mode;
+        return std::nullopt;
+    }
+
+    std::optional<AncMode> parse_anc(const uint8_t* data, size_t len) {
+        if (data == nullptr || len != ANC_PACKET_BYTES)
+            return std::nullopt;
+        if (std::memcmp(data, ANC_PREFIX, sizeof(ANC_PREFIX)) != 0)
+            return std::nullopt;
+        const uint8_t mode = data[ANC_MODE_OFFSET];
+        if (mode < static_cast<uint8_t>(AncMode::Off) || mode > static_cast<uint8_t>(AncMode::Adaptive))
+            return std::nullopt;
+        return static_cast<AncMode>(mode);
     }
 
     std::optional<BatteryUpdate> parse_battery(const uint8_t* data, size_t len) {
@@ -215,6 +254,10 @@ namespace tether::bluetooth {
         AirPodsState published;
         std::string target_address;
         std::string target_name;
+        // Handed to the worker rather than written from the caller's thread: the
+        // socket belongs to the session and closing it out from under a write is
+        // the one race worth not having.
+        std::optional<AncMode> pending_anc;
         bool stopping = false;
 
         int wake_fd = -1;
@@ -255,6 +298,25 @@ namespace tether::bluetooth {
         void backoff(int ms) {
             if (wait_for(-1, wake_fd, 0, ms) == 0)
                 drain_wake();
+        }
+
+        // Sends whatever the caller queued, on the worker thread. False means the
+        // write failed and the session is over.
+        bool send_pending(int fd) {
+            std::optional<AncMode> mode;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                std::swap(mode, pending_anc);
+            }
+            if (!mode)
+                return true;
+            const uint8_t packet[] = {
+                0x04, 0x00, 0x04, 0x00, 0x09, 0x00, 0x0d, static_cast<uint8_t>(*mode), 0x00, 0x00, 0x00};
+            static_assert(sizeof(packet) == ANC_PACKET_BYTES);
+            if (write_all(fd, packet, sizeof(packet)))
+                return true;
+            debug::log(DEBUG, "airpods: listening mode write failed: {}", std::strerror(errno));
+            return false;
         }
 
         // Runs one channel from connect to close. Sets `delivered` when at least one
@@ -320,6 +382,8 @@ namespace tether::bluetooth {
                 const int ready = wait_for(fd, wake_fd, POLLIN, timeout);
                 if (ready == 0) {
                     drain_wake();
+                    if (!send_pending(fd))
+                        break;
                     continue;
                 }
                 if (ready < 0)
@@ -329,7 +393,17 @@ namespace tether::bluetooth {
                 if (got <= 0)
                     break;
 
-                auto update = parse_battery(buffer.data(), static_cast<size_t>(got));
+                const size_t size = static_cast<size_t>(got);
+                if (auto mode = parse_anc(buffer.data(), size)) {
+                    {
+                        std::lock_guard<std::mutex> lock(mutex);
+                        state.anc = *mode;
+                    }
+                    publish(delivered ? AirPodsStatus::Live : AirPodsStatus::Connecting, "");
+                    continue;
+                }
+
+                auto update = parse_battery(buffer.data(), size);
                 if (!update)
                     continue;
 
@@ -341,6 +415,11 @@ namespace tether::bluetooth {
                 publish(AirPodsStatus::Live, "");
             }
 
+            {
+                // A queued mode change does not outlive the channel it was meant for.
+                std::lock_guard<std::mutex> lock(mutex);
+                pending_anc.reset();
+            }
             ::close(fd);
         }
 
@@ -365,6 +444,7 @@ namespace tether::bluetooth {
                         state.address.clear();
                         state.name.clear();
                         state.battery = {};
+                        state.anc.reset();
                     }
                     publish(AirPodsStatus::Idle, "");
                     backoff_ms = BACKOFF_START_MS;
@@ -379,6 +459,7 @@ namespace tether::bluetooth {
                     if (state.address != address) {
                         state.address = address;
                         state.battery = {};
+                        state.anc.reset();
                     }
                     state.name = name;
                 }
@@ -435,6 +516,14 @@ namespace tether::bluetooth {
                 return;
             impl_->target_address = address;
             impl_->target_name = name;
+        }
+        impl_->wake();
+    }
+
+    void AirPodsWatcher::set_anc(AncMode mode) {
+        {
+            std::lock_guard<std::mutex> lock(impl_->mutex);
+            impl_->pending_anc = mode;
         }
         impl_->wake();
     }

--- a/src/core/src/bluetooth/airpods.cpp
+++ b/src/core/src/bluetooth/airpods.cpp
@@ -71,6 +71,10 @@ namespace tether::bluetooth {
 
         // Listening mode, sent and received on the same 11-byte:
         // 04 00 04 00 09 00 0D [mode] 00 00 00
+        // Ear detection: 04 00 04 00 06 00 [primary] [secondary]
+        constexpr uint8_t EAR_PREFIX[] = {0x04, 0x00, 0x04, 0x00, 0x06, 0x00};
+        constexpr size_t EAR_PACKET_BYTES = 8;
+
         constexpr uint8_t ANC_PREFIX[] = {0x04, 0x00, 0x04, 0x00, 0x09, 0x00, 0x0d};
         constexpr size_t ANC_PACKET_BYTES = 11;
         constexpr size_t ANC_MODE_OFFSET = 7;
@@ -152,6 +156,8 @@ namespace tether::bluetooth {
             {"right", s.battery.right},
             {"case", s.battery.case_},
             {"anc", s.anc ? nlohmann::json(to_string(*s.anc)) : nlohmann::json()},
+            {"ear", {{"primary", to_string(s.ear.primary)}, {"secondary", to_string(s.ear.secondary)}}},
+            {"in_ear", s.ear.in_ear()},
             {"status", to_string(s.status)},
             {"reason", s.reason},
         };
@@ -176,6 +182,41 @@ namespace tether::bluetooth {
             if (name == to_string(mode))
                 return mode;
         return std::nullopt;
+    }
+
+    const char* to_string(EarStatus status) {
+        switch (status) {
+        case EarStatus::Unknown:
+            return "unknown";
+        case EarStatus::InEar:
+            return "in_ear";
+        case EarStatus::OutOfEar:
+            return "out_of_ear";
+        case EarStatus::InCase:
+            return "in_case";
+        }
+        return "unknown";
+    }
+
+    std::optional<EarState> parse_ear(const uint8_t* data, size_t len) {
+        if (data == nullptr || len != EAR_PACKET_BYTES)
+            return std::nullopt;
+        if (std::memcmp(data, EAR_PREFIX, sizeof(EAR_PREFIX)) != 0)
+            return std::nullopt;
+
+        const auto decode = [](uint8_t byte) {
+            switch (byte) {
+            case 0x00:
+                return EarStatus::InEar;
+            case 0x01:
+                return EarStatus::OutOfEar;
+            case 0x02:
+                return EarStatus::InCase;
+            default:
+                return EarStatus::Unknown;
+            }
+        };
+        return EarState{decode(data[6]), decode(data[7])};
     }
 
     std::optional<AncMode> parse_anc(const uint8_t* data, size_t len) {
@@ -226,6 +267,23 @@ namespace tether::bluetooth {
         if (!update.has_left && !update.has_right && !update.has_case)
             return std::nullopt;
         return update;
+    }
+
+    MediaAction ear_media_action(const EarState& before, const EarState& after, PauseMode mode, bool holding) {
+        if (mode == PauseMode::Never)
+            return MediaAction::None;
+        if (!before.known() || !after.known() || before == after)
+            return MediaAction::None;
+
+        const int needed = mode == PauseMode::OneRemoved ? 2 : 1;
+        const bool worn_before = before.in_ear() >= needed;
+        const bool worn_after = after.in_ear() >= needed;
+
+        if (worn_before && !worn_after)
+            return MediaAction::Pause;
+        if (!worn_before && worn_after && holding)
+            return MediaAction::Resume;
+        return MediaAction::None;
     }
 
     const Device* find_airpods(const BluezObjects& objects) {
@@ -403,6 +461,15 @@ namespace tether::bluetooth {
                     continue;
                 }
 
+                if (auto ear = parse_ear(buffer.data(), size)) {
+                    {
+                        std::lock_guard<std::mutex> lock(mutex);
+                        state.ear = *ear;
+                    }
+                    publish(delivered ? AirPodsStatus::Live : AirPodsStatus::Connecting, "");
+                    continue;
+                }
+
                 auto update = parse_battery(buffer.data(), size);
                 if (!update)
                     continue;
@@ -445,6 +512,7 @@ namespace tether::bluetooth {
                         state.name.clear();
                         state.battery = {};
                         state.anc.reset();
+                        state.ear = {};
                     }
                     publish(AirPodsStatus::Idle, "");
                     backoff_ms = BACKOFF_START_MS;
@@ -460,6 +528,7 @@ namespace tether::bluetooth {
                         state.address = address;
                         state.battery = {};
                         state.anc.reset();
+                        state.ear = {};
                     }
                     state.name = name;
                 }

--- a/src/core/src/bluetooth/airpods.cpp
+++ b/src/core/src/bluetooth/airpods.cpp
@@ -1,0 +1,447 @@
+#include "tether/bluetooth/airpods.hpp"
+
+#include <tether/i18n.hpp>
+#include <tether/log.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+
+// The kernel's L2CAP ABI, declared here rather than pulled in from bluez-libs.
+// glibc already defines some of them.
+#ifndef AF_BLUETOOTH
+#define AF_BLUETOOTH 31
+#endif
+#ifndef SOL_BLUETOOTH
+#define SOL_BLUETOOTH 274
+#endif
+#ifndef BTPROTO_L2CAP
+#define BTPROTO_L2CAP 0
+#endif
+#ifndef BT_SECURITY
+#define BT_SECURITY 4
+#endif
+#ifndef BT_SECURITY_MEDIUM
+#define BT_SECURITY_MEDIUM 2
+#endif
+#ifndef BDADDR_BREDR
+#define BDADDR_BREDR 0
+#endif
+
+namespace {
+
+    struct sockaddr_l2 {
+        sa_family_t l2_family;
+        uint16_t l2_psm;
+        uint8_t l2_bdaddr[6];
+        uint16_t l2_cid;
+        uint8_t l2_bdaddr_type;
+    };
+
+    struct bt_security {
+        uint8_t level;
+        uint8_t key_size;
+    };
+
+} // namespace
+
+namespace tether::bluetooth {
+
+    AirPodsWatcher* g_airpods = nullptr;
+
+    namespace {
+
+        // AAP control packets,
+        constexpr uint8_t HANDSHAKE[] = {
+            0x00, 0x00, 0x04, 0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        constexpr uint8_t SET_FEATURES[] = {
+            0x04, 0x00, 0x04, 0x00, 0x4d, 0x00, 0xd7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        constexpr uint8_t REQUEST_NOTIFICATIONS[] = {0x04, 0x00, 0x04, 0x00, 0x0f, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+        constexpr uint8_t BATTERY_PREFIX[] = {0x04, 0x00, 0x04, 0x00, 0x04, 0x00};
+        constexpr size_t BATTERY_ENTRY_BYTES = 5;
+
+        constexpr int CONNECT_TIMEOUT_MS = 8000;
+        constexpr int FIRST_PACKET_TIMEOUT_MS = 8000;
+        // A channel that has gone quiet this long is recycled.
+        constexpr int IDLE_TIMEOUT_MS = 300000;
+        constexpr int BACKOFF_START_MS = 1000;
+        constexpr int BACKOFF_MAX_MS = 30000;
+        // A contended channel blocks with no error.
+        constexpr int BUSY_AFTER_ATTEMPTS = 3;
+
+        // "AA:BB:CC:DD:EE:FF" into the kernel's little-endian order.
+        bool parse_address(const std::string& text, uint8_t out[6]) {
+            if (text.size() != 17)
+                return false;
+            for (int i = 0; i < 6; ++i) {
+                const size_t at = static_cast<size_t>(i) * 3;
+                if (i < 5 && text[at + 2] != ':')
+                    return false;
+                char* end = nullptr;
+                const long byte = std::strtol(text.substr(at, 2).c_str(), &end, 16);
+                if (end == nullptr || *end != '\0' || byte < 0 || byte > 0xff)
+                    return false;
+                out[5 - i] = static_cast<uint8_t>(byte);
+            }
+            return true;
+        }
+
+        // Waits for `fd` or the wake eventfd. Returns 1 for fd, 0 for a wake, -1 on
+        // error or timeout. A negative timeout waits forever.
+        int wait_for(int fd, int wake_fd, short events, int timeout_ms) {
+            pollfd fds[2]{};
+            nfds_t count = 0;
+            int socket_slot = -1;
+            if (fd >= 0) {
+                socket_slot = static_cast<int>(count);
+                fds[count++] = {fd, events, 0};
+            }
+            const int wake_slot = static_cast<int>(count);
+            fds[count++] = {wake_fd, POLLIN, 0};
+
+            if (::poll(fds, count, timeout_ms) <= 0)
+                return -1;
+            if (socket_slot >= 0 && fds[socket_slot].revents != 0)
+                return 1;
+            return fds[wake_slot].revents != 0 ? 0 : -1;
+        }
+
+        bool write_all(int fd, const uint8_t* data, size_t len) {
+            return ::send(fd, data, len, MSG_NOSIGNAL) == static_cast<ssize_t>(len);
+        }
+
+    } // namespace
+
+    const char* to_string(AirPodsStatus status) {
+        switch (status) {
+        case AirPodsStatus::Idle:
+            return "idle";
+        case AirPodsStatus::Connecting:
+            return "connecting";
+        case AirPodsStatus::Live:
+            return "live";
+        case AirPodsStatus::Busy:
+            return "busy";
+        case AirPodsStatus::Failed:
+            return "failed";
+        }
+        return "idle";
+    }
+
+    nlohmann::json to_json(const AirPodsState& s) {
+        return {
+            {"command", "bt_airpods"},
+            {"address", s.address},
+            {"name", s.name},
+            {"left", s.battery.left},
+            {"right", s.battery.right},
+            {"case", s.battery.case_},
+            {"status", to_string(s.status)},
+            {"reason", s.reason},
+        };
+    }
+
+    std::optional<BatteryUpdate> parse_battery(const uint8_t* data, size_t len) {
+        if (data == nullptr || len < sizeof(BATTERY_PREFIX) + 1)
+            return std::nullopt;
+        if (std::memcmp(data, BATTERY_PREFIX, sizeof(BATTERY_PREFIX)) != 0)
+            return std::nullopt;
+
+        const size_t count = data[sizeof(BATTERY_PREFIX)];
+        size_t offset = sizeof(BATTERY_PREFIX) + 1;
+        if (count == 0 || offset + count * BATTERY_ENTRY_BYTES > len)
+            return std::nullopt;
+
+        BatteryUpdate update;
+        for (size_t i = 0; i < count; ++i, offset += BATTERY_ENTRY_BYTES) {
+            const uint8_t component = data[offset];
+            const uint8_t level = data[offset + 2];
+            const uint8_t status = data[offset + 3];
+            const int percent = (status == AAP_STATUS_DISCONNECTED || level > 100) ? -1 : static_cast<int>(level);
+            switch (component) {
+            case AAP_COMPONENT_LEFT:
+                update.levels.left = percent;
+                update.has_left = true;
+                break;
+            case AAP_COMPONENT_RIGHT:
+                update.levels.right = percent;
+                update.has_right = true;
+                break;
+            case AAP_COMPONENT_CASE:
+                update.levels.case_ = percent;
+                update.has_case = true;
+                break;
+            default:
+                break;
+            }
+        }
+        if (!update.has_left && !update.has_right && !update.has_case)
+            return std::nullopt;
+        return update;
+    }
+
+    const Device* find_airpods(const BluezObjects& objects) {
+        for (const auto& device : objects.devices)
+            if (device.connected && device.looks_like_airpods())
+                return &device;
+        return nullptr;
+    }
+
+    void merge_battery(AirPodsBattery& into, const BatteryUpdate& update) {
+        if (update.has_left)
+            into.left = update.levels.left;
+        if (update.has_right)
+            into.right = update.levels.right;
+        if (update.has_case)
+            into.case_ = update.levels.case_;
+    }
+
+    struct AirPodsWatcher::Impl {
+        explicit Impl(std::function<void(const AirPodsState&)> cb) : on_change(std::move(cb)) {}
+
+        std::function<void(const AirPodsState&)> on_change;
+
+        mutable std::mutex mutex;
+        AirPodsState state;
+        AirPodsState published;
+        std::string target_address;
+        std::string target_name;
+        bool stopping = false;
+
+        int wake_fd = -1;
+        std::thread worker;
+
+        void wake() {
+            const uint64_t one = 1;
+            [[maybe_unused]] const ssize_t written = ::write(wake_fd, &one, sizeof(one));
+        }
+
+        void drain_wake() {
+            uint64_t value = 0;
+            [[maybe_unused]] const ssize_t got = ::read(wake_fd, &value, sizeof(value));
+        }
+
+        // Publishes only when the state actually changed, as the connection status does.
+        void publish(AirPodsStatus status, const std::string& reason) {
+            AirPodsState copy;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                state.status = status;
+                state.reason = reason;
+                if (state == published)
+                    return;
+                published = state;
+                copy = state;
+            }
+            if (on_change)
+                on_change(copy);
+        }
+
+        bool retargeted(const std::string& address) const {
+            std::lock_guard<std::mutex> lock(mutex);
+            return stopping || target_address != address;
+        }
+
+        // Sleeps, returning early if the target changed or the watcher is stopping.
+        void backoff(int ms) {
+            if (wait_for(-1, wake_fd, 0, ms) == 0)
+                drain_wake();
+        }
+
+        // Runs one channel from connect to close. Sets `delivered` when at least one
+        // battery packet arrived, which is what separates a contended channel from a
+        // healthy but quiet one.
+        void session(const std::string& address, bool& delivered) {
+            uint8_t addr[6] = {};
+            if (!parse_address(address, addr)) {
+                publish(AirPodsStatus::Failed, _("The AirPods address could not be read."));
+                return;
+            }
+
+            const int fd = ::socket(AF_BLUETOOTH, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, BTPROTO_L2CAP);
+            if (fd < 0) {
+                debug::log(DEBUG, "airpods: socket failed: {}", std::strerror(errno));
+                publish(AirPodsStatus::Failed, _("Bluetooth sockets are unavailable on this system."));
+                return;
+            }
+
+            sockaddr_l2 sa{};
+            sa.l2_family = AF_BLUETOOTH;
+            sa.l2_psm = AAP_PSM;
+            sa.l2_bdaddr_type = BDADDR_BREDR;
+            std::memcpy(sa.l2_bdaddr, addr, sizeof(addr));
+
+            int rc = ::connect(fd, reinterpret_cast<sockaddr*>(&sa), sizeof(sa));
+            if (rc < 0 && (errno == EACCES || errno == EPERM)) {
+                // Some controllers refuse an unauthenticated channel.
+                bt_security sec{BT_SECURITY_MEDIUM, 0};
+                ::setsockopt(fd, SOL_BLUETOOTH, BT_SECURITY, &sec, sizeof(sec));
+                rc = ::connect(fd, reinterpret_cast<sockaddr*>(&sa), sizeof(sa));
+            }
+            if (rc < 0 && errno != EINPROGRESS) {
+                debug::log(DEBUG, "airpods: connect failed: {}", std::strerror(errno));
+                ::close(fd);
+                return;
+            }
+            if (rc < 0) {
+                if (wait_for(fd, wake_fd, POLLOUT, CONNECT_TIMEOUT_MS) != 1) {
+                    debug::log(DEBUG, "airpods: channel did not open within {}ms", CONNECT_TIMEOUT_MS);
+                    ::close(fd);
+                    return;
+                }
+                int error = 0;
+                socklen_t size = sizeof(error);
+                if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &size) < 0 || error != 0) {
+                    debug::log(DEBUG, "airpods: connect failed: {}", std::strerror(error));
+                    ::close(fd);
+                    return;
+                }
+            }
+
+            if (!write_all(fd, HANDSHAKE, sizeof(HANDSHAKE)) || !write_all(fd, SET_FEATURES, sizeof(SET_FEATURES)) ||
+                !write_all(fd, REQUEST_NOTIFICATIONS, sizeof(REQUEST_NOTIFICATIONS))) {
+                debug::log(DEBUG, "airpods: handshake failed: {}", std::strerror(errno));
+                ::close(fd);
+                return;
+            }
+
+            std::array<uint8_t, 1024> buffer{};
+            while (!retargeted(address)) {
+                const int timeout = delivered ? IDLE_TIMEOUT_MS : FIRST_PACKET_TIMEOUT_MS;
+                const int ready = wait_for(fd, wake_fd, POLLIN, timeout);
+                if (ready == 0) {
+                    drain_wake();
+                    continue;
+                }
+                if (ready < 0)
+                    break;
+
+                const ssize_t got = ::recv(fd, buffer.data(), buffer.size(), 0);
+                if (got <= 0)
+                    break;
+
+                auto update = parse_battery(buffer.data(), static_cast<size_t>(got));
+                if (!update)
+                    continue;
+
+                delivered = true;
+                {
+                    std::lock_guard<std::mutex> lock(mutex);
+                    merge_battery(state.battery, *update);
+                }
+                publish(AirPodsStatus::Live, "");
+            }
+
+            ::close(fd);
+        }
+
+        void run() {
+            int backoff_ms = BACKOFF_START_MS;
+            int quiet_attempts = 0;
+
+            while (true) {
+                std::string address;
+                std::string name;
+                {
+                    std::lock_guard<std::mutex> lock(mutex);
+                    if (stopping)
+                        return;
+                    address = target_address;
+                    name = target_name;
+                }
+
+                if (address.empty()) {
+                    {
+                        std::lock_guard<std::mutex> lock(mutex);
+                        state.address.clear();
+                        state.name.clear();
+                        state.battery = {};
+                    }
+                    publish(AirPodsStatus::Idle, "");
+                    backoff_ms = BACKOFF_START_MS;
+                    quiet_attempts = 0;
+                    if (wait_for(-1, wake_fd, 0, -1) == 0)
+                        drain_wake();
+                    continue;
+                }
+
+                {
+                    std::lock_guard<std::mutex> lock(mutex);
+                    if (state.address != address) {
+                        state.address = address;
+                        state.battery = {};
+                    }
+                    state.name = name;
+                }
+                if (quiet_attempts < BUSY_AFTER_ATTEMPTS)
+                    publish(AirPodsStatus::Connecting, "");
+
+                bool delivered = false;
+                session(address, delivered);
+
+                if (retargeted(address))
+                    continue;
+
+                if (delivered) {
+                    quiet_attempts = 0;
+                    backoff_ms = BACKOFF_START_MS;
+                } else if (++quiet_attempts == BUSY_AFTER_ATTEMPTS) {
+                    debug::log(INFO, "airpods: the AAP channel is not answering; another program probably holds it");
+                    publish(AirPodsStatus::Busy, _("Another program is using the AirPods channel."));
+                }
+
+                backoff(backoff_ms);
+                backoff_ms = std::min(backoff_ms * 2, BACKOFF_MAX_MS);
+            }
+        }
+    };
+
+    AirPodsWatcher::AirPodsWatcher(std::function<void(const AirPodsState&)> on_change)
+        : impl_(std::make_unique<Impl>(std::move(on_change))) {
+        impl_->wake_fd = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+        if (impl_->wake_fd < 0) {
+            debug::log(WARN, "airpods: eventfd failed: {}", std::strerror(errno));
+            return;
+        }
+        impl_->worker = std::thread([this] { impl_->run(); });
+    }
+
+    AirPodsWatcher::~AirPodsWatcher() {
+        if (impl_->worker.joinable()) {
+            {
+                std::lock_guard<std::mutex> lock(impl_->mutex);
+                impl_->stopping = true;
+            }
+            impl_->wake();
+            impl_->worker.join();
+        }
+        if (impl_->wake_fd >= 0)
+            ::close(impl_->wake_fd);
+    }
+
+    void AirPodsWatcher::set_device(const std::string& address, const std::string& name) {
+        {
+            std::lock_guard<std::mutex> lock(impl_->mutex);
+            if (impl_->target_address == address && impl_->target_name == name)
+                return;
+            impl_->target_address = address;
+            impl_->target_name = name;
+        }
+        impl_->wake();
+    }
+
+    AirPodsState AirPodsWatcher::state() const {
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        return impl_->state;
+    }
+
+} // namespace tether::bluetooth

--- a/src/core/src/bluetooth/config.cpp
+++ b/src/core/src/bluetooth/config.cpp
@@ -23,6 +23,26 @@ namespace tether::bluetooth {
         return value == "explicit-pair" ? AuthStrategy::ExplicitPair : AuthStrategy::ConnectFirst;
     }
 
+    const char* to_string(PauseMode mode) {
+        switch (mode) {
+        case PauseMode::Never:
+            return "never";
+        case PauseMode::OneRemoved:
+            return "one-removed";
+        case PauseMode::BothRemoved:
+            return "both-removed";
+        }
+        return "never";
+    }
+
+    PauseMode pause_mode_from_string(const std::string& value) {
+        if (value == "one-removed")
+            return PauseMode::OneRemoved;
+        if (value == "both-removed")
+            return PauseMode::BothRemoved;
+        return PauseMode::Never;
+    }
+
     std::string config_path() {
         const std::filesystem::path dir = paths::config_dir();
         if (dir.empty())
@@ -43,6 +63,7 @@ namespace tether::bluetooth {
         j["adapter"] = config.adapter;
         j["retention"] = to_string(config.retention);
         j["desktop_popups_enabled"] = config.desktop_popups_enabled;
+        j["airpods_pause"] = to_string(config.airpods_pause);
         return j.dump(2);
     }
 
@@ -63,6 +84,7 @@ namespace tether::bluetooth {
             config.adapter = j.value("adapter", "");
             config.retention = retention_from_string(j.value("retention", "encrypted"));
             config.desktop_popups_enabled = j.value("desktop_popups_enabled", true);
+            config.airpods_pause = pause_mode_from_string(j.value("airpods_pause", ""));
         } catch (const std::exception&) {
             // A corrupt file must not stop the daemon; defaults are safe.
         }

--- a/src/core/src/bluetooth/config.cpp
+++ b/src/core/src/bluetooth/config.cpp
@@ -64,6 +64,7 @@ namespace tether::bluetooth {
         j["retention"] = to_string(config.retention);
         j["desktop_popups_enabled"] = config.desktop_popups_enabled;
         j["airpods_pause"] = to_string(config.airpods_pause);
+        j["airpods_handoff"] = config.airpods_handoff;
         return j.dump(2);
     }
 
@@ -85,6 +86,7 @@ namespace tether::bluetooth {
             config.retention = retention_from_string(j.value("retention", "encrypted"));
             config.desktop_popups_enabled = j.value("desktop_popups_enabled", true);
             config.airpods_pause = pause_mode_from_string(j.value("airpods_pause", ""));
+            config.airpods_handoff = j.value("airpods_handoff", false);
         } catch (const std::exception&) {
             // A corrupt file must not stop the daemon; defaults are safe.
         }

--- a/src/core/src/bluetooth/objects.cpp
+++ b/src/core/src/bluetooth/objects.cpp
@@ -211,6 +211,7 @@ namespace tether::bluetooth {
             d.trusted = get_bool(props, "Trusted");
             d.connected = get_bool(props, "Connected");
             d.uuids = get_strv(props, "UUIDs");
+            d.modalias = get_string(props, "Modalias");
             d.preferred_bearer = get_string(props, "PreferredBearer");
             d.services_resolved = get_bool(props, "ServicesResolved");
             g_variant_unref(props);
@@ -250,6 +251,24 @@ namespace tether::bluetooth {
     }
 
     bool Device::looks_like_iphone() const { return supports_ancs() || (supports_map() && supports_pbap()); }
+
+    bool Device::looks_like_airpods() const {
+        // An iPhone carries the same vendor id, so the audio profile is what separates them.
+        if (looks_like_iphone() || !has_uuid(UUID_A2DP_SINK))
+            return false;
+        std::string lowered = modalias;
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+        if (lowered.rfind(MODALIAS_APPLE, 0) == 0)
+            return true;
+        // Modalias is absent until SDP has been read at least once.
+        lowered = name;
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+        });
+        return lowered.find("airpod") != std::string::npos;
+    }
 
     const Adapter* BluezObjects::find_adapter(const std::string& path) const {
         auto it = std::find_if(adapters.begin(), adapters.end(), [&](const Adapter& a) { return a.path == path; });
@@ -581,6 +600,7 @@ namespace tether::bluetooth {
             {"ancs_notifying", d.ancs_notifying},
             {"services_resolved", d.services_resolved},
             {"iphone", d.looks_like_iphone()},
+            {"airpods", d.looks_like_airpods()},
         };
     }
 

--- a/src/core/src/bluetooth/pairing.cpp
+++ b/src/core/src/bluetooth/pairing.cpp
@@ -788,6 +788,36 @@ namespace tether::bluetooth {
         return result;
     }
 
+    namespace {
+        constexpr int DEVICE_CALL_TIMEOUT_MS = 15000;
+
+        bool call_device_by_address(BluezMonitor& monitor,
+                                    const std::string& address,
+                                    const char* method,
+                                    std::string& err) {
+            GDBusConnection* conn = monitor.connection();
+            if (!conn) {
+                err = "no system bus";
+                return false;
+            }
+            const auto objects = monitor.snapshot();
+            const Device* device = find_by_address(objects, normalize_address(address));
+            if (!device) {
+                err = "no such device";
+                return false;
+            }
+            return call_device(conn, device->path, method, DEVICE_CALL_TIMEOUT_MS, err);
+        }
+    } // namespace
+
+    bool connect_device(BluezMonitor& monitor, const std::string& address, std::string& err) {
+        return call_device_by_address(monitor, address, "Connect", err);
+    }
+
+    bool disconnect_device(BluezMonitor& monitor, const std::string& address, std::string& err) {
+        return call_device_by_address(monitor, address, "Disconnect", err);
+    }
+
     bool scan_devices(BluezMonitor& monitor, int seconds, const std::function<void()>& on_tick, std::string& err) {
         GDBusConnection* conn = monitor.connection();
         if (!conn) {

--- a/src/core/src/mpris.cpp
+++ b/src/core/src/mpris.cpp
@@ -1,0 +1,194 @@
+#include "tether/mpris.hpp"
+
+#include <tether/log.hpp>
+
+#include <gio/gio.h>
+#include <mutex>
+
+namespace tether {
+
+    namespace {
+
+        constexpr const char* MPRIS_PREFIX = "org.mpris.MediaPlayer2.";
+        constexpr const char* MPRIS_PATH = "/org/mpris/MediaPlayer2";
+        constexpr const char* PLAYER_IFACE = "org.mpris.MediaPlayer2.Player";
+
+        constexpr int CALL_TIMEOUT_MS = 1000;
+
+        std::string playback_status(GDBusConnection* bus, const std::string& name) {
+            GError* error = nullptr;
+            GVariant* reply = g_dbus_connection_call_sync(bus,
+                                                          name.c_str(),
+                                                          MPRIS_PATH,
+                                                          "org.freedesktop.DBus.Properties",
+                                                          "Get",
+                                                          g_variant_new("(ss)", PLAYER_IFACE, "PlaybackStatus"),
+                                                          G_VARIANT_TYPE("(v)"),
+                                                          G_DBUS_CALL_FLAGS_NO_AUTO_START,
+                                                          CALL_TIMEOUT_MS,
+                                                          nullptr,
+                                                          &error);
+            if (!reply) {
+                g_clear_error(&error);
+                return {};
+            }
+
+            GVariant* boxed = nullptr;
+            g_variant_get(reply, "(v)", &boxed);
+            std::string status;
+            if (boxed) {
+                if (const char* text = g_variant_get_string(boxed, nullptr))
+                    status = text;
+                g_variant_unref(boxed);
+            }
+            g_variant_unref(reply);
+            return status;
+        }
+
+        bool call_player(GDBusConnection* bus, const std::string& name, const char* method) {
+            GError* error = nullptr;
+            GVariant* reply = g_dbus_connection_call_sync(bus,
+                                                          name.c_str(),
+                                                          MPRIS_PATH,
+                                                          PLAYER_IFACE,
+                                                          method,
+                                                          nullptr,
+                                                          nullptr,
+                                                          G_DBUS_CALL_FLAGS_NO_AUTO_START,
+                                                          CALL_TIMEOUT_MS,
+                                                          nullptr,
+                                                          &error);
+            if (!reply) {
+                debug::log(DEBUG, "mpris: {} on {} failed: {}", method, name, error ? error->message : "unknown");
+                g_clear_error(&error);
+                return false;
+            }
+            g_variant_unref(reply);
+            return true;
+        }
+
+    } // namespace
+
+    struct MediaControl::Impl {
+        mutable std::mutex mutex;
+        std::vector<std::string> paused;
+
+        // Resolved on first use: the daemon starts before the session bus is necessarily interesting.
+        GDBusConnection* bus() const {
+            static GDBusConnection* connection = [] {
+                GError* error = nullptr;
+                GDBusConnection* c = g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, &error);
+                if (!c) {
+                    debug::log(DEBUG, "mpris: no session bus: {}", error ? error->message : "unknown");
+                    g_clear_error(&error);
+                }
+                return c;
+            }();
+            return connection;
+        }
+
+        std::vector<std::string> players() const {
+            GDBusConnection* connection = bus();
+            if (!connection)
+                return {};
+
+            GError* error = nullptr;
+            GVariant* reply = g_dbus_connection_call_sync(connection,
+                                                          "org.freedesktop.DBus",
+                                                          "/org/freedesktop/DBus",
+                                                          "org.freedesktop.DBus",
+                                                          "ListNames",
+                                                          nullptr,
+                                                          G_VARIANT_TYPE("(as)"),
+                                                          G_DBUS_CALL_FLAGS_NONE,
+                                                          CALL_TIMEOUT_MS,
+                                                          nullptr,
+                                                          &error);
+            if (!reply) {
+                debug::log(DEBUG, "mpris: ListNames failed: {}", error ? error->message : "unknown");
+                g_clear_error(&error);
+                return {};
+            }
+
+            std::vector<std::string> names;
+            GVariantIter* iter = nullptr;
+            const char* name = nullptr;
+            g_variant_get(reply, "(as)", &iter);
+            while (g_variant_iter_next(iter, "&s", &name)) {
+                if (g_str_has_prefix(name, MPRIS_PREFIX))
+                    names.emplace_back(name);
+            }
+            g_variant_iter_free(iter);
+            g_variant_unref(reply);
+            return names;
+        }
+    };
+
+    MediaControl::MediaControl() : impl_(std::make_unique<Impl>()) {}
+    MediaControl::~MediaControl() = default;
+
+    std::vector<std::string> MediaControl::playing() const {
+        GDBusConnection* bus = impl_->bus();
+        if (!bus)
+            return {};
+
+        std::vector<std::string> result;
+        for (const auto& name : impl_->players()) {
+            if (playback_status(bus, name) == "Playing")
+                result.push_back(name);
+        }
+        return result;
+    }
+
+    size_t MediaControl::pause() {
+        GDBusConnection* bus = impl_->bus();
+        if (!bus)
+            return 0;
+        {
+            std::lock_guard<std::mutex> lock(impl_->mutex);
+            if (!impl_->paused.empty())
+                return 0;
+        }
+
+        std::vector<std::string> held;
+        for (const auto& name : playing()) {
+            if (call_player(bus, name, "Pause"))
+                held.push_back(name);
+        }
+        if (held.empty())
+            return 0;
+
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        impl_->paused = std::move(held);
+        return impl_->paused.size();
+    }
+
+    size_t MediaControl::resume() {
+        GDBusConnection* bus = impl_->bus();
+        std::vector<std::string> held;
+        {
+            std::lock_guard<std::mutex> lock(impl_->mutex);
+            held.swap(impl_->paused);
+        }
+        if (!bus)
+            return 0;
+
+        size_t resumed = 0;
+        for (const auto& name : held) {
+            if (call_player(bus, name, "Play"))
+                ++resumed;
+        }
+        return resumed;
+    }
+
+    bool MediaControl::holding() const {
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        return !impl_->paused.empty();
+    }
+
+    void MediaControl::forget() {
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        impl_->paused.clear();
+    }
+
+} // namespace tether

--- a/src/core/src/mpris.cpp
+++ b/src/core/src/mpris.cpp
@@ -7,6 +7,8 @@
 
 namespace tether {
 
+    MediaControl* g_media = nullptr;
+
     namespace {
 
         constexpr const char* MPRIS_PREFIX = "org.mpris.MediaPlayer2.";

--- a/src/core/src/net.cpp
+++ b/src/core/src/net.cpp
@@ -310,6 +310,7 @@ namespace tether {
         status["retention"] = to_string(config.retention);
         status["retention_ready"] = secret::have_key();
         status["desktop_popups_enabled"] = config.desktop_popups_enabled;
+        status["airpods_pause"] = to_string(config.airpods_pause);
         status["version"] = TETHER_VERSION;
         if (!bluetooth::g_bluez) {
             status["capability"] = nullptr;
@@ -957,6 +958,12 @@ namespace tether {
                     } else if (j.contains("command") && j["command"] == "bt_airpods") {
                         std::string payload = build_bt_airpods().dump() + "\n";
                         write_plain_packet(client_fd, payload);
+                        continue;
+                    } else if (j.contains("command") && j["command"] == "bt_airpods_pause" && j.contains("mode")) {
+                        auto config = bluetooth::load_config();
+                        config.airpods_pause = bluetooth::pause_mode_from_string(j["mode"]);
+                        bluetooth::save_config(config);
+                        broadcast_local_event(build_bt_status().dump());
                         continue;
                     } else if (j.contains("command") && j["command"] == "bt_airpods_mode" && j.contains("mode")) {
                         const auto mode = bluetooth::anc_mode_from_string(j.value("mode", ""));

--- a/src/core/src/net.cpp
+++ b/src/core/src/net.cpp
@@ -958,6 +958,22 @@ namespace tether {
                         std::string payload = build_bt_airpods().dump() + "\n";
                         write_plain_packet(client_fd, payload);
                         continue;
+                    } else if (j.contains("command") && j["command"] == "bt_airpods_mode" && j.contains("mode")) {
+                        const auto mode = bluetooth::anc_mode_from_string(j.value("mode", ""));
+                        nlohmann::json reply;
+                        reply["command"] = "bt_airpods_mode_result";
+                        if (!mode) {
+                            reply["success"] = false;
+                            reply["message"] = _("Unknown listening mode.");
+                        } else if (!bluetooth::g_airpods || bluetooth::g_airpods->state().address.empty()) {
+                            reply["success"] = false;
+                            reply["message"] = _("No AirPods are connected.");
+                        } else {
+                            bluetooth::g_airpods->set_anc(*mode);
+                            reply["success"] = true;
+                        }
+                        write_plain_packet(client_fd, reply.dump() + "\n");
+                        continue;
                     } else if (j.contains("command") && j["command"] == "bt_list_devices") {
                         std::string payload = build_bt_devices().dump() + "\n";
                         write_plain_packet(client_fd, payload);

--- a/src/core/src/net.cpp
+++ b/src/core/src/net.cpp
@@ -15,6 +15,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include "tether/bluetooth/airpods.hpp"
 #include "tether/bluetooth/config.hpp"
 #include "tether/bluetooth/connection.hpp"
 #include "tether/bluetooth/contacts.hpp"
@@ -669,6 +670,12 @@ namespace tether {
         return result;
     }
 
+    nlohmann::json build_bt_airpods() {
+        if (!bluetooth::g_airpods)
+            return bluetooth::to_json(bluetooth::AirPodsState{});
+        return bluetooth::to_json(bluetooth::g_airpods->state());
+    }
+
     static nlohmann::json build_local_state_snapshot() {
         nlohmann::json snapshot;
         snapshot["command"] = "state_snapshot";
@@ -947,6 +954,10 @@ namespace tether {
                         continue;
                     } else if (j.contains("command") && j["command"] == "bt_scan") {
                         std::thread(run_bt_scan).detach();
+                    } else if (j.contains("command") && j["command"] == "bt_airpods") {
+                        std::string payload = build_bt_airpods().dump() + "\n";
+                        write_plain_packet(client_fd, payload);
+                        continue;
                     } else if (j.contains("command") && j["command"] == "bt_list_devices") {
                         std::string payload = build_bt_devices().dump() + "\n";
                         write_plain_packet(client_fd, payload);

--- a/src/core/src/net.cpp
+++ b/src/core/src/net.cpp
@@ -311,6 +311,7 @@ namespace tether {
         status["retention_ready"] = secret::have_key();
         status["desktop_popups_enabled"] = config.desktop_popups_enabled;
         status["airpods_pause"] = to_string(config.airpods_pause);
+        status["airpods_handoff"] = config.airpods_handoff;
         status["version"] = TETHER_VERSION;
         if (!bluetooth::g_bluez) {
             status["capability"] = nullptr;
@@ -958,6 +959,12 @@ namespace tether {
                     } else if (j.contains("command") && j["command"] == "bt_airpods") {
                         std::string payload = build_bt_airpods().dump() + "\n";
                         write_plain_packet(client_fd, payload);
+                        continue;
+                    } else if (j.contains("command") && j["command"] == "bt_airpods_handoff" && j.contains("enabled")) {
+                        auto config = bluetooth::load_config();
+                        config.airpods_handoff = j.value("enabled", false);
+                        bluetooth::save_config(config);
+                        broadcast_local_event(build_bt_status().dump());
                         continue;
                     } else if (j.contains("command") && j["command"] == "bt_airpods_pause" && j.contains("mode")) {
                         auto config = bluetooth::load_config();

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -10,6 +10,7 @@
 #include <tether/bluetooth/connection.hpp>
 #include <tether/bluetooth/contacts.hpp>
 #include <tether/bluetooth/monitor.hpp>
+#include <tether/bluetooth/pairing.hpp>
 #include <tether/core.hpp>
 #include <tether/crypto.hpp>
 #include <tether/discovery.hpp>
@@ -48,6 +49,10 @@ static void redirect_output_to_log() {
         // Losing the log is survivable; failing to start is not.
     }
 }
+
+// How long to let the phone finish with the buds before reclaiming them.
+constexpr int HANDOFF_SETTLE_SECONDS = 2;
+constexpr int HANDOFF_RECLAIM_ATTEMPTS = 3;
 
 int main(int argc, char** argv) {
     redirect_output_to_log();
@@ -248,29 +253,122 @@ int main(int argc, char** argv) {
     // Pick the controller before the first capability, a second adapter never comes up bound to the wrong one.
     bluez.set_preferred_adapter(bt_config.adapter);
 
+    // Handing the buds to the iPhone for a call and taking them back after.
+    struct Handoff {
+        mutable std::mutex mutex;
+        std::string released;
+        bool busy = false;
+
+        bool holding_buds() const {
+            std::lock_guard<std::mutex> lock(mutex);
+            return !released.empty();
+        }
+    };
+    auto handoff = std::make_shared<Handoff>();
+
     // AirPods battery arrives on its own L2CAP channel, not through BlueZ.
     tether::MediaControl media;
     tether::bluetooth::EarState last_ear;
-    tether::bluetooth::AirPodsWatcher airpods([&media, &last_ear](const tether::bluetooth::AirPodsState& state) {
-        const auto mode = tether::bluetooth::load_config().airpods_pause;
-        switch (tether::bluetooth::ear_media_action(last_ear, state.ear, mode, media.holding())) {
-        case tether::bluetooth::MediaAction::Pause:
-            if (const size_t paused = media.pause())
-                debug::log(INFO, "airpods: paused {} player(s), a bud came out", paused);
-            break;
-        case tether::bluetooth::MediaAction::Resume:
-            if (const size_t resumed = media.resume())
-                debug::log(INFO, "airpods: resumed {} player(s), the buds went back in", resumed);
-            break;
-        case tether::bluetooth::MediaAction::None:
-            break;
-        }
-        if (state.address.empty())
-            media.forget();
-        last_ear = state.ear;
+    tether::bluetooth::AirPodsWatcher airpods(
+        [&media, &last_ear, handoff](const tether::bluetooth::AirPodsState& state) {
+            const auto mode = tether::bluetooth::load_config().airpods_pause;
+            switch (tether::bluetooth::ear_media_action(last_ear, state.ear, mode, media.holding())) {
+            case tether::bluetooth::MediaAction::Pause:
+                if (const size_t paused = media.pause())
+                    debug::log(INFO, "airpods: paused {} player(s), a bud came out", paused);
+                break;
+            case tether::bluetooth::MediaAction::Resume:
+                if (const size_t resumed = media.resume())
+                    debug::log(INFO, "airpods: resumed {} player(s), the buds went back in", resumed);
+                break;
+            case tether::bluetooth::MediaAction::None:
+                break;
+            }
 
-        tether::broadcast_local_event(tether::bluetooth::to_json(state).dump());
-    });
+            if (state.address.empty() && !handoff->holding_buds())
+                media.forget();
+
+            last_ear = state.ear;
+
+            tether::broadcast_local_event(tether::bluetooth::to_json(state).dump());
+        });
+    const auto run_handoff = [&bluez, &media, handoff](const nlohmann::json& calls) {
+        const auto config = tether::bluetooth::load_config();
+        const bool active = tether::bluetooth::call_wants_audio(calls);
+
+        std::string target;
+        bool released_now = false;
+        {
+            std::lock_guard<std::mutex> lock(handoff->mutex);
+            if (handoff->busy)
+                return;
+            released_now = !handoff->released.empty();
+            target = handoff->released;
+        }
+
+        // The snapshot has to outlive the pointer into it.
+        const auto snapshot = bluez.snapshot();
+        const auto* device = tether::bluetooth::find_airpods(snapshot);
+        if (!released_now && device)
+            target = device->address;
+
+        const auto action =
+            tether::bluetooth::handoff_action(active, device != nullptr, released_now, config.airpods_handoff);
+        if (action == tether::bluetooth::HandoffAction::None || target.empty())
+            return;
+
+        {
+            std::lock_guard<std::mutex> lock(handoff->mutex);
+            handoff->busy = true;
+        }
+
+        if (action == tether::bluetooth::HandoffAction::Release) {
+            media.pause();
+            {
+                std::lock_guard<std::mutex> lock(handoff->mutex);
+                handoff->released = target;
+            }
+            std::string err;
+            const bool ok = tether::bluetooth::disconnect_device(bluez, target, err);
+            std::lock_guard<std::mutex> lock(handoff->mutex);
+            handoff->busy = false;
+            if (ok) {
+                debug::log(INFO, "airpods: handed the buds to the iPhone for a call");
+            } else {
+                handoff->released.clear();
+                debug::log(WARN, "airpods: could not release the buds: {}", err);
+            }
+            return;
+        }
+
+        std::thread([handoff, target] {
+            // The phone does not drop them the instant the call ends.
+            std::this_thread::sleep_for(std::chrono::seconds(HANDOFF_SETTLE_SECONDS));
+            bool ok = false;
+            for (int attempt = 0; attempt < HANDOFF_RECLAIM_ATTEMPTS && !ok; ++attempt) {
+                std::string err;
+                ok = tether::bluetooth::g_bluez &&
+                     tether::bluetooth::connect_device(*tether::bluetooth::g_bluez, target, err);
+                if (!ok) {
+                    debug::log(DEBUG, "airpods: reclaim attempt {} failed: {}", attempt + 1, err);
+                    std::this_thread::sleep_for(std::chrono::seconds(HANDOFF_SETTLE_SECONDS));
+                }
+            }
+            if (tether::g_media) {
+                if (ok)
+                    tether::g_media->resume();
+                else
+                    tether::g_media->forget();
+            }
+            debug::log(ok ? INFO : WARN,
+                       ok ? "airpods: took the buds back after the call"
+                          : "airpods: the buds did not come back; leaving them to the phone");
+            std::lock_guard<std::mutex> lock(handoff->mutex);
+            handoff->released.clear();
+            handoff->busy = false;
+        }).detach();
+    };
+
     const auto follow_airpods = [&bluez, &airpods]() {
         const auto snapshot = bluez.snapshot();
         const auto* device = tether::bluetooth::find_airpods(snapshot);
@@ -280,6 +378,7 @@ int main(int argc, char** argv) {
     if (bluez.start()) {
         tether::bluetooth::g_bluez = &bluez;
         tether::bluetooth::g_airpods = &airpods;
+        tether::g_media = &media;
         loop.addFd(bluez.event_fd(), [&bluez, &follow_airpods](int) {
             bluez.drain();
             tether::broadcast_local_event(tether::build_bt_devices().dump());
@@ -346,7 +445,9 @@ int main(int argc, char** argv) {
                 });
         }
 
-        connections.set_call_handler([](const nlohmann::json& calls) {
+        connections.set_call_handler([&run_handoff](const nlohmann::json& calls) {
+            run_handoff(calls);
+
             nlohmann::json event;
             event["command"] = "bt_calls";
             event["calls"] = calls;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -17,6 +17,7 @@
 #include <tether/file_transfer.hpp>
 #include <tether/i18n.hpp>
 #include <tether/log.hpp>
+#include <tether/mpris.hpp>
 #include <tether/net.hpp>
 #include <tether/otp.hpp>
 #include <tether/secret_store.hpp>
@@ -248,7 +249,26 @@ int main(int argc, char** argv) {
     bluez.set_preferred_adapter(bt_config.adapter);
 
     // AirPods battery arrives on its own L2CAP channel, not through BlueZ.
-    tether::bluetooth::AirPodsWatcher airpods([](const tether::bluetooth::AirPodsState& state) {
+    tether::MediaControl media;
+    tether::bluetooth::EarState last_ear;
+    tether::bluetooth::AirPodsWatcher airpods([&media, &last_ear](const tether::bluetooth::AirPodsState& state) {
+        const auto mode = tether::bluetooth::load_config().airpods_pause;
+        switch (tether::bluetooth::ear_media_action(last_ear, state.ear, mode, media.holding())) {
+        case tether::bluetooth::MediaAction::Pause:
+            if (const size_t paused = media.pause())
+                debug::log(INFO, "airpods: paused {} player(s), a bud came out", paused);
+            break;
+        case tether::bluetooth::MediaAction::Resume:
+            if (const size_t resumed = media.resume())
+                debug::log(INFO, "airpods: resumed {} player(s), the buds went back in", resumed);
+            break;
+        case tether::bluetooth::MediaAction::None:
+            break;
+        }
+        if (state.address.empty())
+            media.forget();
+        last_ear = state.ear;
+
         tether::broadcast_local_event(tether::bluetooth::to_json(state).dump());
     });
     const auto follow_airpods = [&bluez, &airpods]() {

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <sys/timerfd.h>
+#include <tether/bluetooth/airpods.hpp>
 #include <tether/bluetooth/config.hpp>
 #include <tether/bluetooth/connection.hpp>
 #include <tether/bluetooth/contacts.hpp>
@@ -245,12 +246,27 @@ int main(int argc, char** argv) {
 
     // Pick the controller before the first capability, a second adapter never comes up bound to the wrong one.
     bluez.set_preferred_adapter(bt_config.adapter);
+
+    // AirPods battery arrives on its own L2CAP channel, not through BlueZ.
+    tether::bluetooth::AirPodsWatcher airpods([](const tether::bluetooth::AirPodsState& state) {
+        tether::broadcast_local_event(tether::bluetooth::to_json(state).dump());
+    });
+    const auto follow_airpods = [&bluez, &airpods]() {
+        const auto snapshot = bluez.snapshot();
+        const auto* device = tether::bluetooth::find_airpods(snapshot);
+        airpods.set_device(device ? device->address : std::string{}, device ? device->name : std::string{});
+    };
+
     if (bluez.start()) {
         tether::bluetooth::g_bluez = &bluez;
-        loop.addFd(bluez.event_fd(), [&bluez](int) {
+        tether::bluetooth::g_airpods = &airpods;
+        loop.addFd(bluez.event_fd(), [&bluez, &follow_airpods](int) {
             bluez.drain();
+            tether::broadcast_local_event(tether::build_bt_devices().dump());
             tether::broadcast_local_event(tether::build_bt_status().dump());
+            follow_airpods();
         });
+        follow_airpods();
         auto cap = bluez.capability();
         debug::log(INFO, "Bluetooth: {} mode", tether::bluetooth::to_string(cap.mode));
         for (const auto& reason : cap.reasons)

--- a/src/gtk/daemon_client.cpp
+++ b/src/gtk/daemon_client.cpp
@@ -157,6 +157,7 @@ namespace tether::ui {
             daemon_send({{"command", "bt_connection"}});
             daemon_send({{"command", "bt_status"}});
             daemon_send({{"command", "bt_list_devices"}});
+            daemon_send({{"command", "bt_airpods"}});
             // primes the tray unread count
             daemon_send({{"command", "bt_list_threads"}});
             set_status_main(_("Daemon Online"));

--- a/src/gtk/devices_view.cpp
+++ b/src/gtk/devices_view.cpp
@@ -64,6 +64,7 @@ namespace tether::ui {
             GtkWidget* lbl_airpods_reason = nullptr;
             GtkWidget* lbl_airpods_worn = nullptr;
             GtkWidget* cmb_airpods_pause = nullptr;
+            GtkWidget* chk_airpods_handoff = nullptr;
             GtkWidget* airpods_mode_buttons[4] = {nullptr, nullptr, nullptr, nullptr};
             bool airpods_syncing = false;
 
@@ -244,6 +245,13 @@ namespace tether::ui {
             daemon_send({{"command", "bt_airpods_pause"}, {"mode", AIRPODS_PAUSE_MODES[index]}});
         }
 
+        void on_airpods_handoff_toggled(GtkWidget* button, gpointer) {
+            if (g_devices.airpods_syncing)
+                return;
+            daemon_send({{"command", "bt_airpods_handoff"},
+                         {"enabled", gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)) == TRUE}});
+        }
+
         void on_airpods_mode_toggled(GtkWidget* button, gpointer data) {
             if (g_devices.airpods_syncing || !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)))
                 return;
@@ -293,6 +301,11 @@ namespace tether::ui {
                     gtk_combo_box_set_active(GTK_COMBO_BOX(g_devices.cmb_airpods_pause), i);
             }
             gtk_widget_set_sensitive(g_devices.cmb_airpods_pause, ear_known);
+
+            gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(g_devices.chk_airpods_handoff),
+                                         g_devices.bt_status.value("airpods_handoff", false));
+            const bool calls_on = g_devices.bt_status.value("calls_enabled", false);
+            gtk_widget_set_sensitive(g_devices.chk_airpods_handoff, calls_on);
             g_devices.airpods_syncing = false;
         }
 
@@ -1493,6 +1506,20 @@ namespace tether::ui {
         g_signal_connect(g_devices.cmb_airpods_pause, "changed", G_CALLBACK(on_airpods_pause_changed), nullptr);
         gtk_box_pack_start(GTK_BOX(pause_row), g_devices.cmb_airpods_pause, FALSE, FALSE, 0);
         gtk_box_pack_start(GTK_BOX(airpods_box), pause_row, FALSE, FALSE, 0);
+
+        GtkWidget* lbl_handoff_title = gtk_label_new(nullptr);
+        gtk_label_set_xalign(GTK_LABEL(lbl_handoff_title), 0.0);
+        set_markup(lbl_handoff_title, "<b>" + escape_markup(_("Calls")) + "</b>");
+        gtk_box_pack_start(GTK_BOX(airpods_box), lbl_handoff_title, FALSE, FALSE, 0);
+
+        g_devices.chk_airpods_handoff =
+            gtk_check_button_new_with_label(_("Hand the AirPods to the iPhone during a call"));
+        gtk_widget_set_tooltip_text(g_devices.chk_airpods_handoff,
+                                    _("Pauses playback and disconnects the AirPods so the iPhone can take them, "
+                                      "then reconnects them when the call ends. Needs call control, and only "
+                                      "applies while the buds are connected to this computer."));
+        g_signal_connect(g_devices.chk_airpods_handoff, "toggled", G_CALLBACK(on_airpods_handoff_toggled), nullptr);
+        gtk_box_pack_start(GTK_BOX(airpods_box), g_devices.chk_airpods_handoff, FALSE, FALSE, 0);
 
         gtk_stack_add_named(GTK_STACK(g_devices.right_pane_stack), airpods_box, "airpods");
 

--- a/src/gtk/devices_view.cpp
+++ b/src/gtk/devices_view.cpp
@@ -131,6 +131,11 @@ namespace tether::ui {
             return nullptr;
         }
 
+        std::string json_string(const nlohmann::json& j, const char* key, const std::string& fallback = "") {
+            const auto it = j.find(key);
+            return it != j.end() && it->is_string() ? it->get<std::string>() : fallback;
+        }
+
         // "L 82%  R 79%  Case 45%", omitting whatever is not reporting, or the reason
         // there are no levels at all. Empty while the channel is still opening, which
         // is the one state not worth reporting anywhere.
@@ -152,9 +157,9 @@ namespace tether::ui {
             if (!text.empty())
                 return text;
 
-            const std::string status = airpods.value("status", "");
+            const std::string status = json_string(airpods, "status");
             if (status == "busy" || status == "failed")
-                return airpods.value("reason", "");
+                return json_string(airpods, "reason");
             return "";
         }
 
@@ -261,12 +266,12 @@ namespace tether::ui {
         void update_airpods_pane() {
             const nlohmann::json& airpods = g_devices.bt_airpods;
             set_markup(g_devices.lbl_airpods_name,
-                       "<b>" + escape_markup(airpods.value("name", g_devices.selected_bt_name)) + "</b>");
+                       "<b>" + escape_markup(json_string(airpods, "name", g_devices.selected_bt_name)) + "</b>");
 
             const std::string levels = airpods_status_text(airpods);
             set_text(g_devices.lbl_airpods_battery, levels.empty() ? _("Reading battery\u2026") : levels);
 
-            const std::string current = airpods.value("anc", "");
+            const std::string current = json_string(airpods, "anc");
             g_devices.airpods_syncing = true;
             for (int i = 0; i < 4; ++i) {
                 GtkWidget* button = g_devices.airpods_mode_buttons[i];
@@ -277,7 +282,7 @@ namespace tether::ui {
 
             // Reuses the daemon's own sentence rather than inventing a second one.
             const char* reason = !current.empty() ? ""
-                                 : airpods.value("address", "").empty()
+                                 : json_string(airpods, "address").empty()
                                      ? _("No AirPods are connected.")
                                      : _("These AirPods do not report a listening mode.");
             set_text(g_devices.lbl_airpods_reason, reason);
@@ -286,8 +291,8 @@ namespace tether::ui {
             // than naming a side.
             const int in_ear = airpods.value("in_ear", 0);
             const nlohmann::json ear = airpods.value("ear", nlohmann::json::object());
-            const bool ear_known =
-                ear.value("primary", "unknown") != "unknown" || ear.value("secondary", "unknown") != "unknown";
+            const bool ear_known = json_string(ear, "primary", "unknown") != "unknown" ||
+                                   json_string(ear, "secondary", "unknown") != "unknown";
             set_text(g_devices.lbl_airpods_worn,
                      !ear_known    ? _("These AirPods do not report whether they are being worn.")
                      : in_ear == 2 ? _("Both buds are in.")
@@ -1259,7 +1264,7 @@ namespace tether::ui {
             // Battery arrives whenever the buds feel like sending it
             const std::string address = event.value("address", "");
             const std::string text = address.empty() ? "" : airpods_row_text(event);
-            tray_set_airpods(event.value("name", ""), address.empty() ? "" : airpods_status_text(event));
+            tray_set_airpods(json_string(event, "name"), address.empty() ? "" : airpods_status_text(event));
             GList* rows = gtk_container_get_children(GTK_CONTAINER(g_devices.list_devices));
             for (GList* item = rows; item; item = item->next) {
                 auto* row = GTK_WIDGET(item->data);

--- a/src/gtk/devices_view.cpp
+++ b/src/gtk/devices_view.cpp
@@ -62,6 +62,8 @@ namespace tether::ui {
             GtkWidget* lbl_airpods_name = nullptr;
             GtkWidget* lbl_airpods_battery = nullptr;
             GtkWidget* lbl_airpods_reason = nullptr;
+            GtkWidget* lbl_airpods_worn = nullptr;
+            GtkWidget* cmb_airpods_pause = nullptr;
             GtkWidget* airpods_mode_buttons[4] = {nullptr, nullptr, nullptr, nullptr};
             bool airpods_syncing = false;
 
@@ -229,6 +231,19 @@ namespace tether::ui {
             {"anc", N_("Noise Cancellation")},
         };
 
+        // Wire values for the pause-on-removal setting, in the order they appear
+        // in the dropdown.
+        const char* const AIRPODS_PAUSE_MODES[3] = {"never", "one-removed", "both-removed"};
+
+        void on_airpods_pause_changed(GtkWidget* combo, gpointer) {
+            if (g_devices.airpods_syncing)
+                return;
+            const int index = gtk_combo_box_get_active(GTK_COMBO_BOX(combo));
+            if (index < 0 || index > 2)
+                return;
+            daemon_send({{"command", "bt_airpods_pause"}, {"mode", AIRPODS_PAUSE_MODES[index]}});
+        }
+
         void on_airpods_mode_toggled(GtkWidget* button, gpointer data) {
             if (g_devices.airpods_syncing || !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)))
                 return;
@@ -258,6 +273,27 @@ namespace tether::ui {
                                      ? _("No AirPods are connected.")
                                      : _("These AirPods do not report a listening mode.");
             set_text(g_devices.lbl_airpods_reason, reason);
+
+            // Which bud is "primary" moves between them, so this counts rather
+            // than naming a side.
+            const int in_ear = airpods.value("in_ear", 0);
+            const nlohmann::json ear = airpods.value("ear", nlohmann::json::object());
+            const bool ear_known =
+                ear.value("primary", "unknown") != "unknown" || ear.value("secondary", "unknown") != "unknown";
+            set_text(g_devices.lbl_airpods_worn,
+                     !ear_known    ? _("These AirPods do not report whether they are being worn.")
+                     : in_ear == 2 ? _("Both buds are in.")
+                     : in_ear == 1 ? _("One bud is in.")
+                                   : _("Neither bud is in."));
+
+            const std::string pause = g_devices.bt_status.value("airpods_pause", "never");
+            g_devices.airpods_syncing = true;
+            for (int i = 0; i < 3; ++i) {
+                if (pause == AIRPODS_PAUSE_MODES[i])
+                    gtk_combo_box_set_active(GTK_COMBO_BOX(g_devices.cmb_airpods_pause), i);
+            }
+            gtk_widget_set_sensitive(g_devices.cmb_airpods_pause, ear_known);
+            g_devices.airpods_syncing = false;
         }
 
         void update_bt_pane() {
@@ -1433,6 +1469,30 @@ namespace tether::ui {
         gtk_label_set_line_wrap(GTK_LABEL(g_devices.lbl_airpods_reason), TRUE);
         gtk_style_context_add_class(gtk_widget_get_style_context(g_devices.lbl_airpods_reason), "muted");
         gtk_box_pack_start(GTK_BOX(airpods_box), g_devices.lbl_airpods_reason, FALSE, FALSE, 0);
+
+        GtkWidget* lbl_wear_title = gtk_label_new(nullptr);
+        gtk_label_set_xalign(GTK_LABEL(lbl_wear_title), 0.0);
+        set_markup(lbl_wear_title, "<b>" + escape_markup(_("In-ear detection")) + "</b>");
+        gtk_box_pack_start(GTK_BOX(airpods_box), lbl_wear_title, FALSE, FALSE, 0);
+
+        g_devices.lbl_airpods_worn = gtk_label_new(nullptr);
+        gtk_label_set_xalign(GTK_LABEL(g_devices.lbl_airpods_worn), 0.0);
+        gtk_label_set_line_wrap(GTK_LABEL(g_devices.lbl_airpods_worn), TRUE);
+        gtk_style_context_add_class(gtk_widget_get_style_context(g_devices.lbl_airpods_worn), "muted");
+        gtk_box_pack_start(GTK_BOX(airpods_box), g_devices.lbl_airpods_worn, FALSE, FALSE, 0);
+
+        GtkWidget* pause_row = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 8);
+        gtk_box_pack_start(GTK_BOX(pause_row), gtk_label_new(_("Pause playback when:")), FALSE, FALSE, 0);
+        g_devices.cmb_airpods_pause = gtk_combo_box_text_new();
+        gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(g_devices.cmb_airpods_pause), _("Never"));
+        gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(g_devices.cmb_airpods_pause), _("One bud is removed"));
+        gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(g_devices.cmb_airpods_pause), _("Both buds are removed"));
+        gtk_widget_set_tooltip_text(g_devices.cmb_airpods_pause,
+                                    _("Pauses whatever is playing on this computer, and starts it again when the "
+                                      "buds go back in. Only playback Tether paused is resumed."));
+        g_signal_connect(g_devices.cmb_airpods_pause, "changed", G_CALLBACK(on_airpods_pause_changed), nullptr);
+        gtk_box_pack_start(GTK_BOX(pause_row), g_devices.cmb_airpods_pause, FALSE, FALSE, 0);
+        gtk_box_pack_start(GTK_BOX(airpods_box), pause_row, FALSE, FALSE, 0);
 
         gtk_stack_add_named(GTK_STACK(g_devices.right_pane_stack), airpods_box, "airpods");
 

--- a/src/gtk/devices_view.cpp
+++ b/src/gtk/devices_view.cpp
@@ -1,5 +1,6 @@
 #include "devices_view.hpp"
 #include "daemon_client.hpp"
+#include "tray.hpp"
 #include "ui_util.hpp"
 #include <tether/i18n.hpp>
 
@@ -121,9 +122,10 @@ namespace tether::ui {
             return nullptr;
         }
 
-        // "L 82%  R 79%  Case 45%", omitting whatever is not reporting. An empty
-        // result means nothing is known yet.
-        std::string airpods_battery_text(const nlohmann::json& airpods) {
+        // "L 82%  R 79%  Case 45%", omitting whatever is not reporting, or the reason
+        // there are no levels at all. Empty while the channel is still opening, which
+        // is the one state not worth reporting anywhere.
+        std::string airpods_status_text(const nlohmann::json& airpods) {
             std::string text;
             const auto append = [&](const char* label, int level) {
                 if (level < 0)
@@ -144,7 +146,13 @@ namespace tether::ui {
             const std::string status = airpods.value("status", "");
             if (status == "busy" || status == "failed")
                 return airpods.value("reason", "");
-            return _("Reading battery\u2026");
+            return "";
+        }
+
+        // The device row has room to say why it is empty; the tray tooltip does not.
+        std::string airpods_row_text(const nlohmann::json& airpods) {
+            const std::string text = airpods_status_text(airpods);
+            return text.empty() ? _("Reading battery\u2026") : text;
         }
 
         // The daemon supervises one iPhone at a time, so the live profile status
@@ -819,7 +827,7 @@ namespace tether::ui {
                 gtk_label_set_xalign(GTK_LABEL(battery), 0.0);
                 gtk_style_context_add_class(gtk_widget_get_style_context(battery), "muted");
                 if (g_devices.bt_airpods.value("address", "") == address)
-                    gtk_label_set_text(GTK_LABEL(battery), airpods_battery_text(g_devices.bt_airpods).c_str());
+                    gtk_label_set_text(GTK_LABEL(battery), airpods_row_text(g_devices.bt_airpods).c_str());
                 g_object_set_data(G_OBJECT(row), "bt_battery", battery);
                 gtk_box_pack_start(GTK_BOX(labels), battery, FALSE, FALSE, 0);
             }
@@ -1148,7 +1156,8 @@ namespace tether::ui {
             g_devices.bt_airpods = event;
             // Battery arrives whenever the buds feel like sending it
             const std::string address = event.value("address", "");
-            const std::string text = address.empty() ? "" : airpods_battery_text(event);
+            const std::string text = address.empty() ? "" : airpods_row_text(event);
+            tray_set_airpods(event.value("name", ""), address.empty() ? "" : airpods_status_text(event));
             GList* rows = gtk_container_get_children(GTK_CONTAINER(g_devices.list_devices));
             for (GList* item = rows; item; item = item->next) {
                 auto* row = GTK_WIDGET(item->data);

--- a/src/gtk/devices_view.cpp
+++ b/src/gtk/devices_view.cpp
@@ -59,6 +59,12 @@ namespace tether::ui {
             std::string selected_bt_address;
             std::string selected_bt_name;
 
+            GtkWidget* lbl_airpods_name = nullptr;
+            GtkWidget* lbl_airpods_battery = nullptr;
+            GtkWidget* lbl_airpods_reason = nullptr;
+            GtkWidget* airpods_mode_buttons[4] = {nullptr, nullptr, nullptr, nullptr};
+            bool airpods_syncing = false;
+
             GtkWidget* lbl_bt_name = nullptr;
             GtkWidget* bt_setup_box = nullptr;
             GtkWidget* lbl_bt_setup_what = nullptr;
@@ -211,6 +217,49 @@ namespace tether::ui {
             daemon_send({{"command", "bt_scan"}});
         }
 
+        // Wire names as the daemon uses them
+        struct AirPodsMode {
+            const char* wire;
+            const char* label;
+        };
+        const AirPodsMode AIRPODS_MODES[4] = {
+            {"off", N_("Off")},
+            {"transparency", N_("Transparency")},
+            {"adaptive", N_("Adaptive")},
+            {"anc", N_("Noise Cancellation")},
+        };
+
+        void on_airpods_mode_toggled(GtkWidget* button, gpointer data) {
+            if (g_devices.airpods_syncing || !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)))
+                return;
+            daemon_send({{"command", "bt_airpods_mode"}, {"mode", AIRPODS_MODES[GPOINTER_TO_INT(data)].wire}});
+        }
+
+        void update_airpods_pane() {
+            const nlohmann::json& airpods = g_devices.bt_airpods;
+            set_markup(g_devices.lbl_airpods_name,
+                       "<b>" + escape_markup(airpods.value("name", g_devices.selected_bt_name)) + "</b>");
+
+            const std::string levels = airpods_status_text(airpods);
+            set_text(g_devices.lbl_airpods_battery, levels.empty() ? _("Reading battery\u2026") : levels);
+
+            const std::string current = airpods.value("anc", "");
+            g_devices.airpods_syncing = true;
+            for (int i = 0; i < 4; ++i) {
+                GtkWidget* button = g_devices.airpods_mode_buttons[i];
+                gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), current == AIRPODS_MODES[i].wire);
+                gtk_widget_set_sensitive(button, !current.empty());
+            }
+            g_devices.airpods_syncing = false;
+
+            // Reuses the daemon's own sentence rather than inventing a second one.
+            const char* reason = !current.empty() ? ""
+                                 : airpods.value("address", "").empty()
+                                     ? _("No AirPods are connected.")
+                                     : _("These AirPods do not report a listening mode.");
+            set_text(g_devices.lbl_airpods_reason, reason);
+        }
+
         void update_bt_pane() {
             const std::string address = g_devices.selected_bt_address;
             const nlohmann::json* device = find_bt_device(address);
@@ -345,6 +394,12 @@ namespace tether::ui {
 
         void update_right_pane() {
             if (!g_devices.selected_bt_address.empty()) {
+                const nlohmann::json* device = find_bt_device(g_devices.selected_bt_address);
+                if (device && device->value("airpods", false)) {
+                    gtk_stack_set_visible_child_name(GTK_STACK(g_devices.right_pane_stack), "airpods");
+                    update_airpods_pane();
+                    return;
+                }
                 gtk_stack_set_visible_child_name(GTK_STACK(g_devices.right_pane_stack), "bluetooth");
                 update_bt_pane();
                 return;
@@ -821,8 +876,6 @@ namespace tether::ui {
             gtk_box_pack_start(GTK_BOX(labels), subtitle, FALSE, FALSE, 0);
 
             if (airpods) {
-                gtk_list_box_row_set_selectable(GTK_LIST_BOX_ROW(row), FALSE);
-
                 GtkWidget* battery = gtk_label_new(nullptr);
                 gtk_label_set_xalign(GTK_LABEL(battery), 0.0);
                 gtk_style_context_add_class(gtk_widget_get_style_context(battery), "muted");
@@ -1168,6 +1221,9 @@ namespace tether::ui {
                 gtk_label_set_text(GTK_LABEL(battery), text.c_str());
             }
             g_list_free(rows);
+            // The pane repaints from the same event, but only when it is showing.
+            if (gtk_stack_get_visible_child_name(GTK_STACK(g_devices.right_pane_stack)) == std::string("airpods"))
+                update_airpods_pane();
             return true;
         }
         if (command == "bt_connection_changed") {
@@ -1337,6 +1393,48 @@ namespace tether::ui {
                          nullptr);
         gtk_box_pack_start(GTK_BOX(placeholder), welcome_scan, FALSE, FALSE, 0);
         gtk_stack_add_named(GTK_STACK(g_devices.right_pane_stack), placeholder, "placeholder");
+
+        // AirPods: battery and the listening mode, which is all the buds expose.
+        GtkWidget* airpods_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 16);
+        gtk_container_set_border_width(GTK_CONTAINER(airpods_box), 32);
+        gtk_widget_set_valign(airpods_box, GTK_ALIGN_CENTER);
+
+        g_devices.lbl_airpods_name = gtk_label_new(nullptr);
+        gtk_label_set_xalign(GTK_LABEL(g_devices.lbl_airpods_name), 0.0);
+        gtk_box_pack_start(GTK_BOX(airpods_box), g_devices.lbl_airpods_name, FALSE, FALSE, 0);
+
+        g_devices.lbl_airpods_battery = gtk_label_new(nullptr);
+        gtk_label_set_xalign(GTK_LABEL(g_devices.lbl_airpods_battery), 0.0);
+        gtk_style_context_add_class(gtk_widget_get_style_context(g_devices.lbl_airpods_battery), "muted");
+        gtk_box_pack_start(GTK_BOX(airpods_box), g_devices.lbl_airpods_battery, FALSE, FALSE, 0);
+
+        GtkWidget* lbl_mode_title = gtk_label_new(nullptr);
+        gtk_label_set_xalign(GTK_LABEL(lbl_mode_title), 0.0);
+        set_markup(lbl_mode_title, "<b>" + escape_markup(_("Listening mode")) + "</b>");
+        gtk_box_pack_start(GTK_BOX(airpods_box), lbl_mode_title, FALSE, FALSE, 0);
+
+        GtkWidget* modes = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+        gtk_style_context_add_class(gtk_widget_get_style_context(modes), "linked");
+        GtkWidget* group = nullptr;
+        for (int i = 0; i < 4; ++i) {
+            GtkWidget* button =
+                gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(group), _(AIRPODS_MODES[i].label));
+            gtk_toggle_button_set_mode(GTK_TOGGLE_BUTTON(button), FALSE);
+            if (!group)
+                group = button;
+            g_signal_connect(button, "toggled", G_CALLBACK(on_airpods_mode_toggled), GINT_TO_POINTER(i));
+            g_devices.airpods_mode_buttons[i] = button;
+            gtk_box_pack_start(GTK_BOX(modes), button, TRUE, TRUE, 0);
+        }
+        gtk_box_pack_start(GTK_BOX(airpods_box), modes, FALSE, FALSE, 0);
+
+        g_devices.lbl_airpods_reason = gtk_label_new(nullptr);
+        gtk_label_set_xalign(GTK_LABEL(g_devices.lbl_airpods_reason), 0.0);
+        gtk_label_set_line_wrap(GTK_LABEL(g_devices.lbl_airpods_reason), TRUE);
+        gtk_style_context_add_class(gtk_widget_get_style_context(g_devices.lbl_airpods_reason), "muted");
+        gtk_box_pack_start(GTK_BOX(airpods_box), g_devices.lbl_airpods_reason, FALSE, FALSE, 0);
+
+        gtk_stack_add_named(GTK_STACK(g_devices.right_pane_stack), airpods_box, "airpods");
 
         // Bluetooth
         GtkWidget* bt_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 16);

--- a/src/gtk/devices_view.cpp
+++ b/src/gtk/devices_view.cpp
@@ -32,6 +32,8 @@ namespace tether::ui {
 
             // The Bluetooth route
             std::vector<nlohmann::json> bt_devices;
+            // An object, not null: bt_devices can arrive before the first bt_airpods.
+            nlohmann::json bt_airpods = nlohmann::json::object();
             nlohmann::json bt_status = nlohmann::json::object();
             nlohmann::json bt_connection = nlohmann::json::object();
 
@@ -117,6 +119,32 @@ namespace tether::ui {
                     return &device;
             }
             return nullptr;
+        }
+
+        // "L 82%  R 79%  Case 45%", omitting whatever is not reporting. An empty
+        // result means nothing is known yet.
+        std::string airpods_battery_text(const nlohmann::json& airpods) {
+            std::string text;
+            const auto append = [&](const char* label, int level) {
+                if (level < 0)
+                    return;
+                if (!text.empty())
+                    text += "   ";
+                text += label + (" " + std::to_string(level) + "%");
+            };
+            // TRANSLATORS: Left earbud, abbreviated to fit the device row. One or two letters.
+            append(_("L"), airpods.value("left", -1));
+            // TRANSLATORS: Right earbud, abbreviated to fit the device row. One or two letters.
+            append(_("R"), airpods.value("right", -1));
+            // TRANSLATORS: The AirPods charging case, on the device row beside the two earbuds.
+            append(_("Case"), airpods.value("case", -1));
+            if (!text.empty())
+                return text;
+
+            const std::string status = airpods.value("status", "");
+            if (status == "busy" || status == "failed")
+                return airpods.value("reason", "");
+            return _("Reading battery\u2026");
         }
 
         // The daemon supervises one iPhone at a time, so the live profile status
@@ -749,6 +777,7 @@ namespace tether::ui {
             const std::string name = device.value("name", "").empty() ? address : device.value("name", "");
             const bool paired = device.value("paired", false);
             const bool connected = device.value("connected", false);
+            const bool airpods = device.value("airpods", false);
             const bool route_ready =
                 is_supervised_bt_device(address) && (g_devices.bt_connection.value("map_open", false) ||
                                                      g_devices.bt_connection.value("ancs_ready", false));
@@ -760,8 +789,10 @@ namespace tether::ui {
             GtkWidget* box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
             gtk_container_set_border_width(GTK_CONTAINER(box), 12);
 
-            GtkWidget* icon = gtk_image_new_from_icon_name(
-                connected ? "bluetooth-active-symbolic" : "bluetooth-symbolic", GTK_ICON_SIZE_LARGE_TOOLBAR);
+            const char* icon_name = airpods     ? "audio-headphones-symbolic"
+                                    : connected ? "bluetooth-active-symbolic"
+                                                : "bluetooth-symbolic";
+            GtkWidget* icon = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_LARGE_TOOLBAR);
             gtk_box_pack_start(GTK_BOX(box), icon, FALSE, FALSE, 0);
 
             GtkWidget* labels = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
@@ -770,14 +801,28 @@ namespace tether::ui {
             gtk_label_set_xalign(GTK_LABEL(title), 0.0);
             gtk_box_pack_start(GTK_BOX(labels), title, FALSE, FALSE, 0);
 
-            const char* subtitle_text = route_ready ? _("Connected")
-                                        : connected ? _("Partially connected")
-                                        : paired    ? _("Paired")
-                                                    : _("Nearby (Tap to Pair)");
+            // "Partially connected" is about the iPhone's message and notification
+            // routes, which say nothing about a pair of earbuds.
+            const char* subtitle_text = (route_ready || (airpods && connected)) ? _("Connected")
+                                        : connected                             ? _("Partially connected")
+                                        : paired                                ? _("Paired")
+                                                                                : _("Nearby (Tap to Pair)");
             GtkWidget* subtitle = gtk_label_new(subtitle_text);
             gtk_label_set_xalign(GTK_LABEL(subtitle), 0.0);
             gtk_style_context_add_class(gtk_widget_get_style_context(subtitle), "muted");
             gtk_box_pack_start(GTK_BOX(labels), subtitle, FALSE, FALSE, 0);
+
+            if (airpods) {
+                gtk_list_box_row_set_selectable(GTK_LIST_BOX_ROW(row), FALSE);
+
+                GtkWidget* battery = gtk_label_new(nullptr);
+                gtk_label_set_xalign(GTK_LABEL(battery), 0.0);
+                gtk_style_context_add_class(gtk_widget_get_style_context(battery), "muted");
+                if (g_devices.bt_airpods.value("address", "") == address)
+                    gtk_label_set_text(GTK_LABEL(battery), airpods_battery_text(g_devices.bt_airpods).c_str());
+                g_object_set_data(G_OBJECT(row), "bt_battery", battery);
+                gtk_box_pack_start(GTK_BOX(labels), battery, FALSE, FALSE, 0);
+            }
 
             gtk_box_pack_start(GTK_BOX(box), labels, TRUE, TRUE, 0);
             gtk_container_add(GTK_CONTAINER(row), box);
@@ -871,7 +916,8 @@ namespace tether::ui {
 
         std::vector<GtkWidget*> bt_rows;
         for (const auto& device : g_devices.bt_devices) {
-            if (!device.value("iphone", false) && !is_supervised_bt_device(device.value("address", "")))
+            if (!device.value("iphone", false) && !device.value("airpods", false) &&
+                !is_supervised_bt_device(device.value("address", "")))
                 continue;
             bt_rows.push_back(create_bt_row(device));
         }
@@ -1096,6 +1142,23 @@ namespace tether::ui {
             }
             devices_view_refresh();
             update_right_pane();
+            return true;
+        }
+        if (command == "bt_airpods") {
+            g_devices.bt_airpods = event;
+            // Battery arrives whenever the buds feel like sending it
+            const std::string address = event.value("address", "");
+            const std::string text = address.empty() ? "" : airpods_battery_text(event);
+            GList* rows = gtk_container_get_children(GTK_CONTAINER(g_devices.list_devices));
+            for (GList* item = rows; item; item = item->next) {
+                auto* row = GTK_WIDGET(item->data);
+                const char* row_address = (const char*)g_object_get_data(G_OBJECT(row), "bt_address");
+                auto* battery = GTK_WIDGET(g_object_get_data(G_OBJECT(row), "bt_battery"));
+                if (!battery || !row_address || (!address.empty() && address != row_address))
+                    continue;
+                gtk_label_set_text(GTK_LABEL(battery), text.c_str());
+            }
+            g_list_free(rows);
             return true;
         }
         if (command == "bt_connection_changed") {

--- a/src/gtk/tray.cpp
+++ b/src/gtk/tray.cpp
@@ -70,6 +70,8 @@ namespace tether::ui {
         std::string g_icon = "tether-offline";
         int g_unread = 0;
         std::string g_tooltip;
+        std::string g_airpods_name;
+        std::string g_airpods_battery;
         bool g_close_to_tray = false;
         std::string g_icon_style = "symbolic";
         std::string g_icon_suffix;
@@ -244,9 +246,11 @@ namespace tether::ui {
         for (Route route : {Route::WiFi, Route::Bluetooth}) {
             const RouteState& r = state(route);
             const std::string status = r.ok ? _("connected") : r.detail.empty() ? _("not connected") : r.detail;
-            // TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth".
+            // TRANSLATORS: {} is a transport name, "Wi-Fi" or "Bluetooth", or a device name.
             tooltip += tether::tr_format(_("{}: {}"), route_name(route), status) + "\n";
         }
+        if (!g_airpods_battery.empty())
+            tooltip += tether::tr_format(_("{}: {}"), g_airpods_name, g_airpods_battery) + "\n";
         if (!daemon_connected())
             tooltip += std::string(_("Daemon: not running")) + "\n";
         if (g_unread > 0)
@@ -266,6 +270,14 @@ namespace tether::ui {
             g_tooltip = tooltip;
             emit("NewToolTip");
         }
+    }
+
+    void tray_set_airpods(const std::string& name, const std::string& battery) {
+        if (name == g_airpods_name && battery == g_airpods_battery)
+            return;
+        g_airpods_name = name;
+        g_airpods_battery = battery;
+        tray_refresh();
     }
 
     void tray_set_unread(int count) {

--- a/src/gtk/tray.hpp
+++ b/src/gtk/tray.hpp
@@ -15,6 +15,10 @@ namespace tether::ui {
     // Total unread across threads. Drives the badged icon and a tooltip line.
     void tray_set_unread(int count);
 
+    // AirPods battery for the tooltip, already formatted. Empty removes the line:
+    // nothing connected, or the channel has reported nothing yet.
+    void tray_set_airpods(const std::string& name, const std::string& battery);
+
     // Repaints from cached state, for when the daemon returns before any route event.
     void tray_refresh();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(tether_test
     test_base64.cpp
+    test_airpods.cpp
     test_bluetooth_objects.cpp
     test_bluetooth_monitor.cpp
     test_bluetooth_pairing.cpp

--- a/test/test_airpods.cpp
+++ b/test/test_airpods.cpp
@@ -250,3 +250,16 @@ TEST(AirPods, DistinguishesAirPodsFromAnIPhone) {
     speaker.uuids = {UUID_A2DP_SINK};
     EXPECT_FALSE(speaker.looks_like_airpods());
 }
+
+TEST(AirPods, JsonOmitsUnknownListeningMode) {
+    AirPodsState state;
+    ASSERT_FALSE(state.anc.has_value());
+
+    const nlohmann::json j = to_json(state);
+    EXPECT_FALSE(j.contains("anc"));
+    // Readers ask for it as a string; a null would throw instead of defaulting.
+    EXPECT_EQ(j.value("anc", ""), "");
+
+    state.anc = AncMode::Transparency;
+    EXPECT_EQ(to_json(state).value("anc", ""), "transparency");
+}

--- a/test/test_airpods.cpp
+++ b/test/test_airpods.cpp
@@ -104,6 +104,83 @@ TEST(AirPods, RejectsMalformedListeningModes) {
     EXPECT_FALSE(anc_mode_from_string("ancs").has_value());
 }
 
+namespace {
+    std::optional<EarState> ear(std::initializer_list<uint8_t> bytes) {
+        std::vector<uint8_t> v(bytes);
+        return parse_ear(v.data(), v.size());
+    }
+    constexpr EarState WORN{EarStatus::InEar, EarStatus::InEar};
+    constexpr EarState ONE_OUT{EarStatus::InEar, EarStatus::OutOfEar};
+    constexpr EarState BOTH_OUT{EarStatus::OutOfEar, EarStatus::OutOfEar};
+    constexpr EarState UNKNOWN{};
+} // namespace
+
+TEST(AirPods, ParsesEarDetection) {
+    auto worn = ear({0x04, 0x00, 0x04, 0x00, 0x06, 0x00, 0x00, 0x00});
+    ASSERT_TRUE(worn.has_value());
+    EXPECT_EQ(worn->primary, EarStatus::InEar);
+    EXPECT_EQ(worn->secondary, EarStatus::InEar);
+    EXPECT_EQ(worn->in_ear(), 2);
+
+    auto mixed = ear({0x04, 0x00, 0x04, 0x00, 0x06, 0x00, 0x01, 0x02});
+    ASSERT_TRUE(mixed.has_value());
+    EXPECT_EQ(mixed->primary, EarStatus::OutOfEar);
+    EXPECT_EQ(mixed->secondary, EarStatus::InCase);
+    EXPECT_EQ(mixed->in_ear(), 0);
+    EXPECT_TRUE(mixed->known());
+
+    // An unrecognised status byte is unknown, not in-ear.
+    auto odd = ear({0x04, 0x00, 0x04, 0x00, 0x06, 0x00, 0x00, 0x7f});
+    ASSERT_TRUE(odd.has_value());
+    EXPECT_EQ(odd->secondary, EarStatus::Unknown);
+    EXPECT_EQ(odd->in_ear(), 1);
+}
+
+TEST(AirPods, RejectsMalformedEarDetection) {
+    // Right prefix, wrong length.
+    EXPECT_FALSE(ear({0x04, 0x00, 0x04, 0x00, 0x06, 0x00, 0x00}).has_value());
+    EXPECT_FALSE(ear({0x04, 0x00, 0x04, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00}).has_value());
+    // A battery notification is 12 bytes, but check the prefix is what rejects it.
+    EXPECT_FALSE(ear({0x04, 0x00, 0x04, 0x00, 0x04, 0x00, 0x01, 0x02}).has_value());
+    EXPECT_FALSE(parse_ear(nullptr, 0).has_value());
+}
+
+TEST(AirPods, PauseModeNeverDoesNothing) {
+    EXPECT_EQ(ear_media_action(WORN, BOTH_OUT, PauseMode::Never, false), MediaAction::None);
+    EXPECT_EQ(ear_media_action(BOTH_OUT, WORN, PauseMode::Never, true), MediaAction::None);
+}
+
+// The first report after connecting says where the buds already are. Reading it
+// as a transition would pause music the moment a case is opened nearby.
+TEST(AirPods, FirstEarReportIsNotATransition) {
+    EXPECT_EQ(ear_media_action(UNKNOWN, BOTH_OUT, PauseMode::OneRemoved, false), MediaAction::None);
+    EXPECT_EQ(ear_media_action(UNKNOWN, WORN, PauseMode::OneRemoved, true), MediaAction::None);
+    EXPECT_EQ(ear_media_action(WORN, UNKNOWN, PauseMode::OneRemoved, false), MediaAction::None);
+}
+
+TEST(AirPods, PausesWhenOneBudComesOut) {
+    EXPECT_EQ(ear_media_action(WORN, ONE_OUT, PauseMode::OneRemoved, false), MediaAction::Pause);
+    EXPECT_EQ(ear_media_action(ONE_OUT, WORN, PauseMode::OneRemoved, true), MediaAction::Resume);
+
+    // Both-removed is the looser policy: one bud out is still "worn".
+    EXPECT_EQ(ear_media_action(WORN, ONE_OUT, PauseMode::BothRemoved, false), MediaAction::None);
+    EXPECT_EQ(ear_media_action(ONE_OUT, BOTH_OUT, PauseMode::BothRemoved, false), MediaAction::Pause);
+    EXPECT_EQ(ear_media_action(BOTH_OUT, ONE_OUT, PauseMode::BothRemoved, true), MediaAction::Resume);
+}
+
+// Only a pause this code made is undone. Music the user stopped by hand stays stopped.
+TEST(AirPods, DoesNotResumeWhatItDidNotPause) {
+    EXPECT_EQ(ear_media_action(BOTH_OUT, WORN, PauseMode::OneRemoved, false), MediaAction::None);
+    EXPECT_EQ(ear_media_action(BOTH_OUT, WORN, PauseMode::OneRemoved, true), MediaAction::Resume);
+}
+
+TEST(AirPods, PutsABudInTheCaseTheSameAsOutOfTheEar) {
+    const EarState in_case{EarStatus::InEar, EarStatus::InCase};
+    EXPECT_EQ(ear_media_action(WORN, in_case, PauseMode::OneRemoved, false), MediaAction::Pause);
+    // An unchanged state is never a trigger, however it is reported.
+    EXPECT_EQ(ear_media_action(in_case, in_case, PauseMode::OneRemoved, false), MediaAction::None);
+}
+
 TEST(AirPods, DistinguishesAirPodsFromAnIPhone) {
     Device buds;
     buds.name = "ZBZ AirPros";

--- a/test/test_airpods.cpp
+++ b/test/test_airpods.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+#include <tether/bluetooth/airpods.hpp>
+
+using namespace tether::bluetooth;
+
+namespace {
+
+    std::optional<BatteryUpdate> parse(const std::vector<uint8_t>& packet) {
+        return parse_battery(packet.data(), packet.size());
+    }
+
+    // 04 00 04 00 04 00 [count] ([component] 01 [level] [status] 01) * count
+    const std::vector<uint8_t> ALL_THREE = {0x04, 0x00, 0x04, 0x00, 0x04, 0x00, 0x03, 0x04, 0x01, 0x52, 0x01,
+                                            0x01, 0x02, 0x01, 0x4f, 0x01, 0x01, 0x08, 0x01, 0x2d, 0x01, 0x01};
+
+    const std::vector<uint8_t> RIGHT_ONLY = {0x04, 0x00, 0x04, 0x00, 0x04, 0x00, 0x01, 0x02, 0x01, 0x50, 0x01, 0x01};
+
+    // A bud back in the case: present in the packet, reporting nothing.
+    const std::vector<uint8_t> LEFT_DISCONNECTED = {
+        0x04, 0x00, 0x04, 0x00, 0x04, 0x00, 0x01, 0x04, 0x01, 0x00, 0x04, 0x01};
+
+} // namespace
+
+TEST(AirPods, ParsesEveryComponent) {
+    auto update = parse(ALL_THREE);
+    ASSERT_TRUE(update.has_value());
+    EXPECT_TRUE(update->has_left);
+    EXPECT_TRUE(update->has_right);
+    EXPECT_TRUE(update->has_case);
+    EXPECT_EQ(update->levels.left, 82);
+    EXPECT_EQ(update->levels.right, 79);
+    EXPECT_EQ(update->levels.case_, 45);
+}
+
+// A component the packet leaves out must keep whatever it had. Reporting it as 0
+// or unknown would make one bud's update blank the other.
+TEST(AirPods, PartialUpdateLeavesOtherComponentsAlone) {
+    AirPodsBattery battery;
+    merge_battery(battery, *parse(ALL_THREE));
+    merge_battery(battery, *parse(RIGHT_ONLY));
+
+    EXPECT_EQ(battery.left, 82);
+    EXPECT_EQ(battery.right, 80);
+    EXPECT_EQ(battery.case_, 45);
+}
+
+// Status 0x04 is a bud in the case or a shut case, not a flat battery.
+TEST(AirPods, DisconnectedComponentReadsUnknownNotZero) {
+    auto update = parse(LEFT_DISCONNECTED);
+    ASSERT_TRUE(update.has_value());
+    EXPECT_TRUE(update->has_left);
+    EXPECT_EQ(update->levels.left, -1);
+
+    AirPodsBattery battery;
+    merge_battery(battery, *parse(ALL_THREE));
+    merge_battery(battery, *update);
+    EXPECT_EQ(battery.left, -1);
+    EXPECT_EQ(battery.right, 79);
+}
+
+TEST(AirPods, RejectsMalformedPackets) {
+    // Count says two entries, only one follows.
+    EXPECT_FALSE(parse({0x04, 0x00, 0x04, 0x00, 0x04, 0x00, 0x02, 0x04, 0x01, 0x52, 0x01, 0x01}).has_value());
+    // Some other AAP notification on the same channel.
+    EXPECT_FALSE(parse({0x04, 0x00, 0x04, 0x00, 0x0f, 0x00, 0x01, 0x04, 0x01, 0x52, 0x01, 0x01}).has_value());
+    EXPECT_FALSE(parse({0x04, 0x00, 0x04}).has_value());
+    EXPECT_FALSE(parse({}).has_value());
+    // Well-formed but carrying only components we have no field for.
+    EXPECT_FALSE(parse({0x04, 0x00, 0x04, 0x00, 0x04, 0x00, 0x01, 0x01, 0x01, 0x52, 0x01, 0x01}).has_value());
+}
+
+TEST(AirPods, DistinguishesAirPodsFromAnIPhone) {
+    Device buds;
+    buds.name = "ZBZ AirPros";
+    buds.modalias = "bluetooth:v004Cp200Ed0100";
+    buds.uuids = {UUID_A2DP_SINK};
+    EXPECT_TRUE(buds.looks_like_airpods());
+    EXPECT_FALSE(buds.looks_like_iphone());
+
+    // An iPhone is the same vendor and can carry the same audio profile.
+    Device phone;
+    phone.name = "iPhone";
+    phone.modalias = "bluetooth:v004Cp700Ed0100";
+    phone.uuids = {UUID_A2DP_SINK, UUID_MAP_MAS, UUID_PBAP_PSE};
+    EXPECT_FALSE(phone.looks_like_airpods());
+
+    // Modalias is absent until SDP has been read, so the name still has to work.
+    Device unread;
+    unread.name = "AirPods Pro";
+    unread.uuids = {UUID_A2DP_SINK};
+    EXPECT_TRUE(unread.looks_like_airpods());
+
+    Device speaker;
+    speaker.name = "Kitchen Speaker";
+    speaker.uuids = {UUID_A2DP_SINK};
+    EXPECT_FALSE(speaker.looks_like_airpods());
+}

--- a/test/test_airpods.cpp
+++ b/test/test_airpods.cpp
@@ -69,6 +69,41 @@ TEST(AirPods, RejectsMalformedPackets) {
     EXPECT_FALSE(parse({0x04, 0x00, 0x04, 0x00, 0x04, 0x00, 0x01, 0x01, 0x01, 0x52, 0x01, 0x01}).has_value());
 }
 
+TEST(AirPods, ParsesEveryListeningMode) {
+    const std::pair<uint8_t, AncMode> cases[] = {
+        {0x01, AncMode::Off},
+        {0x02, AncMode::NoiseCancellation},
+        {0x03, AncMode::Transparency},
+        {0x04, AncMode::Adaptive},
+    };
+    for (const auto& [wire, expected] : cases) {
+        std::vector<uint8_t> packet = {0x04, 0x00, 0x04, 0x00, 0x09, 0x00, 0x0d, wire, 0x00, 0x00, 0x00};
+        auto mode = parse_anc(packet.data(), packet.size());
+        ASSERT_TRUE(mode.has_value()) << "wire value " << int(wire);
+        EXPECT_EQ(*mode, expected);
+        // Round trip through the names the IPC and CLI use.
+        EXPECT_EQ(anc_mode_from_string(to_string(*mode)), expected);
+    }
+}
+
+TEST(AirPods, RejectsMalformedListeningModes) {
+    const auto packet = [](std::initializer_list<uint8_t> bytes) {
+        std::vector<uint8_t> v(bytes);
+        return parse_anc(v.data(), v.size());
+    };
+    // Mode 0 and 5 are outside the range; the wire values start at 1.
+    EXPECT_FALSE(packet({0x04, 0x00, 0x04, 0x00, 0x09, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x00}).has_value());
+    EXPECT_FALSE(packet({0x04, 0x00, 0x04, 0x00, 0x09, 0x00, 0x0d, 0x05, 0x00, 0x00, 0x00}).has_value());
+    // Right prefix, wrong length.
+    EXPECT_FALSE(packet({0x04, 0x00, 0x04, 0x00, 0x09, 0x00, 0x0d, 0x02}).has_value());
+    // A battery notification must not be read as a listening mode.
+    EXPECT_FALSE(packet({0x04, 0x00, 0x04, 0x00, 0x04, 0x00, 0x01, 0x02, 0x01, 0x50, 0x01}).has_value());
+    EXPECT_FALSE(parse_anc(nullptr, 0).has_value());
+
+    EXPECT_FALSE(anc_mode_from_string("").has_value());
+    EXPECT_FALSE(anc_mode_from_string("ancs").has_value());
+}
+
 TEST(AirPods, DistinguishesAirPodsFromAnIPhone) {
     Device buds;
     buds.name = "ZBZ AirPros";

--- a/test/test_airpods.cpp
+++ b/test/test_airpods.cpp
@@ -181,6 +181,49 @@ TEST(AirPods, PutsABudInTheCaseTheSameAsOutOfTheEar) {
     EXPECT_EQ(ear_media_action(in_case, in_case, PauseMode::OneRemoved, false), MediaAction::None);
 }
 
+TEST(AirPods, HandoffIsOffUnlessEnabled) {
+    EXPECT_EQ(handoff_action(true, true, false, false), HandoffAction::None);
+    EXPECT_EQ(handoff_action(false, false, true, false), HandoffAction::None);
+}
+
+TEST(AirPods, HandsBudsOverForACallAndTakesThemBack) {
+    EXPECT_EQ(handoff_action(true, true, false, true), HandoffAction::Release);
+    // Released, so the buds are no longer on this machine; the call ending is the trigger.
+    EXPECT_EQ(handoff_action(true, false, true, true), HandoffAction::None);
+    EXPECT_EQ(handoff_action(false, false, true, true), HandoffAction::Reclaim);
+}
+
+// Buds the user disconnected themselves are not ours to take back.
+TEST(AirPods, DoesNotReclaimBudsItDidNotRelease) {
+    EXPECT_EQ(handoff_action(false, false, false, true), HandoffAction::None);
+    EXPECT_EQ(handoff_action(false, true, false, true), HandoffAction::None);
+}
+
+// A call while the buds are already on the phone has nothing to hand over.
+TEST(AirPods, DoesNothingWhenTheBudsAreNotOnThisMachine) {
+    EXPECT_EQ(handoff_action(true, false, false, true), HandoffAction::None);
+}
+
+// Releasing twice would lose track of what to give back.
+TEST(AirPods, DoesNotReleaseTwice) { EXPECT_EQ(handoff_action(true, true, true, true), HandoffAction::None); }
+
+TEST(AirPods, RecognisesCallsThatWantTheBuds) {
+    const auto calls = [](const char* text) { return nlohmann::json::parse(text); };
+    EXPECT_TRUE(call_wants_audio(calls(R"([{"state":"incoming","ringing":true}])")));
+    EXPECT_TRUE(call_wants_audio(calls(R"([{"state":"active","connected":true}])")));
+    EXPECT_TRUE(call_wants_audio(calls(R"([{"state":"dialing","outgoing":true}])")));
+    // A held call still has the buds' attention.
+    EXPECT_TRUE(call_wants_audio(calls(R"([{"state":"held","connected":true}])")));
+
+    EXPECT_FALSE(call_wants_audio(calls("[]")));
+    EXPECT_FALSE(call_wants_audio(calls(R"([{"state":"disconnected"}])")));
+    EXPECT_FALSE(call_wants_audio(nlohmann::json()));
+    EXPECT_FALSE(call_wants_audio(calls(R"({"not":"an array"})")));
+
+    // One live call among finished ones still counts.
+    EXPECT_TRUE(call_wants_audio(calls(R"([{"state":"disconnected"},{"state":"active","connected":true}])")));
+}
+
 TEST(AirPods, DistinguishesAirPodsFromAnIPhone) {
     Device buds;
     buds.name = "ZBZ AirPros";


### PR DESCRIPTION
Initial support for AirPods:
1. Existing paired airpods are identified by Tether
2. Audio handoff for phone calls
3. MPRIS (media) control and ducking
4. Ear detection (pause / resume)
5. "Listening mode" (Transparency, Noise Cancellation, etc)
6. Battery status