### PR TITLE
cli: subcommands for the flags that already exist

### DIFF
--- a/docs/man/man1/tether.1.in
+++ b/docs/man/man1/tether.1.in
@@ -4,11 +4,17 @@ tether \- Wayland companion CLI for iPhone integration
 .SH SYNOPSIS
 .B tether
 [\fIOPTIONS\fR]
+.br
+.B tether
+\fICOMMAND\fR [\fIARGUMENTS\fR]
 .SH DESCRIPTION
 .B tether
 is a command-line interface for communicating with the Tether daemon (\fBtetherd\fR).
 It allows for clipboard synchronization, file transfers, and device management between
 a Linux Wayland desktop and an iOS device.
+.PP
+Most options also have a subcommand form, so \fBtether devices\fR and
+\fBtether \-\-list-devices\fR are the same thing. See \fBCOMMANDS\fR.
 .SH OPTIONS
 .TP
 \fB\-h, \-\-help\fR
@@ -65,6 +71,26 @@ distro packages install the manifests system\-wide.
 Write \fBtether-btclass@.service\fR to \fB/etc/systemd/system\fR. Needs root, and
 never enables it. Needed only for a portable build such as the AppImage; the distro
 packages install the unit themselves. See \fB\-\-bt-setup\fR.
+.SH COMMANDS
+Each of these is the option named beside it, so nothing behaves differently for
+having been typed as a word. A first argument that is not one of these, or that
+starts with a dash, is left for the option parser.
+.TP
+\fBdevices\fR
+\fB\-\-list-devices\fR
+.TP
+\fBaccept\fR \fIFINGERPRINT\fR, \fBforget\fR \fIFINGERPRINT\fR, \fBpair\fR
+\fB\-\-accept\fR, \fB\-\-forget\fR, \fB\-\-pair\fR
+.TP
+\fBdiscover\fR, \fBsend\fR \fIFILE\fR, \fBcopy\fR [\fISTRING\fR], \fBpaste\fR
+\fB\-\-discover\fR, \fB\-\-send-file\fR, \fB\-\-set-clipboard\fR, \fB\-\-get-clipboard\fR
+.TP
+\fBversion\fR, \fBhelp\fR
+\fB\-\-version\fR, \fB\-\-help\fR
+.TP
+\fBbt\fR \fINAME\fR [\fIARGUMENTS\fR]
+The \fB\-\-bt-\fR\fINAME\fR option, so \fBtether bt pair AA:BB:CC:DD:EE:FF\fR is
+\fBtether \-\-bt-pair AA:BB:CC:DD:EE:FF\fR.
 .SH BLUETOOTH OPTIONS
 Bluetooth carries iPhone messages (MAP), contacts (PBAP), and notification
 mirroring (ANCS). It is independent of the Wi-Fi pairing above.
@@ -201,6 +227,12 @@ tether \-f document.pdf
 See what Bluetooth still needs before pairing an iPhone:
 .IP
 tether \-\-bt-setup
+.PP
+The same things, as subcommands:
+.IP
+tether send document.pdf
+.IP
+tether bt setup
 .SH FILES
 .TP
 \fB/usr/lib/systemd/system/tether\-btclass@.service\fR

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -260,6 +260,14 @@ msgid "Options:"
 msgstr "Volby:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Příkazy:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Libovolný přepínač --bt-<name> jako podpříkaz."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Příklady:"
 
@@ -465,12 +473,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Nepodařilo se načíst baterii AirPods z démona.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Nejsou připojena žádná AirPods.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Správa AirPods je vypnutá.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nejsou připojena žádná AirPods.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -264,6 +264,14 @@ msgid "Options:"
 msgstr "Optionen:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Befehle:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Jede --bt-<name>-Option, als Unterbefehl."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Beispiele:"
 
@@ -464,12 +472,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Der Akkustand der AirPods konnte nicht vom Daemon gelesen werden.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Keine AirPods verbunden.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Die AirPods-Verwaltung ist ausgeschaltet.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Keine AirPods verbunden.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -266,6 +266,14 @@ msgid "Options:"
 msgstr "Opciones:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Comandos:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Cualquier opción --bt-<name>, como subcomando."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Ejemplos:"
 
@@ -467,12 +475,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "No se pudo leer la batería de los AirPods desde el demonio.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "No hay AirPods conectados.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "La gestión de los AirPods está desactivada.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "No hay AirPods conectados.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -269,6 +269,14 @@ msgid "Options:"
 msgstr "Options :"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Commandes :"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "N'importe quelle option --bt-<name>, en sous-commande."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Exemples :"
 
@@ -470,12 +478,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Impossible de lire la batterie des AirPods depuis le démon.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Aucun AirPods connecté.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "La gestion des AirPods est désactivée.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Aucun AirPods connecté.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -267,6 +267,14 @@ msgid "Options:"
 msgstr "Opzioni:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Comandi:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Qualsiasi opzione --bt-<name>, come sottocomando."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Esempi:"
 
@@ -467,12 +475,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Impossibile leggere la batteria degli AirPods dal demone.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Nessun AirPods connesso.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "La gestione degli AirPods è disattivata.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nessun AirPods connesso.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -263,6 +263,14 @@ msgid "Options:"
 msgstr "オプション:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "コマンド:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "任意の --bt-<name> フラグをサブコマンドとして。"
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "例:"
 
@@ -456,12 +464,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "デーモンから AirPods のバッテリーを読み取れませんでした。\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "AirPods は接続されていません。\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods の管理はオフです。\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "AirPods は接続されていません。\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -260,6 +260,14 @@ msgid "Options:"
 msgstr "옵션:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "명령:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "모든 --bt-<name> 플래그를 하위 명령으로."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "예제:"
 
@@ -453,12 +461,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "데몬에서 AirPods 배터리를 읽을 수 없습니다.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "연결된 AirPods가 없습니다.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods 관리가 꺼져 있습니다.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "연결된 AirPods가 없습니다.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -264,6 +264,14 @@ msgid "Options:"
 msgstr "Opties:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Opdrachten:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Elke --bt-<name>-optie, als subopdracht."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Voorbeelden:"
 
@@ -465,12 +473,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Kon de accu van de AirPods niet uitlezen via de daemon.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Geen AirPods verbonden.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods-beheer staat uit.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Geen AirPods verbonden.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -263,6 +263,14 @@ msgid "Options:"
 msgstr "Opcje:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Polecenia:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Dowolna flaga --bt-<name> jako podpolecenie."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Przykłady:"
 
@@ -468,12 +476,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Nie można odczytać poziomu baterii AirPods z demona.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Nie podłączono żadnych AirPods.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Zarządzanie AirPods jest wyłączone.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nie podłączono żadnych AirPods.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -264,6 +264,14 @@ msgid "Options:"
 msgstr "Opções:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Comandos:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Qualquer opção --bt-<name>, como subcomando."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Exemplos:"
 
@@ -464,12 +472,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Não foi possível ler a bateria dos AirPods do daemon.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Nenhum AirPods conectado.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "O gerenciamento dos AirPods está desativado.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nenhum AirPods conectado.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -263,6 +263,14 @@ msgid "Options:"
 msgstr "Параметры:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Команды:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Любой флаг --bt-<name> в виде подкоманды."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Примеры:"
 
@@ -468,12 +476,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Не удалось получить заряд AirPods от службы.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "AirPods не подключены.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Управление AirPods отключено.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "AirPods не подключены.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -262,6 +262,14 @@ msgid "Options:"
 msgstr "Flaggor:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Kommandon:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Valfri --bt-<name>-flagga, som underkommando."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Exempel:"
 
@@ -461,12 +469,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Kunde inte läsa AirPods batterinivå från demonen.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Inga AirPods anslutna.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Hanteringen av AirPods är avstängd.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Inga AirPods anslutna.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: tether 0.2.28\n"
+"Project-Id-Version: tether 0.2.29\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -241,6 +241,14 @@ msgid "Options:"
 msgstr ""
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr ""
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr ""
 
@@ -420,11 +428,11 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr ""
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
+msgid "AirPods management is off.\n"
 msgstr ""
 
 #: src/cli/main.cpp
-msgid "AirPods management is off.\n"
+msgid "No AirPods connected.\n"
 msgstr ""
 
 #: src/cli/main.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -262,6 +262,14 @@ msgid "Options:"
 msgstr "Seçenekler:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Komutlar:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Herhangi bir --bt-<name> bayrağı, alt komut olarak."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Örnekler:"
 
@@ -462,12 +470,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "AirPods pil durumu arka plan hizmetinden okunamadı.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Bağlı AirPods yok.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods yönetimi kapalı.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Bağlı AirPods yok.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -264,6 +264,14 @@ msgid "Options:"
 msgstr "Параметри:"
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "Команди:"
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "Будь-який прапорець --bt-<name> як підкоманда."
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "Приклади:"
 
@@ -469,12 +477,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Не вдалося отримати заряд AirPods від служби.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "AirPods не під'єднано.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Керування AirPods вимкнено.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "AirPods не під'єднано.\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:05+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -251,6 +251,14 @@ msgid "Options:"
 msgstr "选项："
 
 #: src/cli/main.cpp
+msgid "Commands:"
+msgstr "命令："
+
+#: src/cli/main.cpp
+msgid "Any --bt-<name> flag, as a subcommand."
+msgstr "任何 --bt-<name> 选项，均可作为子命令使用。"
+
+#: src/cli/main.cpp
 msgid "Examples:"
 msgstr "示例："
 
@@ -443,12 +451,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "无法从守护进程读取 AirPods 电量。\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "未连接 AirPods。\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods 管理已关闭。\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "未连接 AirPods。\n"
 
 #: src/cli/main.cpp
 msgid "Left"

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(tether_cli
     main.cpp
+    verbs.cpp
 )
 
 target_link_libraries(tether_cli PRIVATE tether)

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1,3 +1,5 @@
+#include "verbs.hpp"
+
 #include <algorithm>
 #include <atomic>
 #include <charconv>
@@ -238,6 +240,22 @@ static const Opt kOptions[] = {
     {"--pair", N_("Send a pair_request over TCP to the daemon.")},
 };
 
+// The option row a subcommand stands for, matched on the long flag so the two
+// lists cannot drift apart.
+static const char* describe_flag(const std::string& flag) {
+    for (const auto& opt : kOptions) {
+        const std::string flags = opt.flags;
+        const auto at = flags.find(flag);
+        if (at == std::string::npos)
+            continue;
+        // "--pair" must not match "--bt-pair".
+        const auto end = at + flag.size();
+        if ((at == 0 || flags[at - 1] == ' ') && (end == flags.size() || flags[end] == ' ' || flags[end] == ','))
+            return opt.desc;
+    }
+    return "";
+}
+
 void print_help() {
     fprintf(stdout, "%s\n\n%s\n", _("tether - Wayland companion CLI"), _("Options:"));
 
@@ -256,16 +274,44 @@ void print_help() {
         }
     }
 
+    fprintf(stdout, "\n%s\n", _("Commands:"));
+
+    size_t verb_col = 0;
+    for (size_t i = 0; i < tether::cli::kVerbCount; ++i)
+        verb_col = std::max(verb_col, tether::display_width(tether::cli::kVerbs[i].usage));
+
+    const size_t verb_desc_width = total > verb_col + 8 ? total - verb_col - 4 : 40;
+    for (size_t i = 0; i < tether::cli::kVerbCount; ++i) {
+        const auto& verb = tether::cli::kVerbs[i];
+        const std::string pad(verb_col - tether::display_width(verb.usage), ' ');
+        // One description per capability: a subcommand borrows its flag's.
+        // gettext("") would hand back the catalog header, so ask only for text.
+        const char* desc = describe_flag(verb.flag);
+        auto lines = wrap(*desc ? _(desc) : "", verb_desc_width);
+        if (lines.empty())
+            lines.emplace_back();
+        for (size_t line = 0; line < lines.size(); ++line) {
+            const std::string prefix = line == 0 ? verb.usage + pad : std::string(verb_col, ' ');
+            fprintf(stdout, "  %s  %s\n", prefix.c_str(), lines[line].c_str());
+        }
+    }
+
     // Literal invocations: never translated.
     fprintf(stdout,
+            "  %-*s  %s\n",
+            static_cast<int>(verb_col),
+            "tether bt <name> ...",
+            _("Any --bt-<name> flag, as a subcommand."));
+
+    fprintf(stdout,
             "\n%s\n"
-            "  tether -g\n"
-            "  tether -g --host 127.0.0.1\n"
-            "  echo \"pipe\" | tether -s\n"
-            "  tether --discover\n"
-            "  tether --discover --timeout 5000\n"
-            "  tether -f ./report.pdf\n"
-            "  tether --accept 9a4f21...\n",
+            "  tether paste\n"
+            "  tether paste --host 127.0.0.1\n"
+            "  echo \"pipe\" | tether copy\n"
+            "  tether discover --timeout 5000\n"
+            "  tether send ./report.pdf\n"
+            "  tether accept 9a4f21...\n"
+            "  tether bt pair AA:BB:CC:DD:EE:FF\n",
             _("Examples:"));
 }
 
@@ -1050,6 +1096,15 @@ static int send_bt_message(tether::Client& client, const std::string& thread, co
 
 int main(int argc, char* argv[]) {
     tether::init_locale();
+
+    // Subcommands are rewritten into the flags below, so there is one parser.
+    const std::vector<std::string> expanded = tether::cli::expand_verbs({argv, argv + argc});
+    std::vector<char*> rewritten;
+    rewritten.reserve(expanded.size());
+    for (const auto& arg : expanded)
+        rewritten.push_back(const_cast<char*>(arg.c_str()));
+    argc = static_cast<int>(rewritten.size());
+    argv = rewritten.data();
 
     if (argc < 2) {
         print_help();

--- a/src/cli/verbs.cpp
+++ b/src/cli/verbs.cpp
@@ -1,0 +1,49 @@
+#include "verbs.hpp"
+
+namespace tether::cli {
+
+    const Verb kVerbs[] = {
+        {"devices", "--list-devices", "tether devices"},
+        {"accept", "--accept", "tether accept <fingerprint>"},
+        {"forget", "--forget", "tether forget <fingerprint>"},
+        {"pair", "--pair", "tether pair --host <ip>"},
+        {"discover", "--discover", "tether discover"},
+        {"send", "--send-file", "tether send <path>"},
+        {"copy", "--set-clipboard", "tether copy [text]"},
+        {"paste", "--get-clipboard", "tether paste"},
+        {"version", "--version", "tether version"},
+        {"help", "--help", "tether help"},
+    };
+
+    const size_t kVerbCount = sizeof(kVerbs) / sizeof(kVerbs[0]);
+
+    std::vector<std::string> expand_verbs(const std::vector<std::string>& args) {
+        if (args.size() < 2 || args[1].empty() || args[1][0] == '-')
+            return args;
+
+        std::vector<std::string> out;
+        out.reserve(args.size());
+        out.push_back(args[0]);
+
+        // 'tether bt <name> ...' is '--bt-<name> ...', so every Bluetooth flag
+        // has a subcommand without a table to keep in step with it.
+        if (args[1] == "bt") {
+            if (args.size() < 3 || args[2].empty() || args[2][0] == '-')
+                return args;
+            out.push_back("--bt-" + args[2]);
+            out.insert(out.end(), args.begin() + 3, args.end());
+            return out;
+        }
+
+        for (size_t i = 0; i < kVerbCount; ++i) {
+            if (args[1] != kVerbs[i].verb)
+                continue;
+            out.push_back(kVerbs[i].flag);
+            out.insert(out.end(), args.begin() + 2, args.end());
+            return out;
+        }
+
+        return args;
+    }
+
+} // namespace tether::cli

--- a/src/cli/verbs.hpp
+++ b/src/cli/verbs.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace tether::cli {
+
+    struct Verb {
+        const char* verb;
+        const char* flag;  // what it stands for, and where its help text comes from
+        const char* usage; // how it reads on the command line
+    };
+
+    // Subcommands, for people who reach for 'tether status' before 'tether
+    // --status'. Every flag keeps working exactly as it did.
+    extern const Verb kVerbs[];
+    extern const size_t kVerbCount;
+
+    // Rewrites a leading subcommand into the flag it stands for, and 'bt <name>'
+    // into '--bt-<name>'. Anything else, flags included, is passed through
+    // untouched. args[0] is the program name.
+    std::vector<std::string> expand_verbs(const std::vector<std::string>& args);
+
+} // namespace tether::cli

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,9 @@ add_executable(tether_test
     test_otp.cpp
     test_paths.cpp
     test_message_format.cpp
+    test_verbs.cpp
     ../src/gtk/message_format.cpp
+    ../src/cli/verbs.cpp
 )
 
 target_include_directories(tether_test PRIVATE

--- a/test/test_verbs.cpp
+++ b/test/test_verbs.cpp
@@ -1,0 +1,55 @@
+#include "../src/cli/verbs.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+    std::vector<std::string> expand(std::initializer_list<const char*> args) {
+        std::vector<std::string> in(args.begin(), args.end());
+        return tether::cli::expand_verbs(in);
+    }
+
+} // namespace
+
+TEST(Verbs, RewritesASubcommandIntoItsFlag) {
+    EXPECT_EQ(expand({"tether", "devices"}), (std::vector<std::string>{"tether", "--list-devices"}));
+    EXPECT_EQ(expand({"tether", "paste"}), (std::vector<std::string>{"tether", "--get-clipboard"}));
+    EXPECT_EQ(expand({"tether", "discover"}), (std::vector<std::string>{"tether", "--discover"}));
+}
+
+TEST(Verbs, KeepsTheArgumentsThatFollow) {
+    EXPECT_EQ(expand({"tether", "accept", "9a4f21"}), (std::vector<std::string>{"tether", "--accept", "9a4f21"}));
+    EXPECT_EQ(expand({"tether", "paste", "--host", "10.0.0.2"}),
+              (std::vector<std::string>{"tether", "--get-clipboard", "--host", "10.0.0.2"}));
+}
+
+TEST(Verbs, MapsBtToTheMatchingBluetoothFlag) {
+    EXPECT_EQ(expand({"tether", "bt", "setup"}), (std::vector<std::string>{"tether", "--bt-setup"}));
+    EXPECT_EQ(expand({"tether", "bt", "pair", "AA:BB"}), (std::vector<std::string>{"tether", "--bt-pair", "AA:BB"}));
+    EXPECT_EQ(expand({"tether", "bt", "airpods-mode", "anc"}),
+              (std::vector<std::string>{"tether", "--bt-airpods-mode", "anc"}));
+}
+
+TEST(Verbs, LeavesFlagsAlone) {
+    const auto flags = expand({"tether", "--bt-send", "thread", "hello"});
+    EXPECT_EQ(flags, (std::vector<std::string>{"tether", "--bt-send", "thread", "hello"}));
+
+    // Value of a flag, not a subcommand: only the first argument is a verb.
+    EXPECT_EQ(expand({"tether", "-s", "paste"}), (std::vector<std::string>{"tether", "-s", "paste"}));
+}
+
+TEST(Verbs, LeavesSomethingItDoesNotKnowForTheParserToReject) {
+    EXPECT_EQ(expand({"tether", "frobnicate"}), (std::vector<std::string>{"tether", "frobnicate"}));
+    EXPECT_EQ(expand({"tether", "bt"}), (std::vector<std::string>{"tether", "bt"}));
+    EXPECT_EQ(expand({"tether", "bt", "--help"}), (std::vector<std::string>{"tether", "bt", "--help"}));
+    EXPECT_EQ(expand({"tether"}), (std::vector<std::string>{"tether"}));
+}
+
+TEST(Verbs, EveryVerbHasAFlagAndHelp) {
+    for (size_t i = 0; i < tether::cli::kVerbCount; ++i) {
+        const auto& verb = tether::cli::kVerbs[i];
+        EXPECT_NE(verb.verb[0], '-') << verb.verb;
+        EXPECT_EQ(verb.flag[0], '-') << verb.verb;
+        EXPECT_NE(verb.usage[0], '\0') << verb.verb;
+    }
+}


### PR DESCRIPTION
First of the two halves of #157, split as you asked. This one is only the argv work: no installer, no auto-update, no systemd.

`tether devices` and the like now work, rewritten into the flag they stand for before parsing, so there is still one parser and every existing flag behaves exactly as it did. `tether bt <name>` maps to `--bt-<name>` by rule rather than by a table, so the Bluetooth flags cannot drift out of step with their subcommands.

The verb table only covers flags that exist on `main` today. `status`, `pending` and `service` are deliberately absent here: those flags arrive in the headless PR, and a verb pointing at a flag the parser does not know would just produce a confusing error. Once both land I will add the two rows in a follow-up.

`--help` grows a `Commands:` section. A subcommand borrows the description of the flag it stands for, matched on the long flag, so the two lists cannot disagree. The match is anchored at word boundaries so `--pair` does not match `--bt-pair`.

```
Commands:
  tether devices               List all paired connection devices.
  tether accept <fingerprint>  Accept a pending pairing request locally.
  tether discover              Scan the local network for tetherd instances via
                               mDNS.
  tether send <path>           Send a file through tether.
  tether copy [text]           Take string input and copy it to the local
                               Wayland clipboard.
  tether paste                 Retrieve the current Wayland clipboard text.
  tether bt <name> ...         Any --bt-<name> flag, as a subcommand.
```

### Checked

- `test/test_verbs.cpp` covers the rewrite, the `bt` rule, arguments after the verb, flags passed through untouched, and anything unknown left for the parser to reject.
- `po/update-pot.sh --check` and `po/check-catalogs.sh` both pass; the two new strings are translated in all 15 catalogs. `msgmerge` guessed "Commands:" from "Copy commands", which was wrong, so those are written rather than left fuzzy.
- The man page documents the subcommand form.

I could not build the full tree locally (no wayland/avahi/libsecret dev packages on this box), so I exercised `expand_verbs` and the real `print_help`/`describe_flag` in isolation instead. CI here is the first full compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)