### PR TITLE
CLI installer, update/uninstall, and running tether headless

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,24 @@ configure_file(
 install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/tether-native-host"
         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+# systemd user unit for the daemon. The distro packages install it with the real
+# path in ExecStart; a portable build carries a copy with a placeholder the CLI
+# fills in with wherever that build happens to live.
+set(TETHERD_EXEC "${CMAKE_INSTALL_FULL_BINDIR}/tetherd")
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/packaging/systemd/tetherd.service.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/tetherd.service"
+    @ONLY
+)
+set(TETHERD_EXEC "__TETHERD_EXEC__")
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/packaging/systemd/tetherd.service.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/generated/tetherd.service.tmpl"
+    @ONLY
+)
+
 # embed files only the distro packages can install, so portable build can write them out at runtime.
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/generated/tetherd.service.tmpl" TETHERD_UNIT)
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/packaging/systemd/tether-btclass@.service" BTCLASS_UNIT)
 file(READ "${CMAKE_CURRENT_BINARY_DIR}/com.tether.extension.chrome.json" CHROME_MANIFEST)
 file(READ "${CMAKE_CURRENT_BINARY_DIR}/com.tether.extension.mozilla.json" MOZILLA_MANIFEST)
@@ -145,6 +162,10 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/man/tetherd.8"
 set(SYSTEMD_UNIT_DIR "lib/systemd/system" CACHE PATH "systemd system unit directory")
 install(FILES packaging/systemd/tether-btclass@.service
         DESTINATION "${SYSTEMD_UNIT_DIR}")
+
+set(SYSTEMD_USER_UNIT_DIR "lib/systemd/user" CACHE PATH "systemd user unit directory")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tetherd.service"
+        DESTINATION "${SYSTEMD_USER_UNIT_DIR}")
 
 # firewall profiles for the mTLS listener (5134/tcp) and mDNS (5353/udp) installed but not applied (user's call).
 set(UFW_APPLICATIONS_DIR "/etc/ufw/applications.d" CACHE PATH "ufw application profile directory")

--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ The extension communicates with `tetherd` via native messaging. This allows user
 
 ## Installation
 
+### Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zackb/tether/main/scripts/install.sh | sh
+```
+
+It takes the distro package where it can use one and the AppImage otherwise,
+into `~/.local` with no root needed, and installs the `tetherd` systemd user
+service without enabling anything. `--help` lists the rest:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zackb/tether/main/scripts/install.sh | sh -s -- --help
+curl -fsSL https://raw.githubusercontent.com/zackb/tether/main/scripts/install.sh | sh -s -- --headless --enable
+```
+
+Afterwards `tether update` and `tether uninstall` do what they say. Where
+something else owns the build, a distro package or flatpak, they print the
+command that tool wants rather than working behind its back.
+
 ### iOS App
 - Get the app: [Tether - Linux Companion](https://apps.apple.com/us/app/tether-linux-companion/id6762097135)
 
@@ -237,7 +256,8 @@ make install
    or
 
    ```bash
-   tether --accept <fingerprint>   # fingerprint is printed by the daemon log
+   tether pending                  # the requests waiting, with their fingerprints
+   tether accept <fingerprint>
    ```
 
 3. Bluetooth (for Messages and Notifications):
@@ -275,6 +295,21 @@ make install
    "Show Message Notifications" and "Sync Contacts". Both are needed. They can
    take a few minutes to appear; "Show iPhone Permissions" in the GTK app
    re-advertises so they show up again.
+
+
+### No desktop on the machine?
+
+The daemon does not need a Wayland session. Everything but clipboard sync works
+over SSH, pairing included:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zackb/tether/main/scripts/install.sh | sh -s -- --headless --enable
+tether pending          # the pairing requests waiting, with fingerprints
+tether accept 9a4f21...
+tether status           # devices, links, and recent transfers
+```
+
+See [docs/HEADLESS.md](docs/HEADLESS.md).
 
 
 ## Components

--- a/docs/HEADLESS.md
+++ b/docs/HEADLESS.md
@@ -1,0 +1,113 @@
+# Tether on a machine with no desktop
+
+Tether is built for a Wayland desktop, but the daemon does not need one. On a
+server, a Raspberry Pi, or a machine you only ever reach over SSH, `tetherd`
+still speaks to the iPhone over Wi-Fi and everything except clipboard sync
+works. This is how to set that up and drive it from the CLI.
+
+What you get, and what you do not:
+
+| Feature | Headless |
+|---|---|
+| File transfer, both directions | ✅ |
+| OTP handling and the vault | ✅ |
+| Pairing, device management, status | ✅ |
+| Messages, notifications, calls | ✅ with a Bluetooth adapter the machine can see |
+| Clipboard sync | ❌ needs a Wayland session with `wlr-data-control` |
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zackb/tether/main/scripts/install.sh | sh -s -- --headless --enable
+```
+
+`--headless` unpacks the AppImage into `~/.local/share/tether` rather than
+pulling the GTK stack in through a distro package, and skips the browser and
+mail extension hosts. `--enable` starts the daemon now, on every login, and
+keeps it running after you log out.
+
+Nothing there needs root. Leave `--enable` off and the installer prints the two
+commands instead, which is the better order if you want to read them first:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now tetherd.service
+loginctl enable-linger $USER      # or the daemon dies with your SSH session
+```
+
+`loginctl enable-linger` is the part people miss. Without it systemd tears the
+user session down when your last shell exits, and the daemon goes with it.
+
+## Pair the iPhone
+
+The daemon advertises itself over mDNS and the iOS app finds it. Both ends have
+to accept, and on the desktop that prompt is a GTK window you do not have here,
+so accept it from the shell instead:
+
+```bash
+tether status         # is the daemon up, is mDNS advertising
+tether pending        # the requests waiting, with their fingerprints
+tether accept 9a4f21c8…
+tether devices        # what is paired now
+```
+
+If the phone cannot find the machine, mDNS or the firewall is usually why:
+
+```bash
+sudo systemctl enable --now avahi-daemon    # tetherd needs it to advertise
+sudo ufw allow tether                        # 5134/tcp and 5353/udp
+```
+
+The package ships profiles for ufw and firewalld but applies neither. Opening
+5134 is your call: it is the mTLS listener, and both ends pin certificates, but
+it is still a port.
+
+## Use it
+
+```bash
+tether send ./report.pdf              # to the phone
+tether status                         # what arrived, and from whom
+tether bt threads                     # conversations, over Bluetooth
+tether bt send <thread> "on my way"
+```
+
+Files the phone sends land in `$XDG_DOWNLOAD_DIR`, or `~/Downloads`. On a server
+where that does not exist, set `XDG_DOWNLOAD_DIR` in the unit's environment:
+
+```bash
+systemctl --user edit tetherd.service
+# [Service]
+# Environment=XDG_DOWNLOAD_DIR=%h/inbox
+```
+
+## Clipboard sync
+
+`tether status` says `Clipboard: off, no Wayland session on this machine` and
+that is the whole story: without a compositor there is no clipboard to sync. The
+rest of the daemon does not care. If the machine does run a compositor and this
+still says off, the compositor is missing `wlr-data-control` or
+`ext-data-control`.
+
+## From another machine
+
+The CLI talks to a remote daemon over the same TLS the phone uses:
+
+```bash
+tether paste --host 10.0.0.5
+tether pair --host 10.0.0.5
+```
+
+## Updating and removing
+
+```bash
+tether update
+tether uninstall            # keeps pairings and settings
+```
+
+Both defer to whatever installed the build: the installer replaces what it put
+there, and a distro package, flatpak, or source tree gets the right command
+printed instead. To take everything, pairings included:
+
+```bash
+~/.local/share/tether/install.sh uninstall --purge
+```

--- a/docs/man/man1/tether.1.in
+++ b/docs/man/man1/tether.1.in
@@ -4,11 +4,17 @@ tether \- Wayland companion CLI for iPhone integration
 .SH SYNOPSIS
 .B tether
 [\fIOPTIONS\fR]
+.br
+.B tether
+\fICOMMAND\fR [\fIARGUMENTS\fR]
 .SH DESCRIPTION
 .B tether
 is a command-line interface for communicating with the Tether daemon (\fBtetherd\fR).
 It allows for clipboard synchronization, file transfers, and device management between
 a Linux Wayland desktop and an iOS device.
+.PP
+Every option below also has a subcommand form, so \fBtether status\fR and
+\fBtether \-\-status\fR are the same thing. See \fBCOMMANDS\fR.
 .SH OPTIONS
 .TP
 \fB\-h, \-\-help\fR
@@ -44,6 +50,16 @@ Discovery scan duration in milliseconds (default: 3000).
 \fB\-\-list-devices\fR
 List all paired connection devices and their fingerprints.
 .TP
+\fB\-\-status\fR
+Print what the daemon is doing: version, clipboard and mDNS state, how many
+devices are paired, how many pairing requests wait, which peers are connected,
+and the files most recently received.
+.TP
+\fB\-\-pending\fR
+List the Wi\-Fi pairing requests waiting to be accepted, with the fingerprint
+\fB\-\-accept\fR takes. On a machine with no GTK app to show the prompt, this
+is how a request is seen.
+.TP
 \fB\-\-accept\fR \fIFINGERPRINT\fR
 Accept a pending pairing request locally for the specified device fingerprint.
 .TP
@@ -65,6 +81,42 @@ distro packages install the manifests system\-wide.
 Write \fBtether-btclass@.service\fR to \fB/etc/systemd/system\fR. Needs root, and
 never enables it. Needed only for a portable build such as the AppImage; the distro
 packages install the unit themselves. See \fB\-\-bt-setup\fR.
+.TP
+\fB\-\-install-service\fR
+Write \fBtetherd.service\fR into \fB~/.config/systemd/user\fR and print the
+commands that enable it. Never enables or starts anything. Needed only for a
+portable build; the distro packages install the unit system\-wide.
+.TP
+\fB\-\-uninstall-service\fR
+Remove the \fBtetherd.service\fR unit this user installed.
+.TP
+\fB\-\-self-update\fR
+Update tether. When \fBscripts/install.sh\fR installed this build, it runs the
+copy it left in \fB~/.local/share/tether\fR. Otherwise the package manager,
+flatpak or source tree owns the build, and tether prints the command that
+updates it rather than acting behind that tool's back.
+.TP
+\fB\-\-uninstall\fR
+Remove tether, on the same terms as \fB\-\-self-update\fR.
+.SH COMMANDS
+Each of these is the option named beside it, so nothing behaves differently for
+having been typed as a word.
+.TP
+\fBstatus\fR, \fBdevices\fR, \fBpending\fR
+\fB\-\-status\fR, \fB\-\-list-devices\fR, \fB\-\-pending\fR
+.TP
+\fBaccept\fR \fIFINGERPRINT\fR, \fBforget\fR \fIFINGERPRINT\fR, \fBpair\fR
+\fB\-\-accept\fR, \fB\-\-forget\fR, \fB\-\-pair\fR
+.TP
+\fBdiscover\fR, \fBsend\fR \fIFILE\fR, \fBcopy\fR [\fISTRING\fR], \fBpaste\fR
+\fB\-\-discover\fR, \fB\-\-send-file\fR, \fB\-\-set-clipboard\fR, \fB\-\-get-clipboard\fR
+.TP
+\fBservice\fR, \fBupdate\fR, \fBuninstall\fR (or \fBremove\fR)
+\fB\-\-install-service\fR, \fB\-\-self-update\fR, \fB\-\-uninstall\fR
+.TP
+\fBbt\fR \fINAME\fR [\fIARGUMENTS\fR]
+The \fB\-\-bt-\fR\fINAME\fR option, so \fBtether bt pair AA:BB:CC:DD:EE:FF\fR is
+\fBtether \-\-bt-pair AA:BB:CC:DD:EE:FF\fR.
 .SH BLUETOOTH OPTIONS
 Bluetooth carries iPhone messages (MAP), contacts (PBAP), and notification
 mirroring (ANCS). It is independent of the Wi-Fi pairing above.
@@ -196,7 +248,18 @@ tether \-f document.pdf
 See what Bluetooth still needs before pairing an iPhone:
 .IP
 tether \-\-bt-setup
+.PP
+Pair an iPhone over Wi\-Fi from a machine with no desktop, after the phone has
+found the daemon:
+.IP
+tether pending && tether accept 9a4f21...
 .SH FILES
+.TP
+\fB/usr/lib/systemd/user/tetherd.service\fR
+Starts \fBtetherd\fR for one user. Installed by the distro packages but never
+enabled; a portable build writes its own copy to
+\fB~/.config/systemd/user\fR with \fB\-\-install-service\fR. The daemon does
+not need a Wayland session: without one it runs with clipboard sync off.
 .TP
 \fB/usr/lib/systemd/system/tether\-btclass@.service\fR
 Sets the Bluetooth adapter's Class of Device to A/V Hands\-Free, which iOS
@@ -205,4 +268,5 @@ by the distro packages but never enabled; a portable build writes it to
 \fB/etc/systemd/system\fR instead. See \fB\-\-bt-setup\fR.
 .SH SEE ALSO
 .BR tetherd (8),
-.BR tether-gtk (1)
+.BR tether-gtk (1),
+.BR systemd.unit (5)

--- a/packaging/systemd/tetherd.service.in
+++ b/packaging/systemd/tetherd.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Tether daemon, bridging an iPhone to this computer
+Documentation=https://github.com/zackb/tether
+# Deliberately not tied to graphical-session.target: tetherd runs without a
+# Wayland session, it just does not sync the clipboard when there is none.
+After=dbus.socket network.target bluetooth.target
+Wants=network.target
+
+[Service]
+Type=simple
+ExecStart=@TETHERD_EXEC@
+Restart=on-failure
+RestartSec=3
+# The daemon writes its own log into $XDG_STATE_HOME/tether.
+StandardOutput=null
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -236,6 +236,29 @@ msgstr ""
 "Potřebné pouze pro přenosná sestavení; balíčky distribuce ji instalují samy."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Zapíše uživatelskou službu systemd tetherd pro tohoto uživatele a vypíše, "
+"jak ji zapnout. Potřeba jen u přenosných sestavení; distribuční balíčky ji "
+"instalují samy."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Odebere uživatelskou službu systemd tetherd, kterou tento uživatel "
+"nainstaloval."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Ukáže, co démon dělá: zařízení, spojení a poslední přenosy."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Vypíše žádosti o spárování přes Wi-Fi, které čekají na přijetí."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Přijmout čekající žádost o spárování místně."
 
@@ -248,12 +271,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Odeslat pair_request démonovi přes TCP."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Aktualizuje tether, nebo vypíše příkaz, který to udělá, když toto sestavení "
+"spravuje jiný nástroj."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Odebere tether, nebo vypíše příkaz, který to udělá, když toto sestavení "
+"spravuje jiný nástroj."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - doprovodný nástroj příkazové řádky pro Wayland"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Volby:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Příkazy:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Libovolný přepínač --bt-<název> jako podpříkaz."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -699,6 +746,169 @@ msgstr "Odesláno na %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Zpráva nebyla odeslána."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Stav démona se nepodařilo přečíst.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Verze"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Démon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "běží"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Schránka"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synchronizuje se"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "vypnuto, na tomto stroji není relace Wayland"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "oznamuje se"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "nedostupné"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Spárovaná zařízení"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Čekající žádosti"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Právě připojeno"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "spárováno"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "nespárováno"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Nedávno přijaté:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Spusťte 'tether pending' a uvidíte, co čeká na přijetí.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Nečekají žádné žádosti o spárování.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Přijměte některou pomocí: tether accept <otisk>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether ji za vás nezapne. Démona spustíte nyní i při každém přihlášení "
+"takto:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Na serveru, ze kterého se odhlašujete, udržte naživu i uživatelskou relaci:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Pro tohoto uživatele nebyla nainstalována žádná uživatelská služba tetherd.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "Odebráno: %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Spusťte 'systemctl --user daemon-reload', aby na ni systemd zapomněl.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "Nepodařilo se spustit {}: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Odebrání tohoto sestavení není na tetheru. Spusťte:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Aktualizace tohoto sestavení není na tetheru. Spusťte:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2176,7 +2386,9 @@ msgstr "Zamknout relaci, když iPhone opustí dosah"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Zamkne asi půl minuty po vypršení spojení. Vypnutí Bluetooth na iPhonu nezamkne, stejně jako uspání tohoto počítače."
+msgstr ""
+"Zamkne asi půl minuty po vypršení spojení. Vypnutí Bluetooth na iPhonu "
+"nezamkne, stejně jako uspání tohoto počítače."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -109,7 +109,8 @@ msgstr "AirPods während eines Anrufs an das iPhone übergeben: on oder off."
 
 #: src/cli/main.cpp
 msgid "Lock the session when the iPhone goes out of range: on or off."
-msgstr "Die Sitzung sperren, wenn das iPhone außer Reichweite gerät: on oder off."
+msgstr ""
+"Die Sitzung sperren, wenn das iPhone außer Reichweite gerät: on oder off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -239,6 +240,30 @@ msgstr ""
 "portable Builds nötig; die Distributionspakete installieren sie selbst."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Schreibt den systemd-Benutzerdienst tetherd für diesen Benutzer und zeigt, "
+"wie er aktiviert wird. Nur für portable Builds nötig; die "
+"Distributionspakete installieren ihn selbst."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Entfernt den systemd-Benutzerdienst tetherd, den dieser Benutzer installiert "
+"hat."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+"Zeigt, was der Daemon tut: Geräte, Verbindungen und letzte Übertragungen."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Listet WLAN-Kopplungsanfragen auf, die auf Bestätigung warten."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Eine ausstehende Kopplungsanfrage lokal annehmen."
 
@@ -251,12 +276,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Einen pair_request per TCP an den Daemon senden."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Aktualisiert tether oder zeigt den Befehl dafür, wenn ein anderes Werkzeug "
+"diesen Build verwaltet."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Entfernt tether oder zeigt den Befehl dafür, wenn ein anderes Werkzeug "
+"diesen Build verwaltet."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - Wayland-Begleitprogramm für die Kommandozeile"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Optionen:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Befehle:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Jedes --bt-<name>-Flag, als Unterbefehl."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -703,6 +752,169 @@ msgstr "Gesendet an %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Die Nachricht wurde nicht gesendet."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Der Zustand des Daemons konnte nicht gelesen werden.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Version"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Daemon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "läuft"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Zwischenablage"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "wird synchronisiert"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "aus, keine Wayland-Sitzung auf diesem Rechner"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "wird angekündigt"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "nicht verfügbar"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Gekoppelte Geräte"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Offene Anfragen"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Jetzt verbunden"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "gekoppelt"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "nicht gekoppelt"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Zuletzt empfangen:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Mit 'tether pending' sehen Sie, was auf Bestätigung wartet.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Es warten keine Kopplungsanfragen.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Eine bestätigen mit: tether accept <Fingerabdruck>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether aktiviert ihn nicht für Sie. So starten Sie den Daemon jetzt und bei "
+"jeder Anmeldung:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Auf einem Server, von dem Sie sich abmelden, halten Sie auch die "
+"Benutzersitzung am Leben:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr "Für diesen Benutzer war kein tetherd-Benutzerdienst installiert.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s entfernt\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Mit 'systemctl --user daemon-reload' wird er vergessen.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "{} konnte nicht ausgeführt werden: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Das Entfernen dieses Builds ist nicht Tethers Aufgabe. Führen Sie aus:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Das Aktualisieren dieses Builds ist nicht Tethers Aufgabe. Führen Sie aus:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2222,7 +2434,10 @@ msgstr "Sitzung sperren, wenn das iPhone außer Reichweite gerät"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Sperrt etwa eine halbe Minute nachdem die Verbindung abgelaufen ist. Bluetooth am iPhone auszuschalten sperrt nicht, und diese Maschine in den Ruhezustand zu versetzen ebenso wenig."
+msgstr ""
+"Sperrt etwa eine halbe Minute nachdem die Verbindung abgelaufen ist. "
+"Bluetooth am iPhone auszuschalten sperrt nicht, und diese Maschine in den "
+"Ruhezustand zu versetzen ebenso wenig."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -242,6 +242,31 @@ msgstr ""
 "la instalan."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Escribe el servicio de usuario de systemd tetherd para este usuario y "
+"muestra cómo activarlo. Solo hace falta en compilaciones portables; los "
+"paquetes de la distribución lo instalan."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Elimina el servicio de usuario de systemd tetherd que instaló este usuario."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+"Muestra qué está haciendo el demonio: dispositivos, conexiones y "
+"transferencias recientes."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr ""
+"Lista las solicitudes de emparejamiento por Wi-Fi que esperan aceptación."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Aceptar localmente una solicitud de emparejamiento pendiente."
 
@@ -254,12 +279,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Enviar un pair_request al daemon por TCP."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Actualiza tether, o muestra el comando que lo hace cuando otra herramienta "
+"gestiona esta compilación."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Elimina tether, o muestra el comando que lo hace cuando otra herramienta "
+"gestiona esta compilación."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - CLI complementaria para Wayland"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Opciones:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Comandos:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Cualquier opción --bt-<nombre>, como subcomando."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -703,6 +752,170 @@ msgstr "Enviado a %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "El mensaje no se envió."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "No se pudo leer el estado del demonio.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Versión"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Demonio"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "en ejecución"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Portapapeles"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "sincronizando"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "desactivado, no hay sesión Wayland en esta máquina"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "anunciando"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "no disponible"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Cortafuegos"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Dispositivos emparejados"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Solicitudes pendientes"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Conectados ahora"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "emparejado"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "sin emparejar"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Recibidos recientemente:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Ejecuta 'tether pending' para ver qué espera aceptación.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "No hay solicitudes de emparejamiento esperando.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Acepta una con: tether accept <huella>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether no lo activa por ti. Para iniciar el demonio ahora y en cada inicio "
+"de sesión:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"En un servidor del que cierras sesión, mantén viva también la sesión de "
+"usuario:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"No había ningún servicio de usuario tetherd instalado para este usuario.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s eliminado\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Ejecuta 'systemctl --user daemon-reload' para olvidarlo.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "No se pudo ejecutar {}: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Eliminar esta compilación no le corresponde a tether. Ejecuta:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Actualizar esta compilación no le corresponde a tether. Ejecuta:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2211,7 +2424,9 @@ msgstr "Bloquear la sesión cuando el iPhone quede fuera de alcance"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Bloquea alrededor de medio minuto después de que el enlace expire. Apagar el Bluetooth en el iPhone no bloquea, y suspender esta máquina tampoco."
+msgstr ""
+"Bloquea alrededor de medio minuto después de que el enlace expire. Apagar el "
+"Bluetooth en el iPhone no bloquea, y suspender esta máquina tampoco."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -245,6 +245,28 @@ msgstr ""
 "l'installent."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Écrit le service utilisateur systemd tetherd pour cet utilisateur et indique "
+"comment l'activer. Nécessaire uniquement pour les versions portables ; les "
+"paquets de distribution l'installent."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Supprime le service utilisateur systemd tetherd installé par cet utilisateur."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Affiche ce que fait le démon : appareils, liens et transferts récents."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Liste les demandes d'appairage Wi-Fi en attente d'acceptation."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Accepter localement une demande d'appairage en attente."
 
@@ -257,12 +279,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Envoyer un pair_request au démon en TCP."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Met à jour tether, ou affiche la commande qui le fait quand un autre outil "
+"gère cette version."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Supprime tether, ou affiche la commande qui le fait quand un autre outil "
+"gère cette version."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - utilitaire compagnon pour Wayland"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Options :"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Commandes :"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "N'importe quelle option --bt-<nom>, en sous-commande."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -708,6 +754,170 @@ msgstr "Envoyé à %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Le message n'a pas été envoyé."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Impossible de lire l'état du démon.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Version"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Démon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "en cours"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Presse-papiers"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synchronisation"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "désactivé, aucune session Wayland sur cette machine"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "diffusion"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "indisponible"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Pare-feu"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Appareils appairés"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Demandes en attente"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Connectés"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "appairé"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "non appairé"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Reçus récemment :"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Lancez 'tether pending' pour voir ce qui attend d'être accepté.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Aucune demande d'appairage en attente.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Acceptez-en une avec : tether accept <empreinte>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether ne l'active pas à votre place. Pour démarrer le démon maintenant et à "
+"chaque connexion :\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Sur un serveur dont vous vous déconnectez, gardez aussi la session "
+"utilisateur en vie :\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Aucun service utilisateur tetherd n'était installé pour cet utilisateur.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s supprimé\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Lancez 'systemctl --user daemon-reload' pour l'oublier.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "Impossible d'exécuter {} : {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Supprimer cette version n'appartient pas à tether. Lancez :\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Mettre à jour cette version n'appartient pas à tether. Lancez :\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2218,7 +2428,10 @@ msgstr "Verrouiller la session quand l'iPhone sort de portée"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Verrouille environ une demi-minute après l'expiration du lien. Couper le Bluetooth sur l'iPhone ne verrouille pas, et mettre cette machine en veille non plus."
+msgstr ""
+"Verrouille environ une demi-minute après l'expiration du lien. Couper le "
+"Bluetooth sur l'iPhone ne verrouille pas, et mettre cette machine en veille "
+"non plus."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -243,6 +243,31 @@ msgstr ""
 "installano."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Scrive il servizio utente systemd tetherd per questo utente e mostra come "
+"abilitarlo. Serve solo per le build portabili; i pacchetti della "
+"distribuzione lo installano."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Rimuove il servizio utente systemd tetherd installato da questo utente."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+"Mostra cosa sta facendo il demone: dispositivi, collegamenti e trasferimenti "
+"recenti."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr ""
+"Elenca le richieste di associazione Wi-Fi in attesa di essere accettate."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Accetta localmente una richiesta di accoppiamento in sospeso."
 
@@ -255,12 +280,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Invia un pair_request al daemon tramite TCP."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Aggiorna tether, o mostra il comando che lo fa quando questa build è gestita "
+"da un altro strumento."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Rimuove tether, o mostra il comando che lo fa quando questa build è gestita "
+"da un altro strumento."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - CLI complementare per Wayland"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Opzioni:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Comandi:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Qualsiasi opzione --bt-<nome>, come sottocomando."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -703,6 +752,168 @@ msgstr "Inviato a %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Il messaggio non è stato inviato."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Impossibile leggere lo stato del demone.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Versione"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Demone"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "in esecuzione"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Appunti"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "in sincronizzazione"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "disattivato, nessuna sessione Wayland su questa macchina"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "in annuncio"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "non disponibile"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Dispositivi associati"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Richieste in attesa"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Connessi ora"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "associato"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "non associato"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Ricevuti di recente:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Esegui 'tether pending' per vedere cosa è in attesa di essere accettato.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Nessuna richiesta di associazione in attesa.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Accettane una con: tether accept <impronta>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether non lo abilita al posto tuo. Per avviare il demone ora e a ogni "
+"accesso:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Su un server da cui esci, mantieni viva anche la sessione utente:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr "Per questo utente non era installato alcun servizio utente tetherd.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s rimosso\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Esegui 'systemctl --user daemon-reload' per dimenticarlo.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "Impossibile eseguire {}: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Rimuovere questa build non spetta a tether. Esegui:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Aggiornare questa build non spetta a tether. Esegui:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2211,7 +2422,9 @@ msgstr "Blocca la sessione quando l'iPhone esce dalla portata"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Blocca circa mezzo minuto dopo la scadenza del collegamento. Disattivare il Bluetooth sull'iPhone non blocca, e nemmeno sospendere questa macchina."
+msgstr ""
+"Blocca circa mezzo minuto dopo la scadenza del collegamento. Disattivare il "
+"Bluetooth sull'iPhone non blocca, e nemmeno sospendere questa macchina."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -239,6 +239,28 @@ msgstr ""
 "ンストールします。"
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"このユーザー用に tetherd の systemd ユーザーサービスを書き出し、有効にする方"
+"法を表示します。ポータブルビルドでのみ必要です。ディストリビューションのパッ"
+"ケージは自動で導入します。"
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"このユーザーが導入した tetherd の systemd ユーザーサービスを削除します。"
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "デーモンの状況を表示します: デバイス、接続、最近の転送。"
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "承認待ちの Wi-Fi ペアリング要求を一覧表示します。"
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "保留中のペアリング要求をローカルで承認します。"
 
@@ -251,12 +273,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "TCP でデーモンに pair_request を送信します。"
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"tether を更新します。別のツールがこのビルドを管理している場合は、そのコマンド"
+"を表示します。"
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"tether を削除します。別のツールがこのビルドを管理している場合は、そのコマンド"
+"を表示します。"
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - Wayland 用のコンパニオン CLI"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "オプション:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "コマンド:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "任意の --bt-<名前> フラグをサブコマンドとして。"
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -689,6 +735,169 @@ msgstr "%s に送信しました\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "メッセージは送信されませんでした。"
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "デーモンの状態を読み取れませんでした。\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "バージョン"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "デーモン"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "実行中"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "クリップボード"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "同期中"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "オフ、このマシンに Wayland セッションがありません"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "アドバタイズ中"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "利用できません"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "ファイアウォール"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "ペアリング済みデバイス"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "保留中の要求"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "現在の接続"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "ペアリング済み"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "未ペアリング"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "最近受信したファイル:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"承認待ちの内容は 'tether pending' で確認できます。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "保留中のペアリング要求はありません。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"承認するには: tether accept <フィンガープリント>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether が自動で有効にすることはありません。今すぐ、そしてログインのたびにデー"
+"モンを起動するには:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"ログアウトするサーバーでは、ユーザーセッションも維持してください:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"このユーザーには tetherd ユーザーサービスが導入されていませんでした。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s を削除しました\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"'systemctl --user daemon-reload' を実行すると反映されます。\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "{} を実行できませんでした: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"このビルドの削除は tether の担当ではありません。次を実行してください:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"このビルドの更新は tether の担当ではありません。次を実行してください:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2172,7 +2381,9 @@ msgstr "iPhone が範囲外になったらセッションをロックする"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "リンクがタイムアウトしてから約 30 秒後にロックします。iPhone 側で Bluetooth を切ってもロックせず、このマシンをサスペンドしてもロックしません。"
+msgstr ""
+"リンクがタイムアウトしてから約 30 秒後にロックします。iPhone 側で Bluetooth "
+"を切ってもロックせず、このマシンをサスペンドしてもロックしません。"
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -236,6 +236,26 @@ msgstr ""
 "다. 배포판 패키지는 직접 설치합니다."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"이 사용자를 위한 tetherd systemd 사용자 서비스를 작성하고 활성화 방법을 출력"
+"합니다. 이식형 빌드에만 필요하며, 배포판 패키지는 직접 설치합니다."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "이 사용자가 설치한 tetherd systemd 사용자 서비스를 제거합니다."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "데몬의 상태를 보여줍니다: 장치, 연결, 최근 전송."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "수락을 기다리는 Wi-Fi 페어링 요청을 나열합니다."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "대기 중인 페어링 요청을 로컬에서 수락합니다."
 
@@ -248,12 +268,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "TCP로 데몬에 pair_request를 보냅니다."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"tether를 업데이트하거나, 다른 도구가 이 빌드를 관리하는 경우 그 명령을 출력합"
+"니다."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"tether를 제거하거나, 다른 도구가 이 빌드를 관리하는 경우 그 명령을 출력합니"
+"다."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - Wayland용 보조 CLI"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "옵션:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "명령:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "모든 --bt-<이름> 플래그를 하위 명령으로."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -686,6 +730,168 @@ msgstr "%s(으)로 보냈습니다\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "메시지가 전송되지 않았습니다."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "데몬의 상태를 읽을 수 없습니다.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "버전"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "데몬"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "실행 중"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "클립보드"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "동기화 중"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "꺼짐, 이 컴퓨터에 Wayland 세션이 없습니다"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "알리는 중"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "사용할 수 없음"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "방화벽"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "페어링된 장치"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "대기 중인 요청"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "현재 연결됨"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "페어링됨"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "페어링되지 않음"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "최근에 받은 파일:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"무엇이 수락을 기다리는지 보려면 'tether pending'을 실행하세요.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "대기 중인 페어링 요청이 없습니다.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"수락하려면: tether accept <지문>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether가 대신 활성화하지는 않습니다. 데몬을 지금 그리고 로그인할 때마다 시작"
+"하려면:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"로그아웃하는 서버에서는 사용자 세션도 유지하세요:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr "이 사용자에게 설치된 tetherd 사용자 서비스가 없습니다.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s 제거함\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"'systemctl --user daemon-reload'를 실행하면 반영됩니다.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "{}을(를) 실행할 수 없습니다: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"이 빌드를 제거하는 일은 tether의 몫이 아닙니다. 다음을 실행하세요:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"이 빌드를 업데이트하는 일은 tether의 몫이 아닙니다. 다음을 실행하세요:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2145,7 +2351,9 @@ msgstr "iPhone이 범위를 벗어나면 세션 잠그기"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "링크가 시간 초과된 뒤 약 30초 후에 잠급니다. iPhone에서 Bluetooth를 꺼도 잠기지 않으며, 이 기기를 절전 모드로 두어도 잠기지 않습니다."
+msgstr ""
+"링크가 시간 초과된 뒤 약 30초 후에 잠급니다. iPhone에서 Bluetooth를 꺼도 잠기"
+"지 않으며, 이 기기를 절전 모드로 두어도 잠기지 않습니다."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -110,7 +110,8 @@ msgstr "De AirPods tijdens een gesprek aan de iPhone geven: on of off."
 
 #: src/cli/main.cpp
 msgid "Lock the session when the iPhone goes out of range: on or off."
-msgstr "De sessie vergrendelen wanneer de iPhone buiten bereik raakt: on of off."
+msgstr ""
+"De sessie vergrendelen wanneer de iPhone buiten bereik raakt: on of off."
 
 #: src/cli/main.cpp
 msgid "List iPhone message conversations."
@@ -239,6 +240,30 @@ msgstr ""
 "voor draagbare builds; de distributiepakketten installeren hem zelf."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Schrijft de systemd-gebruikersservice tetherd voor deze gebruiker en toont "
+"hoe je hem inschakelt. Alleen nodig voor draagbare builds; de "
+"distributiepakketten installeren hem."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Verwijdert de systemd-gebruikersservice tetherd die deze gebruiker heeft "
+"geïnstalleerd."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+"Toont wat de daemon doet: apparaten, verbindingen en recente overdrachten."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Toont wifi-koppelverzoeken die op acceptatie wachten."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Een openstaand koppelverzoek lokaal accepteren."
 
@@ -251,12 +276,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Een pair_request via TCP naar de daemon sturen."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Werkt tether bij, of toont het commando dat dat doet wanneer een ander "
+"programma deze build beheert."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Verwijdert tether, of toont het commando dat dat doet wanneer een ander "
+"programma deze build beheert."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - Wayland-hulpprogramma voor de opdrachtregel"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Opties:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Opdrachten:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Elke --bt-<naam>-optie, als subopdracht."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -699,6 +748,169 @@ msgstr "Verstuurd naar %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Het bericht is niet verstuurd."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Kon de status van de daemon niet lezen.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Versie"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Daemon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "actief"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Klembord"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synchroniseert"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "uit, geen Wayland-sessie op deze machine"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "adverteert"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "niet beschikbaar"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Gekoppelde apparaten"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Openstaande verzoeken"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Nu verbonden"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "gekoppeld"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "niet gekoppeld"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Recent ontvangen:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Voer 'tether pending' uit om te zien wat op acceptatie wacht.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Er wachten geen koppelverzoeken.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Accepteer er een met: tether accept <vingerafdruk>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether schakelt hem niet voor je in. Start de daemon nu en bij elke "
+"aanmelding:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Op een server waar je uitlogt, houd je ook de gebruikerssessie in leven:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Voor deze gebruiker was geen tetherd-gebruikersservice geïnstalleerd.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s verwijderd\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Voer 'systemctl --user daemon-reload' uit om hem te vergeten.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "Kon {} niet uitvoeren: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Deze build verwijderen is niet aan tether. Voer uit:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Deze build bijwerken is niet aan tether. Voer uit:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2195,7 +2407,10 @@ msgstr "De sessie vergrendelen wanneer de iPhone buiten bereik raakt"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Vergrendelt ongeveer een halve minuut nadat de verbinding verlopen is. Bluetooth uitzetten op de iPhone vergrendelt niet, en deze machine in slaapstand zetten evenmin."
+msgstr ""
+"Vergrendelt ongeveer een halve minuut nadat de verbinding verlopen is. "
+"Bluetooth uitzetten op de iPhone vergrendelt niet, en deze machine in "
+"slaapstand zetten evenmin."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -239,6 +239,29 @@ msgstr ""
 "tylko dla wersji przenośnych; pakiety dystrybucji instalują ją same."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Zapisuje usługę użytkownika systemd tetherd dla tego użytkownika i pokazuje, "
+"jak ją włączyć. Potrzebne tylko dla wersji przenośnych; pakiety dystrybucji "
+"instalują ją same."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Usuwa usługę użytkownika systemd tetherd zainstalowaną przez tego "
+"użytkownika."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Pokazuje, co robi demon: urządzenia, połączenia i ostatnie transfery."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Wyświetla żądania parowania przez Wi-Fi czekające na akceptację."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Zaakceptuj lokalnie oczekujące żądanie parowania."
 
@@ -251,12 +274,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Wyślij pair_request do demona przez TCP."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Aktualizuje tether albo wypisuje polecenie, które to robi, gdy tą wersją "
+"zarządza inne narzędzie."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Usuwa tether albo wypisuje polecenie, które to robi, gdy tą wersją zarządza "
+"inne narzędzie."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - towarzyszące narzędzie wiersza poleceń dla Waylanda"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Opcje:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Polecenia:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Dowolna opcja --bt-<nazwa> jako podpolecenie."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -704,6 +751,169 @@ msgstr "Wysłano do %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Wiadomość nie została wysłana."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Nie udało się odczytać stanu demona.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Wersja"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Demon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "działa"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Schowek"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synchronizuje"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "wyłączone, brak sesji Wayland na tej maszynie"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "rozgłasza"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "niedostępne"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Zapora"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Sparowane urządzenia"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Oczekujące żądania"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Połączone teraz"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "sparowane"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "niesparowane"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Ostatnio odebrane:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Uruchom 'tether pending', aby zobaczyć, co czeka na akceptację.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Żadne żądania parowania nie czekają.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Zaakceptuj je poleceniem: tether accept <odcisk>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether nie włącza jej za ciebie. Aby uruchomić demona teraz i przy każdym "
+"logowaniu:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Na serwerze, z którego się wylogowujesz, utrzymaj też sesję użytkownika:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Dla tego użytkownika nie była zainstalowana usługa użytkownika tetherd.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "Usunięto %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Uruchom 'systemctl --user daemon-reload', aby o niej zapomniał.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "Nie udało się uruchomić {}: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Usunięcie tej wersji nie należy do tethera. Uruchom:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Aktualizacja tej wersji nie należy do tethera. Uruchom:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2197,7 +2407,9 @@ msgstr "Zablokuj sesję, gdy iPhone znajdzie się poza zasięgiem"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Blokuje około pół minuty po wygaśnięciu połączenia. Wyłączenie Bluetootha w iPhonie nie blokuje, podobnie jak uśpienie tego komputera."
+msgstr ""
+"Blokuje około pół minuty po wygaśnięciu połączenia. Wyłączenie Bluetootha w "
+"iPhonie nie blokuje, podobnie jak uśpienie tego komputera."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -240,6 +240,29 @@ msgstr ""
 "apenas para builds portáteis; os pacotes da distribuição a instalam."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Escreve o serviço de usuário systemd tetherd para este usuário e mostra como "
+"ativá-lo. Necessário apenas em builds portáteis; os pacotes da distribuição "
+"o instalam."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Remove o serviço de usuário systemd tetherd que este usuário instalou."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+"Mostra o que o daemon está fazendo: dispositivos, conexões e transferências "
+"recentes."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Lista os pedidos de pareamento por Wi-Fi aguardando aceitação."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Aceitar localmente uma solicitação de pareamento pendente."
 
@@ -252,12 +275,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Enviar um pair_request ao daemon por TCP."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Atualiza o tether, ou mostra o comando que faz isso quando outra ferramenta "
+"gerencia esta build."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Remove o tether, ou mostra o comando que faz isso quando outra ferramenta "
+"gerencia esta build."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - CLI complementar para Wayland"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Opções:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Comandos:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Qualquer opção --bt-<nome>, como subcomando."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -700,6 +747,168 @@ msgstr "Enviado para %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "A mensagem não foi enviada."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Não foi possível ler o estado do daemon.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Versão"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Daemon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "em execução"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Área de transferência"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "sincronizando"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "desligado, nenhuma sessão Wayland nesta máquina"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "anunciando"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "indisponível"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Dispositivos pareados"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Pedidos pendentes"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Conectados agora"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "pareado"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "não pareado"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Recebidos recentemente:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Execute 'tether pending' para ver o que aguarda aceitação.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Nenhum pedido de pareamento aguardando.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Aceite um com: tether accept <impressão digital>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"O Tether não o ativa por você. Para iniciar o daemon agora e a cada login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Em um servidor do qual você sai, mantenha também a sessão de usuário viva:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Nenhum serviço de usuário tetherd estava instalado para este usuário.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s removido\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Execute 'systemctl --user daemon-reload' para esquecê-lo.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "Não foi possível executar {}: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Remover esta build não cabe ao tether. Execute:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Atualizar esta build não cabe ao tether. Execute:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2198,7 +2407,9 @@ msgstr "Bloquear a sessão quando o iPhone sair do alcance"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Bloqueia cerca de meio minuto após o enlace expirar. Desligar o Bluetooth no iPhone não bloqueia, e suspender esta máquina também não."
+msgstr ""
+"Bloqueia cerca de meio minuto após o enlace expirar. Desligar o Bluetooth no "
+"iPhone não bloqueia, e suspender esta máquina também não."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -239,6 +239,30 @@ msgstr ""
 "для переносимых сборок; пакеты дистрибутива устанавливают его сами."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Записывает пользовательскую службу systemd tetherd для этого пользователя и "
+"показывает, как её включить. Нужно только для переносимых сборок; пакеты "
+"дистрибутива устанавливают её сами."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Удаляет пользовательскую службу systemd tetherd, установленную этим "
+"пользователем."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+"Показывает, чем занят демон: устройства, соединения и последние передачи."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Показывает запросы сопряжения по Wi-Fi, ожидающие подтверждения."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Принять ожидающий запрос на сопряжение локально."
 
@@ -251,12 +275,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Отправить pair_request демону по TCP."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Обновляет tether или показывает команду для этого, если сборкой управляет "
+"другой инструмент."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Удаляет tether или показывает команду для этого, если сборкой управляет "
+"другой инструмент."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether — вспомогательная утилита командной строки для Wayland"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Параметры:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Команды:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Любой флаг --bt-<имя> в виде подкоманды."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -704,6 +752,169 @@ msgstr "Отправлено в %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Сообщение не отправлено."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Не удалось прочитать состояние демона.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Версия"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Демон"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "работает"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Буфер обмена"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "синхронизируется"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "выключено, на этой машине нет сеанса Wayland"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "объявляется"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "недоступно"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Брандмауэр"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Сопряжённые устройства"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Ожидающие запросы"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Сейчас подключено"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "сопряжено"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "не сопряжено"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Недавно получено:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Запустите 'tether pending', чтобы увидеть, что ждёт подтверждения.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Запросов сопряжения нет.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Подтвердите один командой: tether accept <отпечаток>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether не включает её за вас. Чтобы запустить демон сейчас и при каждом "
+"входе:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"На сервере, из которого вы выходите, оставьте пользовательский сеанс "
+"работать:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr "Для этого пользователя служба tetherd не была установлена.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "Удалено: %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Запустите 'systemctl --user daemon-reload', чтобы systemd о ней забыл.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "Не удалось запустить {}: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Удаление этой сборки — не дело tether. Запустите:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Обновление этой сборки — не дело tether. Запустите:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2197,7 +2408,10 @@ msgstr "Блокировать сеанс, когда iPhone выходит из
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Блокирует примерно через полминуты после истечения времени соединения. Выключение Bluetooth на iPhone не блокирует, как и переход этой машины в спящий режим."
+msgstr ""
+"Блокирует примерно через полминуты после истечения времени соединения. "
+"Выключение Bluetooth на iPhone не блокирует, как и переход этой машины в "
+"спящий режим."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -238,6 +238,29 @@ msgstr ""
 "bara för portabla byggen; distributionspaketen installerar den själva."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Skriver systemd-användartjänsten tetherd för den här användaren och visar "
+"hur den aktiveras. Behövs bara för portabla byggen; distributionspaketen "
+"installerar den."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Tar bort systemd-användartjänsten tetherd som den här användaren "
+"installerade."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Visar vad demonen gör: enheter, anslutningar och senaste överföringar."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Listar Wi-Fi-parkopplingsförfrågningar som väntar på att accepteras."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Godkänn en väntande parkopplingsförfrågan lokalt."
 
@@ -250,12 +273,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Skicka en pair_request till demonen via TCP."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Uppdaterar tether, eller visar kommandot som gör det när ett annat verktyg "
+"äger bygget."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Tar bort tether, eller visar kommandot som gör det när ett annat verktyg "
+"äger bygget."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - Wayland-kompanjon för kommandoraden"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Flaggor:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Kommandon:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Vilken --bt-<namn>-flagga som helst, som underkommando."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -696,6 +743,168 @@ msgstr "Skickat till %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Meddelandet skickades inte."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Kunde inte läsa demonens tillstånd.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Version"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Demon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "kör"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Urklipp"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synkroniserar"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "av, ingen Wayland-session på den här maskinen"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "annonserar"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "otillgänglig"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Brandvägg"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Parkopplade enheter"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Väntande förfrågningar"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Anslutna nu"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "parkopplad"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "inte parkopplad"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Nyligen mottagna:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Kör 'tether pending' för att se vad som väntar på att accepteras.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Inga parkopplingsförfrågningar väntar.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Acceptera en med: tether accept <fingeravtryck>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether aktiverar den inte åt dig. Så här startar du demonen nu och vid varje "
+"inloggning:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"På en server du loggar ut från, håll även användarsessionen vid liv:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr "Ingen tetherd-användartjänst var installerad för den här användaren.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s borttagen\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Kör 'systemctl --user daemon-reload' för att glömma den.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "Kunde inte köra {}: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Att ta bort det här bygget är inte tethers sak. Kör:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Att uppdatera det här bygget är inte tethers sak. Kör:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2177,7 +2386,10 @@ msgstr "Lås sessionen när iPhonen hamnar utom räckhåll"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Låser ungefär en halv minut efter att länken gått ut. Att stänga av Bluetooth på iPhonen låser inte, och inte heller att försätta den här maskinen i vila."
+msgstr ""
+"Låser ungefär en halv minut efter att länken gått ut. Att stänga av "
+"Bluetooth på iPhonen låser inte, och inte heller att försätta den här "
+"maskinen i vila."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether 0.2.28\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -217,6 +217,24 @@ msgid ""
 msgstr ""
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr ""
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr ""
 
@@ -229,11 +247,31 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr ""
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr ""
 
 #: src/cli/main.cpp
 msgid "Options:"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
 msgstr ""
 
 #: src/cli/main.cpp
@@ -644,6 +682,146 @@ msgstr ""
 
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
 msgstr ""
 
 #: src/cli/main.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -238,6 +238,29 @@ msgstr ""
 "taşınabilir yapılar için gereklidir; dağıtım paketleri onu kendisi kurar."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Bu kullanıcı için tetherd systemd kullanıcı hizmetini yazar ve nasıl "
+"etkinleştirileceğini gösterir. Yalnızca taşınabilir yapılar için gerekir; "
+"dağıtım paketleri bunu kendisi kurar."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Bu kullanıcının kurduğu tetherd systemd kullanıcı hizmetini kaldırır."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+"Arka plan hizmetinin ne yaptığını gösterir: aygıtlar, bağlantılar ve son "
+"aktarımlar."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Kabul edilmeyi bekleyen Wi-Fi eşleştirme isteklerini listeler."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Bekleyen bir eşleşme isteğini yerel olarak kabul et."
 
@@ -250,12 +273,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Arka plan hizmetine TCP üzerinden bir pair_request gönder."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"tether'ı günceller ya da bu yapıyı başka bir araç yönetiyorsa bunu yapan "
+"komutu yazar."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"tether'ı kaldırır ya da bu yapıyı başka bir araç yönetiyorsa bunu yapan "
+"komutu yazar."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - Wayland için yardımcı komut satırı aracı"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Seçenekler:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Komutlar:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Herhangi bir --bt-<ad> seçeneği, alt komut olarak."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -697,6 +744,168 @@ msgstr "%s adresine gönderildi\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Mesaj gönderilmedi."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Arka plan hizmetinin durumu okunamadı.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Sürüm"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Arka plan hizmeti"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "çalışıyor"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Pano"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "eşitleniyor"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "kapalı, bu makinede Wayland oturumu yok"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "duyuruyor"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "kullanılamıyor"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Güvenlik duvarı"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Eşleştirilmiş aygıtlar"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Bekleyen istekler"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Şu anda bağlı"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "eşleştirildi"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "eşleştirilmedi"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Son alınanlar:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Neyin kabul edilmeyi beklediğini görmek için 'tether pending' çalıştırın.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Bekleyen eşleştirme isteği yok.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Birini şununla kabul edin: tether accept <parmak izi>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether bunu sizin yerinize etkinleştirmez. Hizmeti şimdi ve her oturum "
+"açışta başlatmak için:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Oturumu kapattığınız bir sunucuda kullanıcı oturumunu da açık tutun:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr "Bu kullanıcı için kurulu bir tetherd kullanıcı hizmeti yoktu.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "%s kaldırıldı\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Unutulması için 'systemctl --user daemon-reload' çalıştırın.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "{} çalıştırılamadı: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Bu yapıyı kaldırmak tether'ın işi değil. Şunu çalıştırın:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Bu yapıyı güncellemek tether'ın işi değil. Şunu çalıştırın:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2174,7 +2383,10 @@ msgstr "iPhone menzil dışına çıkınca oturumu kilitle"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Bağlantı zaman aşımına uğradıktan yaklaşık yarım dakika sonra kilitler. iPhone'da Bluetooth'u kapatmak kilitlemez, bu makineyi uyku moduna almak da kilitlemez."
+msgstr ""
+"Bağlantı zaman aşımına uğradıktan yaklaşık yarım dakika sonra kilitler. "
+"iPhone'da Bluetooth'u kapatmak kilitlemez, bu makineyi uyku moduna almak da "
+"kilitlemez."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -240,6 +240,29 @@ msgstr ""
 "переносних збірок; пакунки дистрибутива встановлюють його самі."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"Записує користувацьку службу systemd tetherd для цього користувача й "
+"показує, як її увімкнути. Потрібно лише для переносних збірок; пакунки "
+"дистрибутива встановлюють її самі."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+"Вилучає користувацьку службу systemd tetherd, яку встановив цей користувач."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+"Показує, чим зайнятий демон: пристрої, з'єднання та останні передавання."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Перелічує запити на пару через Wi-Fi, які чекають на підтвердження."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Прийняти локально запит на створення пари, що очікує."
 
@@ -252,12 +275,36 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "Надіслати pair_request демону через TCP."
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Оновлює tether або показує команду для цього, якщо збіркою керує інший "
+"інструмент."
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr ""
+"Вилучає tether або показує команду для цього, якщо збіркою керує інший "
+"інструмент."
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether — допоміжна утиліта командного рядка для Wayland"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "Параметри:"
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Команди:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Будь-який прапорець --bt-<назва> як підкоманда."
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -704,6 +751,168 @@ msgstr "Надіслано до %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Повідомлення не надіслано."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "Не вдалося прочитати стан демона.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Версія"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Демон"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "працює"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Буфер обміну"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "синхронізується"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "вимкнено, на цій машині немає сеансу Wayland"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "оголошується"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "недоступно"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Брандмауер"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Пов'язані пристрої"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Запити в очікуванні"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Зараз під'єднано"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "пов'язано"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "не пов'язано"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Нещодавно отримано:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Запустіть 'tether pending', щоб побачити, що чекає на підтвердження.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "Запитів на пару немає.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Підтвердьте один командою: tether accept <відбиток>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether не вмикає її замість вас. Щоб запустити демон зараз і за кожного "
+"входу:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"На сервері, з якого ви виходите, тримайте користувацький сеанс живим:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr "Для цього користувача службу tetherd не було встановлено.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "Вилучено: %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Запустіть 'systemctl --user daemon-reload', щоб systemd про неї забув.\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "Не вдалося запустити {}: {}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Вилучення цієї збірки — не справа tether. Запустіть:\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"Оновлення цієї збірки — не справа tether. Запустіть:\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2195,7 +2404,9 @@ msgstr "Блокувати сеанс, коли iPhone виходить із з�
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "Блокує приблизно за півхвилини після того, як з'єднання завершиться за часом. Вимкнення Bluetooth на iPhone не блокує, як і присипляння цієї машини."
+msgstr ""
+"Блокує приблизно за півхвилини після того, як з'єднання завершиться за "
+"часом. Вимкнення Bluetooth на iPhone не блокує, як і присипляння цієї машини."
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-08 22:55-0700\n"
+"POT-Creation-Date: 2026-09-09 11:11+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -227,6 +227,26 @@ msgstr ""
 "root，且从不启用它。仅便携式构建需要；发行版软件包会自行安装。"
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+"为该用户写入 tetherd 的 systemd 用户服务，并说明如何启用。仅便携版需要；发行"
+"版软件包会自行安装。"
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "移除该用户安装的 tetherd systemd 用户服务。"
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "显示守护进程的状况：设备、连接和最近的传输。"
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "列出等待接受的 Wi-Fi 配对请求。"
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "在本地接受待处理的配对请求。"
 
@@ -239,12 +259,32 @@ msgid "Send a pair_request over TCP to the daemon."
 msgstr "通过 TCP 向守护进程发送 pair_request。"
 
 #: src/cli/main.cpp
+msgid ""
+"Update tether, or print the command that does, when another tool owns this "
+"build."
+msgstr "更新 tether；若该构建由其他工具管理，则打印相应的命令。"
+
+#: src/cli/main.cpp
+msgid ""
+"Remove tether, or print the command that does, when another tool owns this "
+"build."
+msgstr "移除 tether；若该构建由其他工具管理，则打印相应的命令。"
+
+#: src/cli/main.cpp
 msgid "tether - Wayland companion CLI"
 msgstr "tether - Wayland 配套命令行工具"
 
 #: src/cli/main.cpp
 msgid "Options:"
 msgstr "选项："
+
+#: src/cli/main.cpp
+msgid "Commands:"
+msgstr "命令："
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "任意 --bt-<名称> 选项，作为子命令。"
 
 #: src/cli/main.cpp
 msgid "Examples:"
@@ -674,6 +714,167 @@ msgstr "已发送至 %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "信息未发送。"
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr "无法读取守护进程的状态。\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "版本"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "守护进程"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "运行中"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "剪贴板"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "同步中"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "已关闭，本机没有 Wayland 会话"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "正在广播"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "不可用"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "防火墙"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "已配对设备"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "待处理请求"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "当前连接"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "已配对"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "未配对"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "最近收到："
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"运行 'tether pending' 查看有什么在等待接受。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr "没有等待处理的配对请求。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether accept <fingerprint>\n"
+msgstr ""
+"\n"
+"用这个接受其中一个：tether accept <指纹>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether 不会替你启用它。要现在以及每次登录时启动守护进程：\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"在你会退出登录的服务器上，还要让用户会话保持存活：\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr "该用户没有安装 tetherd 用户服务。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr "已移除 %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"运行 'systemctl --user daemon-reload' 让它被忘记。\n"
+
+#: src/cli/main.cpp
+#, c++-format
+msgid "Could not run {}: {}\n"
+msgstr "无法运行 {}：{}\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Removing this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"移除该构建不归 tether 管。请运行：\n"
+"\n"
+"%s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"Updating this build is not tether's to do. Run:\n"
+"\n"
+"%s\n"
+msgstr ""
+"更新该构建不归 tether 管。请运行：\n"
+"\n"
+"%s\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"
@@ -2100,7 +2301,8 @@ msgstr "当 iPhone 超出范围时锁定会话"
 msgid ""
 "Locks about half a minute after the link times out. Switching Bluetooth off "
 "on the iPhone does not lock, and neither does suspending this machine."
-msgstr "在链路超时约半分钟后锁定。在 iPhone 上关闭蓝牙不会锁定，将本机挂起也不会。"
+msgstr ""
+"在链路超时约半分钟后锁定。在 iPhone 上关闭蓝牙不会锁定，将本机挂起也不会。"
 
 #: src/gtk/settings_view.cpp
 msgid "SMS and iMessage conversations synced over Bluetooth."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,638 @@
+#!/bin/sh
+# Install, update and remove tether without a desktop in the way.
+#
+#   curl -fsSL https://raw.githubusercontent.com/zackb/tether/main/scripts/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/zackb/tether/main/scripts/install.sh | sh -s -- --method appimage
+#   sh scripts/install.sh update
+#   sh scripts/install.sh uninstall
+#
+# It picks the distro package when it can use one, and the AppImage otherwise,
+# unpacked into your home directory so it needs neither root nor FUSE. Nothing
+# is enabled or started unless you ask for it with --enable.
+set -eu
+
+REPO="zackb/tether"
+API="https://api.github.com/repos/$REPO/releases"
+RAW="https://raw.githubusercontent.com/$REPO/main/scripts/install.sh"
+
+COMMAND="install"
+METHOD="auto"
+VERSION=""
+PREFIX=""
+WANT_SERVICE=1
+WANT_ENABLE=0
+WANT_EXTENSIONS=1
+PURGE=0
+ASSUME_YES=0
+
+# ---------------------------------------------------------------- output
+
+log() { printf '==> %s\n' "$*"; }
+note() { printf '    %s\n' "$*"; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+tether installer
+
+Usage:
+  install.sh [install|update|uninstall|status|version|help] [options]
+
+Commands:
+  install      Install tether (the default).
+  update       Replace an install with the current release.
+  uninstall    Remove what this installer put on the machine.
+  status       Print what is installed and where.
+
+Options:
+  --method <auto|deb|rpm|appimage|source>
+                   How to install. Default: auto, which prefers the distro
+                   package when it can use one and the AppImage otherwise.
+  --version <tag>  A release to install, e.g. v0.2.28. Default: the latest.
+  --prefix <dir>   Where a portable install goes. Default: ~/.local
+  --service        Install the tetherd systemd user service (default).
+  --no-service     Do not install it.
+  --enable         Enable and start the service, and keep the user session
+                   alive after logout, which a server needs.
+  --headless       No desktop on this machine: prefer the AppImage, and skip
+                   the browser and mail extension hosts.
+  --no-extensions  Skip the browser and mail extension hosts.
+  --purge          With uninstall: delete pairings, messages and settings too.
+  -y, --yes        Do not stop to confirm anything, and let update reinstall
+                   the release that is already there.
+  -h, --help       This.
+EOF
+}
+
+# ---------------------------------------------------------------- environment
+
+need() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+require() {
+    need "$1" || die "$1 is needed and not installed."
+}
+
+# Downloads to stdout, curl or wget, whichever is here.
+fetch() {
+    if need curl; then
+        curl -fsSL "$1"
+    elif need wget; then
+        wget -qO- "$1"
+    else
+        die "neither curl nor wget is installed."
+    fi
+}
+
+fetch_to() {
+    if need curl; then
+        curl -fsSL -o "$2" "$1"
+    elif need wget; then
+        wget -qO "$2" "$1"
+    else
+        die "neither curl nor wget is installed."
+    fi
+}
+
+# Runs a command as root, or explains what to run when it cannot.
+as_root() {
+    if [ "$(id -u)" = "0" ]; then
+        "$@"
+    elif need sudo; then
+        sudo "$@"
+    else
+        die "this needs root and sudo is not installed. Run: $*"
+    fi
+}
+
+can_root() {
+    [ "$(id -u)" = "0" ] || need sudo
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64 | amd64) echo x86_64 ;;
+        aarch64 | arm64) echo aarch64 ;;
+        *) uname -m ;;
+    esac
+}
+
+# apt, dnf, pacman, zypper, or none.
+detect_pm() {
+    if need pacman; then
+        echo pacman
+    elif need apt-get; then
+        echo apt
+    elif need dnf; then
+        echo dnf
+    elif need zypper; then
+        echo zypper
+    else
+        echo none
+    fi
+}
+
+# ---------------------------------------------------------------- locations
+
+xdg_dir() {
+    # $1 is the XDG variable, $2 the fallback relative to $HOME.
+    eval "value=\${$1:-}"
+    case "$value" in
+        /*) printf '%s/tether\n' "$value" ;;
+        *) printf '%s/%s/tether\n' "$HOME" "$2" ;;
+    esac
+}
+
+DATA_DIR=""
+CONFIG_DIR=""
+STATE_DIR=""
+MANIFEST=""
+
+set_dirs() {
+    [ -n "${HOME:-}" ] || die "\$HOME is not set."
+    DATA_DIR=$(xdg_dir XDG_DATA_HOME .local/share)
+    CONFIG_DIR=$(xdg_dir XDG_CONFIG_HOME .config)
+    STATE_DIR=$(xdg_dir XDG_STATE_HOME .local/state)
+    MANIFEST="$DATA_DIR/install-manifest"
+    [ -n "$PREFIX" ] || PREFIX="$HOME/.local"
+}
+
+manifest_get() {
+    [ -f "$MANIFEST" ] || return 1
+    value=$(sed -n "s/^$1=//p" "$MANIFEST" | tail -n 1)
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+# ---------------------------------------------------------------- releases
+
+release_json() {
+    if [ -n "$VERSION" ]; then
+        fetch "$API/tags/$VERSION"
+    else
+        fetch "$API/latest"
+    fi
+}
+
+# The tag and the asset urls of the release we are installing, cached so the
+# API is asked once.
+RELEASE_TAG=""
+RELEASE_ASSETS=""
+
+load_release() {
+    [ -z "$RELEASE_TAG" ] || return 0
+
+    json=$(release_json) || die "could not reach the GitHub releases API."
+    RELEASE_TAG=$(printf '%s' "$json" | sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p' | head -n 1)
+    [ -n "$RELEASE_TAG" ] || die "no release found${VERSION:+ for $VERSION}."
+
+    # One url per line, which is all the asset picking below needs.
+    RELEASE_ASSETS=$(printf '%s' "$json" | tr ',' '\n' | sed -n 's/.*"browser_download_url" *: *"\([^"]*\)".*/\1/p')
+    [ -n "$RELEASE_ASSETS" ] || die "release $RELEASE_TAG has no downloads."
+}
+
+asset_url() {
+    printf '%s\n' "$RELEASE_ASSETS" | grep -i -- "$1" | head -n 1
+}
+
+# GitHub serves these over TLS and the releases are built in the project's own
+# CI. When a release publishes checksums, use them.
+verify_checksum() {
+    file="$1"
+    sums_url=$(asset_url 'SHA256SUMS' || true)
+    [ -n "$sums_url" ] || return 0
+    need sha256sum || return 0
+
+    sums="$TMP/SHA256SUMS"
+    fetch_to "$sums_url" "$sums" || return 0
+
+    want=$(grep -F "$(basename "$file")" "$sums" | awk '{print $1}' | head -n 1)
+    [ -n "$want" ] || return 0
+
+    got=$(sha256sum "$file" | awk '{print $1}')
+    [ "$want" = "$got" ] || die "checksum mismatch for $(basename "$file")."
+    note "checksum verified"
+}
+
+# ---------------------------------------------------------------- install
+
+TMP=""
+
+make_tmp() {
+    # update calls install, and a second trap would orphan the first directory.
+    [ -z "$TMP" ] || return 0
+    TMP=$(mktemp -d "${TMPDIR:-/tmp}/tether-install.XXXXXX")
+    trap 'rm -rf "$TMP"' EXIT INT TERM
+}
+
+choose_method() {
+    [ "$METHOD" = "auto" ] || return 0
+
+    arch=$(detect_arch)
+    if [ "$arch" != "x86_64" ]; then
+        note "no $arch release is published, building from source"
+        METHOD="source"
+        return 0
+    fi
+
+    case "$(detect_pm)" in
+        apt) METHOD="deb" ;;
+        dnf | zypper) METHOD="rpm" ;;
+        pacman)
+            # There is an AUR package, but building it is makepkg's job, not this
+            # script's, so say so and take the portable route.
+            note "on Arch, 'yay -S tether' is the packaged route; installing the AppImage"
+            METHOD="appimage"
+            ;;
+        *) METHOD="appimage" ;;
+    esac
+
+    # The packages pull GTK in. A machine with no desktop does not want that.
+    if [ "$METHOD" != "appimage" ] && ! can_root; then
+        note "no root here, so installing the AppImage into $PREFIX"
+        METHOD="appimage"
+    fi
+}
+
+install_package() {
+    load_release
+    case "$METHOD" in
+        deb) url=$(asset_url '\.deb$') ;;
+        rpm) url=$(asset_url '\.rpm$') ;;
+    esac
+    [ -n "$url" ] || die "release $RELEASE_TAG has no $METHOD package."
+
+    file="$TMP/$(basename "$url")"
+    log "downloading $(basename "$url")"
+    fetch_to "$url" "$file"
+    verify_checksum "$file"
+
+    log "installing it"
+    case "$(detect_pm)" in
+        apt) as_root apt-get install -y "$file" ;;
+        dnf) as_root dnf install -y "$file" ;;
+        zypper) as_root zypper --non-interactive install --allow-unsigned-rpm "$file" ;;
+        *) die "no package manager to install $METHOD with." ;;
+    esac
+
+    BIN_DIR="/usr/bin"
+}
+
+install_appimage() {
+    load_release
+    url=$(asset_url "$(detect_arch).AppImage\$")
+    [ -n "$url" ] || url=$(asset_url '\.AppImage$')
+    [ -n "$url" ] || die "release $RELEASE_TAG has no AppImage."
+
+    file="$TMP/$(basename "$url")"
+    log "downloading $(basename "$url")"
+    fetch_to "$url" "$file"
+    verify_checksum "$file"
+    chmod +x "$file"
+
+    BIN_DIR="$PREFIX/bin"
+    APP_DIR="$DATA_DIR/opt"
+    mkdir -p "$BIN_DIR" "$APP_DIR"
+
+    # An AppImage needs FUSE to mount itself, which a server usually has no
+    # reason to have installed, so unpack it and run the contents directly.
+    rm -rf "$APP_DIR/squashfs-root"
+    log "unpacking into $APP_DIR"
+    (cd "$APP_DIR" && "$file" --appimage-extract >/dev/null) ||
+        die "could not unpack the AppImage."
+
+    rm -rf "$APP_DIR/AppDir"
+    mv "$APP_DIR/squashfs-root" "$APP_DIR/AppDir"
+
+    write_wrapper "$BIN_DIR/tether" ''
+    write_wrapper "$BIN_DIR/tether-gtk" '' gui
+    write_wrapper "$BIN_DIR/tetherd" '--daemon'
+}
+
+# AppRun routes on its first argument: --daemon is the daemon, no argument at
+# all is the GTK app, and anything else is the CLI. So the CLI wrapper asks for
+# help when it is given nothing, rather than opening a window.
+write_wrapper() {
+    target="$1"
+    lead="$2"
+    kind="${3:-cli}"
+
+    # shellcheck disable=SC2016  # the wrapper's own variables, written literally
+    {
+        echo '#!/bin/sh'
+        echo '# Written by tether install.sh. Edits are lost on the next update.'
+        printf 'APPDIR="%s/AppDir"\n' "$APP_DIR"
+        if [ "$kind" = "cli" ] && [ -z "$lead" ]; then
+            echo '[ $# -gt 0 ] || set -- --help'
+        fi
+        if [ -n "$lead" ]; then
+            printf 'exec "$APPDIR/AppRun" %s "$@"\n' "$lead"
+        else
+            echo 'exec "$APPDIR/AppRun" "$@"'
+        fi
+    } >"$target"
+    chmod +x "$target"
+}
+
+install_source() {
+    require git
+    require cmake
+
+    src="$DATA_DIR/src"
+    log "building from source in $src"
+    if [ -d "$src/.git" ]; then
+        (cd "$src" && git fetch --quiet origin && git reset --quiet --hard origin/main)
+    else
+        rm -rf "$src"
+        git clone --quiet --depth 1 "https://github.com/$REPO.git" "$src"
+    fi
+
+    (cd "$src" && sh scripts/ci-deps.sh) || warn "could not install the build dependencies; carrying on"
+    (cd "$src" && make release) || die "the build failed."
+    (cd "$src" && as_root cmake --install build/release) || die "the install failed."
+
+    BIN_DIR="/usr/local/bin"
+    [ -x "$BIN_DIR/tether" ] || BIN_DIR="/usr/bin"
+    RELEASE_TAG="source"
+}
+
+# The copy 'tether update' runs. Prefer the one in this checkout, and fall back
+# to the network when the script was piped into a shell and has no file of its
+# own.
+save_installer() {
+    self="$0"
+    mkdir -p "$DATA_DIR"
+    if [ -f "$self" ] && [ "$self" != "sh" ] && [ "$self" != "-" ]; then
+        cp "$self" "$DATA_DIR/install.sh"
+    else
+        fetch_to "$RAW" "$DATA_DIR/install.sh" || return 0
+    fi
+    chmod +x "$DATA_DIR/install.sh"
+}
+
+write_manifest() {
+    mkdir -p "$DATA_DIR"
+    {
+        echo "# Written by tether install.sh. Uninstall reads it."
+        echo "method=$METHOD"
+        echo "version=$RELEASE_TAG"
+        echo "prefix=$PREFIX"
+        echo "bindir=$BIN_DIR"
+        echo "installed=$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    } >"$MANIFEST"
+}
+
+install_service() {
+    [ "$WANT_SERVICE" = "1" ] || return 0
+    need systemctl || {
+        note "no systemd here, so no service was installed"
+        return 0
+    }
+
+    unit="$CONFIG_DIR/systemd/user/tetherd.service"
+    case "$METHOD" in
+        deb | rpm | source)
+            # The package ships the unit in the system directory already.
+            note "the package installed the tetherd user service"
+            ;;
+        *)
+            # A release older than this script has no --install-service. That is
+            # not a reason to fail an install that otherwise worked.
+            if "$BIN_DIR/tether" --install-service >/dev/null 2>&1; then
+                # Point it at the wrapper rather than at whatever the CLI
+                # resolved: the wrapper is what survives the next update.
+                sed -i "s|^ExecStart=.*|ExecStart=$BIN_DIR/tetherd|" "$unit"
+                note "wrote $unit"
+            else
+                warn "this tether cannot write the user service; skipping it"
+                WANT_ENABLE=0
+            fi
+            ;;
+    esac
+
+    if [ "$WANT_ENABLE" = "1" ]; then
+        systemctl --user daemon-reload || true
+        systemctl --user enable --now tetherd.service ||
+            warn "could not enable tetherd.service; is this a systemd user session?"
+        if need loginctl; then
+            # Without lingering the daemon dies with the SSH session.
+            loginctl enable-linger "$(id -un)" >/dev/null 2>&1 ||
+                warn "could not enable lingering; the daemon will stop when you log out."
+        fi
+    fi
+}
+
+install_extensions() {
+    [ "$WANT_EXTENSIONS" = "1" ] || return 0
+    case "$METHOD" in
+        deb | rpm | source) return 0 ;; # installed system-wide by the package
+    esac
+    "$BIN_DIR/tether" --install-extension-host >/dev/null 2>&1 || true
+}
+
+check_path() {
+    case ":$PATH:" in
+        *":$BIN_DIR:"*) return 0 ;;
+    esac
+    warn "$BIN_DIR is not on your PATH. Add this to your shell profile:"
+    # shellcheck disable=SC2016  # $PATH is for the profile to expand, not us
+    printf '\n    export PATH="%s:$PATH"\n\n' "$BIN_DIR"
+}
+
+do_install() {
+    set_dirs
+    make_tmp
+    choose_method
+
+    case "$METHOD" in
+        deb | rpm) install_package ;;
+        appimage) install_appimage ;;
+        source) install_source ;;
+        *) die "unknown method: $METHOD" ;;
+    esac
+
+    save_installer
+    write_manifest
+    install_service
+    install_extensions
+    check_path
+
+    log "tether $RELEASE_TAG installed"
+    printf '\n'
+    note "tether status            what the daemon is doing"
+    note "tether pending           pairing requests waiting for you"
+    note "tether accept <hash>     accept one"
+    note "tether --help            everything else"
+    if [ "$WANT_SERVICE" = "1" ] && [ "$WANT_ENABLE" != "1" ]; then
+        printf '\n'
+        note "Start the daemon with:"
+        note "  systemctl --user enable --now tetherd.service"
+        note "  loginctl enable-linger \$USER      # on a server you log out of"
+    fi
+}
+
+# ---------------------------------------------------------------- update
+
+do_update() {
+    set_dirs
+    if installed=$(manifest_get method); then
+        METHOD="$installed"
+        PREFIX=$(manifest_get prefix || echo "$PREFIX")
+        was=$(manifest_get version || echo "unknown")
+    else
+        was="unknown"
+    fi
+
+    make_tmp
+    choose_method
+    if [ "$METHOD" != "source" ]; then
+        load_release
+        if [ "$was" = "$RELEASE_TAG" ]; then
+            log "tether $was is already the current release"
+            [ "$ASSUME_YES" = "1" ] || return 0
+        fi
+    fi
+
+    log "updating from $was"
+    do_install
+}
+
+# ---------------------------------------------------------------- uninstall
+
+do_uninstall() {
+    set_dirs
+    method=$(manifest_get method || echo "$METHOD")
+    bindir=$(manifest_get bindir || echo "$PREFIX/bin")
+
+    if need systemctl; then
+        systemctl --user disable --now tetherd.service >/dev/null 2>&1 || true
+    fi
+    rm -f "$CONFIG_DIR/systemd/user/tetherd.service"
+
+    case "$method" in
+        deb) as_root apt-get remove -y tether || true ;;
+        rpm)
+            if need dnf; then as_root dnf remove -y tether || true; else as_root zypper --non-interactive remove tether || true; fi
+            ;;
+        source)
+            src="$DATA_DIR/src"
+            [ ! -d "$src/build/release" ] ||
+                (cd "$src" && as_root cmake --build build/release --target uninstall >/dev/null 2>&1) || true
+            rm -rf "$src"
+            ;;
+        *)
+            rm -f "$bindir/tether" "$bindir/tether-gtk" "$bindir/tetherd"
+            rm -rf "$DATA_DIR/opt"
+            ;;
+    esac
+
+    # Native messaging manifests this user's install wrote.
+    for dir in "$HOME/.mozilla/native-messaging-hosts" \
+        "$HOME/.thunderbird/native-messaging-hosts" \
+        "$HOME/.betterbird/native-messaging-hosts" \
+        "$HOME/.config/chromium/NativeMessagingHosts" \
+        "$HOME/.config/google-chrome/NativeMessagingHosts"; do
+        rm -f "$dir/com.tether.extension.json"
+    done
+
+    rm -f "$MANIFEST" "$DATA_DIR/install.sh"
+
+    if [ "$PURGE" = "1" ]; then
+        log "removing pairings, messages and settings"
+        rm -rf "$DATA_DIR" "$CONFIG_DIR" "$STATE_DIR"
+    else
+        note "pairings and settings are still in $CONFIG_DIR (--purge removes them)"
+    fi
+
+    log "tether removed"
+}
+
+# ---------------------------------------------------------------- status
+
+do_status() {
+    set_dirs
+    if [ ! -f "$MANIFEST" ]; then
+        log "this installer has not installed tether on this machine"
+        need tether && note "there is a tether on PATH at $(command -v tether)"
+        return 0
+    fi
+
+    log "installed by this installer"
+    sed -n 's/^\([a-z]*\)=/  \1: /p' "$MANIFEST"
+    if need systemctl; then
+        state=$(systemctl --user is-active tetherd.service 2>/dev/null || true)
+        note "service: ${state:-not installed}"
+    fi
+}
+
+# ---------------------------------------------------------------- arguments
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        install | update | upgrade | uninstall | remove | status | version | help)
+            case "$1" in
+                upgrade) COMMAND="update" ;;
+                remove) COMMAND="uninstall" ;;
+                *) COMMAND="$1" ;;
+            esac
+            ;;
+        --method)
+            [ $# -ge 2 ] || die "--method needs a value."
+            METHOD="$2"
+            shift
+            ;;
+        --method=*) METHOD="${1#--method=}" ;;
+        --version)
+            [ $# -ge 2 ] || die "--version needs a value."
+            VERSION="$2"
+            shift
+            ;;
+        --version=*) VERSION="${1#--version=}" ;;
+        --prefix)
+            [ $# -ge 2 ] || die "--prefix needs a value."
+            PREFIX="$2"
+            shift
+            ;;
+        --prefix=*) PREFIX="${1#--prefix=}" ;;
+        --service) WANT_SERVICE=1 ;;
+        --no-service) WANT_SERVICE=0 ;;
+        --enable) WANT_ENABLE=1 ;;
+        --headless)
+            [ "$METHOD" != "auto" ] || METHOD="appimage"
+            WANT_EXTENSIONS=0
+            ;;
+        --no-extensions) WANT_EXTENSIONS=0 ;;
+        --purge) PURGE=1 ;;
+        -y | --yes) ASSUME_YES=1 ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *) die "unknown argument: $1. Run with --help." ;;
+    esac
+    shift
+done
+
+case "$METHOD" in
+    auto | deb | rpm | appimage | source) ;;
+    *) die "unknown method: $METHOD" ;;
+esac
+
+[ "$(uname -s)" = "Linux" ] || die "tether runs on Linux."
+
+case "$COMMAND" in
+    install) do_install ;;
+    update) do_update ;;
+    uninstall) do_uninstall ;;
+    status) do_status ;;
+    version)
+        set_dirs
+        manifest_get version || echo "not installed by this installer"
+        ;;
+    help) usage ;;
+esac

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(tether_cli
     main.cpp
+    verbs.cpp
 )
 
 target_link_libraries(tether_cli PRIVATE tether)

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1,5 +1,8 @@
+#include "verbs.hpp"
+
 #include <algorithm>
 #include <atomic>
+#include <cerrno>
 #include <charconv>
 #include <csignal>
 #include <cstring>
@@ -20,6 +23,8 @@
 #include <tether/i18n.hpp>
 #include <tether/log.hpp>
 #include <tether/packaging.hpp>
+#include <tether/paths.hpp>
+#include <tether/service.hpp>
 #include <tether/version.hpp>
 #include <thread>
 #include <unistd.h>
@@ -232,10 +237,34 @@ static const Opt kOptions[] = {
     {"--install-btclass-unit",
      N_("Write the tether-btclass@.service unit, which sets the Bluetooth adapter class iOS requires. Needs "
         "root, and never enables it. Needed only for portable builds; the distro packages install it.")},
+    {"--install-service",
+     N_("Write the tetherd systemd user service for this user, and print how to enable it. Needed only for "
+        "portable builds; the distro packages install it.")},
+    {"--uninstall-service", N_("Remove the tetherd systemd user service this user installed.")},
+    {"--status", N_("Show what the daemon is doing: devices, links, and recent transfers.")},
+    {"--pending", N_("List Wi-Fi pairing requests waiting to be accepted.")},
     {"--accept <fingerprint>", N_("Accept a pending pairing request locally.")},
     {"--forget <fingerprint>", N_("Remove a Wi-Fi pairing and drop its session.")},
     {"--pair", N_("Send a pair_request over TCP to the daemon.")},
+    {"--self-update", N_("Update tether, or print the command that does, when another tool owns this build.")},
+    {"--uninstall", N_("Remove tether, or print the command that does, when another tool owns this build.")},
 };
+
+// The option row a subcommand stands for, matched on the long flag so the two
+// lists cannot drift apart.
+static const char* describe_flag(const std::string& flag) {
+    for (const auto& opt : kOptions) {
+        const std::string flags = opt.flags;
+        const auto at = flags.find(flag);
+        if (at == std::string::npos)
+            continue;
+        // "--pair" must not match "--bt-pair", nor "--status" "--bt-status".
+        const auto end = at + flag.size();
+        if ((at == 0 || flags[at - 1] == ' ') && (end == flags.size() || flags[end] == ' ' || flags[end] == ','))
+            return opt.desc;
+    }
+    return "";
+}
 
 void print_help() {
     fprintf(stdout, "%s\n\n%s\n", _("tether - Wayland companion CLI"), _("Options:"));
@@ -255,16 +284,45 @@ void print_help() {
         }
     }
 
+    fprintf(stdout, "\n%s\n", _("Commands:"));
+
+    size_t verb_col = 0;
+    for (size_t i = 0; i < tether::cli::kVerbCount; ++i)
+        verb_col = std::max(verb_col, tether::display_width(tether::cli::kVerbs[i].usage));
+
+    const size_t verb_desc_width = total > verb_col + 8 ? total - verb_col - 4 : 40;
+    for (size_t i = 0; i < tether::cli::kVerbCount; ++i) {
+        const auto& verb = tether::cli::kVerbs[i];
+        const std::string pad(verb_col - tether::display_width(verb.usage), ' ');
+        // One description per capability: a subcommand borrows its flag's.
+        // gettext("") would hand back the catalog header, so ask only for text.
+        const char* desc = describe_flag(verb.flag);
+        auto lines = wrap(*desc ? _(desc) : "", verb_desc_width);
+        if (lines.empty())
+            lines.emplace_back();
+        for (size_t line = 0; line < lines.size(); ++line) {
+            const std::string prefix = line == 0 ? verb.usage + pad : std::string(verb_col, ' ');
+            fprintf(stdout, "  %s  %s\n", prefix.c_str(), lines[line].c_str());
+        }
+    }
+
     // Literal invocations: never translated.
     fprintf(stdout,
+            "  %-*s  %s\n",
+            static_cast<int>(verb_col),
+            "tether bt <name> ...",
+            _("Any --bt-<name> flag, as a subcommand."));
+
+    fprintf(stdout,
             "\n%s\n"
-            "  tether -g\n"
-            "  tether -g --host 127.0.0.1\n"
-            "  echo \"pipe\" | tether -s\n"
-            "  tether --discover\n"
-            "  tether --discover --timeout 5000\n"
-            "  tether -f ./report.pdf\n"
-            "  tether --accept 9a4f21...\n",
+            "  tether status\n"
+            "  tether paste\n"
+            "  tether paste --host 127.0.0.1\n"
+            "  echo \"pipe\" | tether copy\n"
+            "  tether discover --timeout 5000\n"
+            "  tether send ./report.pdf\n"
+            "  tether pending && tether accept 9a4f21...\n"
+            "  tether bt pair AA:BB:CC:DD:EE:FF\n",
             _("Examples:"));
 }
 
@@ -1020,8 +1078,163 @@ static int send_bt_message(tether::Client& client, const std::string& thread, co
     }
 }
 
+// The daemon answers one request at a time here, but be strict about it: parse
+// the first line only, so a stray broadcast cannot turn into a parse error.
+static nlohmann::json parse_first_line(const std::string& response) {
+    const auto newline = response.find('\n');
+    return nlohmann::json::parse(newline == std::string::npos ? response : response.substr(0, newline));
+}
+
+static nlohmann::json state_snapshot(tether::Client& client) {
+    return parse_first_line(client.send_and_wait("{\"command\":\"state_snapshot\"}\n"));
+}
+
+static int print_status(tether::Client& client) {
+    nlohmann::json snap;
+    try {
+        snap = state_snapshot(client);
+    } catch (const std::exception&) {
+        debug::log(ERR, _("Could not read the daemon's state.\n"));
+        return 1;
+    }
+
+    // Defaults rather than lookups: a daemon that predates a field should
+    // still give a readable status.
+    const auto paired = snap.value("paired_devices", nlohmann::json::array());
+    const auto pending = snap.value("pending_pairs", nlohmann::json::array());
+    const auto clients = snap.value("connected_clients", nlohmann::json::array());
+
+    std::vector<Field> fields;
+    fields.emplace_back(_("Version"), tether::get_version());
+    fields.emplace_back(_("Daemon"), _("running"));
+    fields.emplace_back(_("Clipboard"),
+                        snap.value("clipboard_available", false) ? _("syncing")
+                                                                 : _("off, no Wayland session on this machine"));
+    fields.emplace_back(_("mDNS"), snap.value("mdns_available", false) ? _("advertising") : _("unavailable"));
+    fields.emplace_back(_("Firewall"), yn(snap.value("firewall_active", false)));
+    fields.emplace_back(_("Paired devices"), std::to_string(paired.size()));
+    fields.emplace_back(_("Pending requests"), std::to_string(pending.size()));
+    fields.emplace_back(_("Connected now"), std::to_string(clients.size()));
+    print_fields(fields);
+
+    for (const auto& c : clients) {
+        fprintf(stdout,
+                "\n  %s  %s  %s\n",
+                c.value("device_name", "?").c_str(),
+                c.value("address", "?").c_str(),
+                c.value("paired", false) ? _("paired") : _("unpaired"));
+    }
+
+    const auto files = snap.value("recent_received_files", nlohmann::json::array());
+    if (!files.empty()) {
+        fprintf(stdout, "\n%s\n", _("Recently received:"));
+        for (const auto& f : files)
+            fprintf(stdout, "  %s\n", f.value("path", "").c_str());
+    }
+
+    // The count is already a field above, so this only says what to do about it.
+    if (!pending.empty())
+        fprintf(stdout, _("\nRun 'tether pending' to see what is waiting to be accepted.\n"));
+
+    return 0;
+}
+
+// The headless half of pairing: with no GTK app to show the prompt, this is how
+// a request is seen before 'tether accept' takes it.
+static int print_pending(tether::Client& client) {
+    nlohmann::json snap;
+    try {
+        snap = state_snapshot(client);
+    } catch (const std::exception&) {
+        debug::log(ERR, _("Could not read the daemon's state.\n"));
+        return 1;
+    }
+
+    const auto pending = snap.value("pending_pairs", nlohmann::json::array());
+    if (pending.empty()) {
+        fprintf(stdout, _("No pairing requests are waiting.\n"));
+        return 0;
+    }
+
+    for (const auto& item : pending)
+        fprintf(stdout, "  %-20s  %s\n", item.value("device_name", "?").c_str(), item.value("fingerprint", "").c_str());
+
+    fprintf(stdout, _("\nAccept one with: tether accept <fingerprint>\n"));
+    return 0;
+}
+
+static int install_service() {
+    const auto result = tether::install_tetherd_service();
+
+    for (const auto& err : result.errors)
+        debug::log(ERR, "{}\n", err);
+    if (!result.errors.empty())
+        return 1;
+
+    fprintf(stdout, _("Installed %s\n"), result.path.c_str());
+    fprintf(stdout,
+            _("\nTether does not enable it for you. To start the daemon now and on every login:\n\n"
+              "systemctl --user daemon-reload\n"
+              "systemctl --user enable --now tetherd.service\n\n"
+              "On a server you log out of, keep the user session alive too:\n\n"
+              "loginctl enable-linger $USER\n"));
+    return 0;
+}
+
+static int uninstall_service() {
+    const auto result = tether::uninstall_tetherd_service();
+
+    for (const auto& err : result.errors)
+        debug::log(ERR, "{}\n", err);
+    if (!result.errors.empty())
+        return 1;
+
+    if (!result.changed) {
+        fprintf(stdout, _("No tetherd user service was installed for this user.\n"));
+        return 0;
+    }
+
+    fprintf(stdout, _("Removed %s\n"), result.path.c_str());
+    fprintf(stdout, _("\nRun 'systemctl --user daemon-reload' to forget it.\n"));
+    return 0;
+}
+
+// Runs the installer, which is the only thing that knows what it put where.
+static int run_installer(const std::string& installer, const char* verb) {
+    execl("/bin/sh", "sh", installer.c_str(), verb, nullptr);
+    debug::log(ERR, _("Could not run {}: {}\n"), installer, std::strerror(errno));
+    return 1;
+}
+
+static int self_manage(bool remove) {
+    const auto flavor = tether::running_flavor();
+    const auto installer = tether::installer_path(tether::paths::data_dir());
+    const auto plan = remove ? tether::remove_plan(flavor, tether::detect_package_manager(), installer)
+                             : tether::update_plan(flavor, tether::detect_package_manager(), installer);
+
+    if (plan.runnable)
+        return run_installer(installer.string(), remove ? "uninstall" : "update");
+
+    // Something else owns this build: a package manager, flatpak, or a source
+    // tree. Say what to run rather than doing it behind that tool's back.
+    fprintf(stdout,
+            remove ? _("Removing this build is not tether's to do. Run:\n\n%s\n")
+                   : _("Updating this build is not tether's to do. Run:\n\n%s\n"),
+            plan.command.c_str());
+    return 0;
+}
+
 int main(int argc, char* argv[]) {
     tether::init_locale();
+
+    // Subcommands are rewritten into the flags below, so there is one parser.
+    const std::vector<std::string> expanded = tether::cli::expand_verbs({argv, argv + argc});
+    std::vector<char*> rewritten;
+    rewritten.reserve(expanded.size());
+    for (const auto& arg : expanded)
+        rewritten.push_back(const_cast<char*>(arg.c_str()));
+    argc = static_cast<int>(rewritten.size());
+    argv = rewritten.data();
 
     if (argc < 2) {
         print_help();
@@ -1051,6 +1264,18 @@ int main(int argc, char* argv[]) {
             action = "install_extension_host";
         } else if (arg == "--install-btclass-unit") {
             action = "install_btclass_unit";
+        } else if (arg == "--install-service") {
+            action = "install_service";
+        } else if (arg == "--uninstall-service") {
+            action = "uninstall_service";
+        } else if (arg == "--self-update") {
+            action = "self_update";
+        } else if (arg == "--uninstall") {
+            action = "uninstall";
+        } else if (arg == "--status") {
+            action = "status";
+        } else if (arg == "--pending") {
+            action = "pending";
         } else if (arg == "--bt-setup") {
             action = "bt_setup";
         } else if (arg == "--bt-status") {
@@ -1196,6 +1421,18 @@ int main(int argc, char* argv[]) {
     if (action == "install_btclass_unit")
         return install_btclass_unit();
 
+    if (action == "install_service")
+        return install_service();
+
+    if (action == "uninstall_service")
+        return uninstall_service();
+
+    if (action == "self_update")
+        return self_manage(false);
+
+    if (action == "uninstall")
+        return self_manage(true);
+
     tether::Client client;
 
     // Fast-path local operations that don't need active daemon connection fundamentally
@@ -1250,6 +1487,12 @@ int main(int argc, char* argv[]) {
               "broken?\n"));
         return 1;
     }
+
+    if (action == "status")
+        return print_status(client);
+
+    if (action == "pending")
+        return print_pending(client);
 
     std::string err;
     if (action == "accept") {

--- a/src/cli/verbs.cpp
+++ b/src/cli/verbs.cpp
@@ -1,0 +1,55 @@
+#include "verbs.hpp"
+
+namespace tether::cli {
+
+    const Verb kVerbs[] = {
+        {"status", "--status", "tether status"},
+        {"devices", "--list-devices", "tether devices"},
+        {"pending", "--pending", "tether pending"},
+        {"accept", "--accept", "tether accept <fingerprint>"},
+        {"forget", "--forget", "tether forget <fingerprint>"},
+        {"pair", "--pair", "tether pair --host <ip>"},
+        {"discover", "--discover", "tether discover"},
+        {"send", "--send-file", "tether send <path>"},
+        {"copy", "--set-clipboard", "tether copy [text]"},
+        {"paste", "--get-clipboard", "tether paste"},
+        {"service", "--install-service", "tether service"},
+        {"update", "--self-update", "tether update"},
+        {"uninstall", "--uninstall", "tether uninstall"},
+        {"remove", "--uninstall", "tether remove"},
+        {"version", "--version", "tether version"},
+        {"help", "--help", "tether help"},
+    };
+
+    const size_t kVerbCount = sizeof(kVerbs) / sizeof(kVerbs[0]);
+
+    std::vector<std::string> expand_verbs(const std::vector<std::string>& args) {
+        if (args.size() < 2 || args[1].empty() || args[1][0] == '-')
+            return args;
+
+        std::vector<std::string> out;
+        out.reserve(args.size());
+        out.push_back(args[0]);
+
+        // 'tether bt <name> ...' is '--bt-<name> ...', so every Bluetooth flag
+        // has a subcommand without a table to keep in step with it.
+        if (args[1] == "bt") {
+            if (args.size() < 3 || args[2].empty() || args[2][0] == '-')
+                return args;
+            out.push_back("--bt-" + args[2]);
+            out.insert(out.end(), args.begin() + 3, args.end());
+            return out;
+        }
+
+        for (size_t i = 0; i < kVerbCount; ++i) {
+            if (args[1] != kVerbs[i].verb)
+                continue;
+            out.push_back(kVerbs[i].flag);
+            out.insert(out.end(), args.begin() + 2, args.end());
+            return out;
+        }
+
+        return args;
+    }
+
+} // namespace tether::cli

--- a/src/cli/verbs.hpp
+++ b/src/cli/verbs.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace tether::cli {
+
+    struct Verb {
+        const char* verb;
+        const char* flag;  // what it stands for, and where its help text comes from
+        const char* usage; // how it reads on the command line
+    };
+
+    // Subcommands, for people who reach for 'tether status' before 'tether
+    // --status'. Every flag keeps working exactly as it did.
+    extern const Verb kVerbs[];
+    extern const size_t kVerbCount;
+
+    // Rewrites a leading subcommand into the flag it stands for, and 'bt <name>'
+    // into '--bt-<name>'. Anything else, flags included, is passed through
+    // untouched. args[0] is the program name.
+    std::vector<std::string> expand_verbs(const std::vector<std::string>& args);
+
+} // namespace tether::cli

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(tether STATIC
     src/secret_store.cpp
     src/client.cpp
     src/extension_host.cpp
+    src/service.cpp
     src/discovery.cpp
     src/mpris.cpp
     src/bluetooth/objects.cpp

--- a/src/core/include/tether/packaging.hpp.in
+++ b/src/core/include/tether/packaging.hpp.in
@@ -4,6 +4,7 @@
 // (AppImage) cannot, so they are embedded here and written out at runtime.
 namespace tether::packaging {
 
+    inline constexpr const char* TETHERD_UNIT = R"TETHER(@TETHERD_UNIT@)TETHER";
     inline constexpr const char* BTCLASS_UNIT = R"TETHER(@BTCLASS_UNIT@)TETHER";
     inline constexpr const char* NATIVE_HOST_MANIFEST_CHROME = R"TETHER(@CHROME_MANIFEST@)TETHER";
     inline constexpr const char* NATIVE_HOST_MANIFEST_MOZILLA = R"TETHER(@MOZILLA_MANIFEST@)TETHER";

--- a/src/core/include/tether/service.hpp
+++ b/src/core/include/tether/service.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace tether {
+
+    // How this build reached the machine. It decides who owns updating and
+    // removing it: a distro package belongs to the package manager, a portable
+    // build to whoever unpacked it.
+    enum class Flavor {
+        Distro,   // .deb, .rpm, pacman, or make install
+        AppImage, // running out of an AppImage mount
+        Flatpak,  // running inside the flatpak sandbox
+        Unknown,
+    };
+
+    enum class PackageManager { Apt, Dnf, Pacman, Zypper, None };
+
+    // The application id flatpak uses in the running sandbox, empty outside one.
+    std::string flatpak_app_id();
+
+    // Absolute path of a program on PATH, empty when it is not there.
+    std::string which_program(const std::string& name);
+
+    Flavor running_flavor();
+    PackageManager detect_package_manager();
+
+    // ExecStart= line for the systemd unit: an absolute program and its
+    // arguments, pointed at the tetherd this build would start. systemd runs no
+    // shell, so this is never quoted for one.
+    std::string tetherd_exec_command();
+
+    // The user unit with its ExecStart filled in.
+    std::string render_tetherd_unit(const std::string& exec_command);
+
+    struct ServiceInstall {
+        std::string path; // unit written, or the one that was removed
+        std::vector<std::string> errors;
+        bool changed = false; // a file was written or removed
+    };
+
+    // Writes the tetherd user unit into $XDG_CONFIG_HOME/systemd/user. Needed by
+    // portable builds, which cannot write the system directory the distro
+    // packages install into. Never enables or starts anything: that is the
+    // user's call, and 'tether --install-service' prints the commands.
+    ServiceInstall install_tetherd_service(const std::filesystem::path& config_dir);
+    ServiceInstall install_tetherd_service();
+
+    // Removes the unit this user's install wrote, if it is there.
+    ServiceInstall uninstall_tetherd_service(const std::filesystem::path& config_dir);
+    ServiceInstall uninstall_tetherd_service();
+
+    // What updating or removing this build takes.
+    struct Plan {
+        bool runnable = false; // tether can carry it out itself
+        std::string command;   // the command that does it
+    };
+
+    // scripts/install.sh keeps a copy of itself here when it installs tether,
+    // which is what makes 'tether --self-update' possible.
+    std::filesystem::path installer_path(const std::filesystem::path& data_dir);
+
+    // installer is the path install.sh left behind, or empty when it never ran.
+    Plan update_plan(Flavor flavor, PackageManager pm, const std::filesystem::path& installer);
+    Plan remove_plan(Flavor flavor, PackageManager pm, const std::filesystem::path& installer);
+
+} // namespace tether

--- a/src/core/src/service.cpp
+++ b/src/core/src/service.cpp
@@ -1,0 +1,263 @@
+#include "tether/service.hpp"
+#include "tether/packaging.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <unistd.h>
+
+namespace tether {
+
+    namespace {
+
+        namespace fs = std::filesystem;
+
+        // The token render_tetherd_unit() replaces. CMake leaves it in the
+        // embedded copy of the unit; the copy the distro packages install has
+        // the real path already.
+        constexpr const char* EXEC_TOKEN = "__TETHERD_EXEC__";
+
+        constexpr const char* INSTALLER_URL = "https://raw.githubusercontent.com/zackb/tether/main/scripts/install.sh";
+
+        std::string curl_installer(const char* verb) {
+            return std::string("curl -fsSL ") + INSTALLER_URL + " | sh -s -- " + verb;
+        }
+
+        bool write_file(const fs::path& path, const std::string& content, std::string& err) {
+            std::error_code ec;
+            fs::create_directories(path.parent_path(), ec);
+            if (ec) {
+                err = path.parent_path().string() + ": " + ec.message();
+                return false;
+            }
+
+            std::ofstream out(path, std::ios::trunc);
+            if (!out.is_open()) {
+                err = path.string() + ": cannot open for writing";
+                return false;
+            }
+            out << content;
+            if (!out) {
+                err = path.string() + ": write failed";
+                return false;
+            }
+            return true;
+        }
+
+    } // namespace
+
+    std::string flatpak_app_id() {
+        std::ifstream in("/.flatpak-info");
+        if (!in.is_open())
+            return {};
+        for (std::string line; std::getline(in, line);) {
+            if (line.rfind("name=", 0) == 0)
+                return line.substr(5);
+        }
+        return {};
+    }
+
+    std::string which_program(const std::string& name) {
+        const char* path = std::getenv("PATH");
+        if (!path || !*path)
+            path = "/usr/local/bin:/usr/bin:/bin";
+
+        std::istringstream parts(path);
+        std::string dir;
+        std::error_code ec;
+        while (std::getline(parts, dir, ':')) {
+            if (dir.empty())
+                continue;
+            const fs::path candidate = fs::path(dir) / name;
+            if (fs::is_regular_file(candidate, ec) && ::access(candidate.c_str(), X_OK) == 0)
+                return candidate.string();
+        }
+        return {};
+    }
+
+    Flavor running_flavor() {
+        if (const char* appimage = std::getenv("APPIMAGE"); appimage && *appimage)
+            return Flavor::AppImage;
+
+        if (!flatpak_app_id().empty())
+            return Flavor::Flatpak;
+
+        std::error_code ec;
+        const std::string self = fs::read_symlink("/proc/self/exe", ec).string();
+        if (!ec && (self.rfind("/usr/", 0) == 0 || self.rfind("/opt/", 0) == 0))
+            return Flavor::Distro;
+
+        return Flavor::Unknown;
+    }
+
+    PackageManager detect_package_manager() {
+        // Order matters only where two are installed: pacman first, because on
+        // Arch tether comes from the AUR and apt is never there.
+        if (!which_program("pacman").empty())
+            return PackageManager::Pacman;
+        if (!which_program("apt-get").empty())
+            return PackageManager::Apt;
+        if (!which_program("dnf").empty())
+            return PackageManager::Dnf;
+        if (!which_program("zypper").empty())
+            return PackageManager::Zypper;
+        return PackageManager::None;
+    }
+
+    std::string tetherd_exec_command() {
+        if (const char* appimage = std::getenv("APPIMAGE"); appimage && *appimage)
+            return std::string(appimage) + " --daemon";
+
+        if (const std::string app_id = flatpak_app_id(); !app_id.empty()) {
+            const std::string flatpak = which_program("flatpak");
+            return (flatpak.empty() ? "/usr/bin/flatpak" : flatpak) + " run --command=tetherd " + app_id;
+        }
+
+        std::error_code ec;
+        const fs::path self = fs::read_symlink("/proc/self/exe", ec);
+        if (!ec) {
+            const fs::path sibling = self.parent_path() / "tetherd";
+            if (fs::is_regular_file(sibling, ec))
+                return sibling.string();
+        }
+
+        const std::string found = which_program("tetherd");
+        return found.empty() ? "/usr/bin/tetherd" : found;
+    }
+
+    std::string render_tetherd_unit(const std::string& exec_command) {
+        std::string unit = packaging::TETHERD_UNIT;
+        const auto at = unit.find(EXEC_TOKEN);
+        if (at != std::string::npos)
+            unit.replace(at, std::strlen(EXEC_TOKEN), exec_command);
+        return unit;
+    }
+
+    ServiceInstall install_tetherd_service(const fs::path& config_dir) {
+        ServiceInstall result;
+        if (config_dir.empty()) {
+            result.errors.push_back("No config directory to write the unit into.");
+            return result;
+        }
+
+        const fs::path unit = config_dir / "systemd" / "user" / "tetherd.service";
+        result.path = unit.string();
+
+        std::string err;
+        if (!write_file(unit, render_tetherd_unit(tetherd_exec_command()), err)) {
+            result.errors.push_back(err);
+            return result;
+        }
+
+        result.changed = true;
+        return result;
+    }
+
+    ServiceInstall install_tetherd_service() {
+        const char* config_home = std::getenv("XDG_CONFIG_HOME");
+        if (config_home && *config_home == '/')
+            return install_tetherd_service(fs::path(config_home));
+
+        const char* home = std::getenv("HOME");
+        if (!home || !*home) {
+            ServiceInstall result;
+            result.errors.push_back("No $HOME, so there is nowhere to write the unit.");
+            return result;
+        }
+        return install_tetherd_service(fs::path(home) / ".config");
+    }
+
+    ServiceInstall uninstall_tetherd_service(const fs::path& config_dir) {
+        ServiceInstall result;
+        if (config_dir.empty())
+            return result;
+
+        const fs::path unit = config_dir / "systemd" / "user" / "tetherd.service";
+        result.path = unit.string();
+
+        std::error_code ec;
+        if (!fs::exists(unit, ec))
+            return result;
+
+        if (!fs::remove(unit, ec)) {
+            result.errors.push_back(unit.string() + ": " + ec.message());
+            return result;
+        }
+
+        result.changed = true;
+        return result;
+    }
+
+    ServiceInstall uninstall_tetherd_service() {
+        const char* config_home = std::getenv("XDG_CONFIG_HOME");
+        if (config_home && *config_home == '/')
+            return uninstall_tetherd_service(fs::path(config_home));
+
+        const char* home = std::getenv("HOME");
+        if (!home || !*home)
+            return {};
+        return uninstall_tetherd_service(fs::path(home) / ".config");
+    }
+
+    fs::path installer_path(const fs::path& data_dir) {
+        return data_dir.empty() ? fs::path{} : data_dir / "install.sh";
+    }
+
+    Plan update_plan(Flavor flavor, PackageManager pm, const fs::path& installer) {
+        std::error_code ec;
+        if (!installer.empty() && fs::is_regular_file(installer, ec)) {
+            return {true, installer.string() + " update"};
+        }
+
+        switch (flavor) {
+        case Flavor::Flatpak: {
+            const std::string app_id = flatpak_app_id();
+            return {false, "flatpak update " + (app_id.empty() ? std::string("com.tether.desktop") : app_id)};
+        }
+        case Flavor::Distro:
+            if (pm == PackageManager::Pacman)
+                return {false, "yay -Syu tether"};
+            return {false, curl_installer("update")};
+        case Flavor::AppImage:
+        case Flavor::Unknown:
+            break;
+        }
+
+        return {false, curl_installer("update")};
+    }
+
+    Plan remove_plan(Flavor flavor, PackageManager pm, const fs::path& installer) {
+        std::error_code ec;
+        if (!installer.empty() && fs::is_regular_file(installer, ec)) {
+            return {true, installer.string() + " uninstall"};
+        }
+
+        switch (flavor) {
+        case Flavor::Flatpak: {
+            const std::string app_id = flatpak_app_id();
+            return {false, "flatpak uninstall " + (app_id.empty() ? std::string("com.tether.desktop") : app_id)};
+        }
+        case Flavor::Distro:
+            switch (pm) {
+            case PackageManager::Pacman:
+                return {false, "sudo pacman -Rns tether"};
+            case PackageManager::Apt:
+                return {false, "sudo apt-get remove tether"};
+            case PackageManager::Dnf:
+                return {false, "sudo dnf remove tether"};
+            case PackageManager::Zypper:
+                return {false, "sudo zypper remove tether"};
+            case PackageManager::None:
+                break;
+            }
+            return {false, "sudo cmake --build build/release --target uninstall"};
+        case Flavor::AppImage:
+        case Flavor::Unknown:
+            break;
+        }
+
+        return {false, curl_installer("uninstall")};
+    }
+
+} // namespace tether

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,10 @@ add_executable(tether_test
     test_otp.cpp
     test_paths.cpp
     test_message_format.cpp
+    test_service.cpp
+    test_verbs.cpp
     ../src/gtk/message_format.cpp
+    ../src/cli/verbs.cpp
 )
 
 target_include_directories(tether_test PRIVATE

--- a/test/test_service.cpp
+++ b/test/test_service.cpp
@@ -1,0 +1,123 @@
+#include "scoped_env.hpp"
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <tether/service.hpp>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+    class ServiceTest : public ::testing::Test {
+    protected:
+        void SetUp() override { fs::create_directories(config_); }
+
+        void TearDown() override {
+            std::error_code ec;
+            fs::remove_all(root_, ec);
+        }
+
+        const fs::path root_ =
+            fs::temp_directory_path() / ("tether-service-" + std::to_string(::getpid()) + "-" +
+                                         ::testing::UnitTest::GetInstance()->current_test_info()->name());
+        const fs::path config_ = root_ / "config";
+        const fs::path unit_ = config_ / "systemd/user/tetherd.service";
+    };
+
+    std::string read(const fs::path& path) {
+        std::ifstream in(path);
+        return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+    }
+
+} // namespace
+
+TEST_F(ServiceTest, RenderTetherdUnitFillsInExecStart) {
+    const std::string unit = tether::render_tetherd_unit("/usr/bin/tetherd");
+
+    EXPECT_NE(unit.find("ExecStart=/usr/bin/tetherd"), std::string::npos) << unit;
+    EXPECT_EQ(unit.find("__TETHERD_EXEC__"), std::string::npos) << unit;
+    EXPECT_NE(unit.find("WantedBy=default.target"), std::string::npos) << unit;
+}
+
+TEST_F(ServiceTest, InstallWritesTheUnitAndUninstallTakesItBack) {
+    const auto installed = tether::install_tetherd_service(config_);
+
+    ASSERT_TRUE(installed.errors.empty()) << installed.errors.front();
+    EXPECT_TRUE(installed.changed);
+    EXPECT_EQ(installed.path, unit_.string());
+    ASSERT_TRUE(fs::exists(unit_));
+    EXPECT_NE(read(unit_).find("ExecStart="), std::string::npos);
+
+    const auto removed = tether::uninstall_tetherd_service(config_);
+    EXPECT_TRUE(removed.errors.empty());
+    EXPECT_TRUE(removed.changed);
+    EXPECT_FALSE(fs::exists(unit_));
+}
+
+TEST_F(ServiceTest, UninstallingWhatWasNeverInstalledIsNotAnError) {
+    const auto removed = tether::uninstall_tetherd_service(config_);
+
+    EXPECT_TRUE(removed.errors.empty());
+    EXPECT_FALSE(removed.changed);
+}
+
+TEST_F(ServiceTest, ExecStartPointsAtTheAppImageWhenRunningFromOne) {
+    const tether::testing::ScopedEnv appimage("APPIMAGE", std::string("/opt/tether.AppImage"));
+
+    EXPECT_EQ(tether::running_flavor(), tether::Flavor::AppImage);
+    EXPECT_EQ(tether::tetherd_exec_command(), "/opt/tether.AppImage --daemon");
+}
+
+TEST_F(ServiceTest, TheInstallerOwnsUpdateAndRemovalWhenItIsThere) {
+    const fs::path installer = root_ / "install.sh";
+    std::ofstream(installer) << "#!/bin/sh\n";
+
+    for (const auto flavor : {tether::Flavor::AppImage, tether::Flavor::Distro, tether::Flavor::Unknown}) {
+        const auto update = tether::update_plan(flavor, tether::PackageManager::Apt, installer);
+        EXPECT_TRUE(update.runnable);
+        EXPECT_EQ(update.command, installer.string() + " update");
+
+        const auto remove = tether::remove_plan(flavor, tether::PackageManager::Apt, installer);
+        EXPECT_TRUE(remove.runnable);
+        EXPECT_EQ(remove.command, installer.string() + " uninstall");
+    }
+}
+
+TEST_F(ServiceTest, WithoutTheInstallerThePackageManagerIsNamedInstead) {
+    const fs::path absent = root_ / "nothing-here.sh";
+
+    const auto apt = tether::remove_plan(tether::Flavor::Distro, tether::PackageManager::Apt, absent);
+    EXPECT_FALSE(apt.runnable);
+    EXPECT_EQ(apt.command, "sudo apt-get remove tether");
+
+    const auto pacman = tether::remove_plan(tether::Flavor::Distro, tether::PackageManager::Pacman, absent);
+    EXPECT_EQ(pacman.command, "sudo pacman -Rns tether");
+
+    const auto arch_update = tether::update_plan(tether::Flavor::Distro, tether::PackageManager::Pacman, absent);
+    EXPECT_EQ(arch_update.command, "yay -Syu tether");
+
+    // Nothing owns a portable build but the installer that fetched it.
+    const auto portable = tether::update_plan(tether::Flavor::AppImage, tether::PackageManager::None, absent);
+    EXPECT_FALSE(portable.runnable);
+    EXPECT_NE(portable.command.find("install.sh"), std::string::npos) << portable.command;
+}
+
+TEST_F(ServiceTest, InstallerLivesBesideTheRestOfTethersData) {
+    EXPECT_EQ(tether::installer_path("/home/x/.local/share/tether"), "/home/x/.local/share/tether/install.sh");
+    EXPECT_TRUE(tether::installer_path("").empty());
+}
+
+TEST_F(ServiceTest, WhichProgramFindsOnlyWhatIsExecutable) {
+    const fs::path bin = root_ / "bin";
+    fs::create_directories(bin);
+    std::ofstream(bin / "tether-fake") << "#!/bin/sh\n";
+    std::ofstream(bin / "tether-data") << "not a program\n";
+    fs::permissions(bin / "tether-fake", fs::perms::owner_all);
+
+    const tether::testing::ScopedEnv path("PATH", bin.string());
+
+    EXPECT_EQ(tether::which_program("tether-fake"), (bin / "tether-fake").string());
+    EXPECT_TRUE(tether::which_program("tether-data").empty());
+    EXPECT_TRUE(tether::which_program("tether-missing").empty());
+}

--- a/test/test_verbs.cpp
+++ b/test/test_verbs.cpp
@@ -1,0 +1,55 @@
+#include "../src/cli/verbs.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+    std::vector<std::string> expand(std::initializer_list<const char*> args) {
+        std::vector<std::string> in(args.begin(), args.end());
+        return tether::cli::expand_verbs(in);
+    }
+
+} // namespace
+
+TEST(Verbs, RewritesASubcommandIntoItsFlag) {
+    EXPECT_EQ(expand({"tether", "status"}), (std::vector<std::string>{"tether", "--status"}));
+    EXPECT_EQ(expand({"tether", "devices"}), (std::vector<std::string>{"tether", "--list-devices"}));
+    EXPECT_EQ(expand({"tether", "paste"}), (std::vector<std::string>{"tether", "--get-clipboard"}));
+}
+
+TEST(Verbs, KeepsTheArgumentsThatFollow) {
+    EXPECT_EQ(expand({"tether", "accept", "9a4f21"}), (std::vector<std::string>{"tether", "--accept", "9a4f21"}));
+    EXPECT_EQ(expand({"tether", "paste", "--host", "10.0.0.2"}),
+              (std::vector<std::string>{"tether", "--get-clipboard", "--host", "10.0.0.2"}));
+}
+
+TEST(Verbs, MapsBtToTheMatchingBluetoothFlag) {
+    EXPECT_EQ(expand({"tether", "bt", "setup"}), (std::vector<std::string>{"tether", "--bt-setup"}));
+    EXPECT_EQ(expand({"tether", "bt", "pair", "AA:BB"}), (std::vector<std::string>{"tether", "--bt-pair", "AA:BB"}));
+    EXPECT_EQ(expand({"tether", "bt", "airpods-mode", "anc"}),
+              (std::vector<std::string>{"tether", "--bt-airpods-mode", "anc"}));
+}
+
+TEST(Verbs, LeavesFlagsAlone) {
+    const auto flags = expand({"tether", "--bt-send", "thread", "hello"});
+    EXPECT_EQ(flags, (std::vector<std::string>{"tether", "--bt-send", "thread", "hello"}));
+
+    // Value of a flag, not a subcommand: only the first argument is a verb.
+    EXPECT_EQ(expand({"tether", "-s", "status"}), (std::vector<std::string>{"tether", "-s", "status"}));
+}
+
+TEST(Verbs, LeavesSomethingItDoesNotKnowForTheParserToReject) {
+    EXPECT_EQ(expand({"tether", "frobnicate"}), (std::vector<std::string>{"tether", "frobnicate"}));
+    EXPECT_EQ(expand({"tether", "bt"}), (std::vector<std::string>{"tether", "bt"}));
+    EXPECT_EQ(expand({"tether", "bt", "--help"}), (std::vector<std::string>{"tether", "bt", "--help"}));
+    EXPECT_EQ(expand({"tether"}), (std::vector<std::string>{"tether"}));
+}
+
+TEST(Verbs, EveryVerbHasAFlagAndHelp) {
+    for (size_t i = 0; i < tether::cli::kVerbCount; ++i) {
+        const auto& verb = tether::cli::kVerbs[i];
+        EXPECT_NE(verb.verb[0], '-') << verb.verb;
+        EXPECT_EQ(verb.flag[0], '-') << verb.verb;
+        EXPECT_NE(verb.usage[0], '\0') << verb.verb;
+    }
+}


### PR DESCRIPTION
## Why

I want Tether on a box I only ever reach over SSH: a home server with the iPhone on the same network, no compositor, no GTK. `tetherd` already handles that — `wayland_srv.init()` failing is not fatal, it just means no clipboard sync — but there was no way to *install* it there, keep it running, or accept a pairing request without a window to click. The fingerprint `--accept` wants was only ever printed to the daemon log.

This adds the missing pieces, and while it was in there, the subcommand form people keep typing.

## What is in it

**`scripts/install.sh`** — install, update and remove from one curl-able entry point:

```bash
curl -fsSL https://raw.githubusercontent.com/zackb/tether/main/scripts/install.sh | sh
curl -fsSL .../install.sh | sh -s -- --headless --enable
```

It takes the `.deb`/`.rpm` where it can use one and the AppImage otherwise, **unpacked** into `~/.local/share/tether` rather than mounted, so it needs neither root nor FUSE — the usual server situation. On Arch it says `yay -S tether` is the packaged route and takes the portable one. It records what it did in `~/.local/share/tether/install-manifest` and leaves a copy of itself beside it, which is what makes `tether update` possible. It never enables or starts anything unless asked with `--enable`, which also does the `loginctl enable-linger` that people miss and then wonder why the daemon dies with their SSH session.

**New flags**, each also a subcommand:

| flag | subcommand | |
|---|---|---|
| `--status` | `tether status` | devices, links, mDNS, recent transfers |
| `--pending` | `tether pending` | the Wi-Fi pairing requests waiting, with fingerprints |
| `--install-service` | `tether service` | write `tetherd.service`, print how to enable it |
| `--uninstall-service` | | take it back |
| `--self-update` | `tether update` | |
| `--uninstall` | `tether uninstall` | |

`--pending` plus the existing `--accept` is the whole headless pairing flow. `--status` reads the `state_snapshot` the GTK app already asks for.

`--self-update` and `--uninstall` never act behind another tool's back. When `install.sh` put the build there, they run it. When a package manager, flatpak or a source tree owns it, they print the command that tool wants and stop — the same posture as `--bt-setup`.

**`packaging/systemd/tetherd.service`** — a user unit, deliberately *not* tied to `graphical-session.target`, since the point is that the daemon does not need one. The distro packages install it with the real path in `ExecStart`; portable builds carry it embedded next to `BTCLASS_UNIT` and fill the path in at runtime, the pattern already there.

**Subcommands** are a translation over argv, not a second parser. `expand_verbs()` rewrites `tether status` to `tether --status` before the existing loop sees it, and `tether bt <name>` to `--bt-<name>` — so every Bluetooth flag gets a subcommand with no table to keep in step. Every flag keeps working exactly as it did. Each subcommand borrows its flag's help text rather than carrying a second copy that would drift.

**Docs**: a Quick install section in the README, `docs/HEADLESS.md`, and the man page.

## Testing

- `make test` — 517/517 pass, including the two new suites (`test_verbs.cpp`, `test_service.cpp`).
- `shellcheck --shell=sh scripts/install.sh` — clean.
- Installed 0.2.28 end to end in a clean container: download, unpack, wrappers, `tether --version`, `install.sh status`, `install.sh uninstall`.
- Ran `tetherd` headless in a container and drove `status`, `pending`, `devices` against it. `Clipboard: off, no Wayland session on this machine` is what a server sees.
- The installer tolerates a release older than itself: if that `tether` has no `--install-service`, it warns and finishes rather than failing an install that otherwise worked.

## Two things worth your eye

- The `Examples:` block in `--help` now shows the subcommand forms (`tether paste`, `tether send ./report.pdf`). Happy to put the flag forms back if you would rather lead with those.
- The new strings are translated into all 15 catalogs so `check-catalogs.sh` stays clean. They are my translations, not a native speaker's — worth a look from anyone who has one. The template regenerates byte-identical to yours apart from the additions, so we are on the same gettext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
