### PR TITLE
headless: tetherd under systemd, with --status and --pending

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,24 @@ configure_file(
 install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/tether-native-host"
         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+# systemd user unit for the daemon. The distro packages install it with the real
+# path in ExecStart; a portable build carries a copy with a placeholder the CLI
+# fills in with wherever that build happens to live.
+set(TETHERD_EXEC "${CMAKE_INSTALL_FULL_BINDIR}/tetherd")
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/packaging/systemd/tetherd.service.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/tetherd.service"
+    @ONLY
+)
+set(TETHERD_EXEC "__TETHERD_EXEC__")
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/packaging/systemd/tetherd.service.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/generated/tetherd.service.tmpl"
+    @ONLY
+)
+
 # embed files only the distro packages can install, so portable build can write them out at runtime.
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/generated/tetherd.service.tmpl" TETHERD_UNIT)
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/packaging/systemd/tether-btclass@.service" BTCLASS_UNIT)
 file(READ "${CMAKE_CURRENT_BINARY_DIR}/com.tether.extension.chrome.json" CHROME_MANIFEST)
 file(READ "${CMAKE_CURRENT_BINARY_DIR}/com.tether.extension.mozilla.json" MOZILLA_MANIFEST)
@@ -145,6 +162,10 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/man/tetherd.8"
 set(SYSTEMD_UNIT_DIR "lib/systemd/system" CACHE PATH "systemd system unit directory")
 install(FILES packaging/systemd/tether-btclass@.service
         DESTINATION "${SYSTEMD_UNIT_DIR}")
+
+set(SYSTEMD_USER_UNIT_DIR "lib/systemd/user" CACHE PATH "systemd user unit directory")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tetherd.service"
+        DESTINATION "${SYSTEMD_USER_UNIT_DIR}")
 
 # firewall profiles for the mTLS listener (5134/tcp) and mDNS (5353/udp) installed but not applied (user's call).
 set(UFW_APPLICATIONS_DIR "/etc/ufw/applications.d" CACHE PATH "ufw application profile directory")

--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ make install
    or
 
    ```bash
-   tether --accept <fingerprint>   # fingerprint is printed by the daemon log
+   tether --pending                # the requests waiting, with their fingerprints
+   tether --accept <fingerprint>
    ```
 
 3. Bluetooth (for Messages and Notifications):
@@ -275,6 +276,22 @@ make install
    "Show Message Notifications" and "Sync Contacts". Both are needed. They can
    take a few minutes to appear; "Show iPhone Permissions" in the GTK app
    re-advertises so they show up again.
+
+
+### No desktop on the machine?
+
+The daemon does not need a Wayland session. Everything but clipboard sync works
+over SSH, pairing included:
+
+```bash
+systemctl --user enable --now tetherd.service   # portable build? tether --install-service first
+tether --pending        # the pairing requests waiting, with fingerprints
+tether --accept 9a4f21...
+tether --status         # devices, links, and recent transfers
+```
+
+See [docs/HEADLESS.md](docs/HEADLESS.md).
+
 
 
 ## Components

--- a/docs/HEADLESS.md
+++ b/docs/HEADLESS.md
@@ -1,0 +1,105 @@
+# Tether on a machine with no desktop
+
+Tether is built for a Wayland desktop, but the daemon does not need one. On a
+server, a Raspberry Pi, or a machine you only ever reach over SSH, `tetherd`
+still speaks to the iPhone over Wi-Fi and everything except clipboard sync
+works. This is how to set that up and drive it from the CLI.
+
+What you get, and what you do not:
+
+| Feature | Headless |
+|---|---|
+| File transfer, both directions | ✅ |
+| OTP handling and the vault | ✅ |
+| Pairing, device management, status | ✅ |
+| Messages, notifications, calls | ✅ with a Bluetooth adapter the machine can see |
+| Clipboard sync | ❌ needs a Wayland session with `wlr-data-control` |
+
+## Run the daemon under systemd
+
+The distro packages install a `tetherd.service` user unit into
+`/usr/lib/systemd/user`, so there is nothing to write. Enable it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now tetherd.service
+loginctl enable-linger $USER      # or the daemon dies with your SSH session
+```
+
+`loginctl enable-linger` is the part people miss. Without it systemd tears the
+user session down when your last shell exits, and the daemon goes with it.
+
+A portable build (an AppImage, or a tree you built yourself) has no package to
+install that unit, so the CLI writes one pointed at wherever that build lives:
+
+```bash
+tether --install-service     # writes ~/.config/systemd/user/tetherd.service
+```
+
+It never enables or starts anything: it prints the commands above and leaves the
+decision to you. `tether --uninstall-service` takes the unit back.
+
+Note the order. A client starts `tetherd` on its own when one is not already
+running, so if you have used the CLI at all there is probably a daemon up
+already, holding the port this unit wants. Enabling the unit takes it over.
+Once the unit is enabled, clients stop spawning their own and leave the daemon
+to systemd.
+
+## Pair the iPhone
+
+The daemon advertises itself over mDNS and the iOS app finds it. Both ends have
+to accept, and on the desktop that prompt is a GTK window you do not have here,
+so accept it from the shell instead:
+
+```bash
+tether --status         # is the daemon up, is mDNS advertising
+tether --pending        # the requests waiting, with their fingerprints
+tether --accept 9a4f21c8…
+tether --list-devices   # what is paired now
+```
+
+If the phone cannot find the machine, mDNS or the firewall is usually why:
+
+```bash
+sudo systemctl enable --now avahi-daemon    # tetherd needs it to advertise
+sudo ufw allow tether                       # 5134/tcp and 5353/udp
+```
+
+The package ships profiles for ufw and firewalld but applies neither. Opening
+5134 is your call: it is the mTLS listener, and both ends pin certificates, but
+it is still a port.
+
+## Use it
+
+```bash
+tether -f ./report.pdf                # to the phone
+tether --status                       # what arrived, and from whom
+tether --bt-threads                   # conversations, over Bluetooth
+tether --bt-send <thread> "on my way"
+```
+
+Files the phone sends land in `$XDG_DOWNLOAD_DIR`, or `~/Downloads`. On a server
+where that does not exist, set `XDG_DOWNLOAD_DIR` in the unit's environment:
+
+```bash
+systemctl --user edit tetherd.service
+# [Service]
+# Environment=XDG_DOWNLOAD_DIR=%h/inbox
+```
+
+## Clipboard sync
+
+`tether --status` says `Clipboard: off, no Wayland session on this machine` and
+that is the whole story: without a compositor there is no clipboard to sync. The
+rest of the daemon does not care. If the machine does run a compositor and this
+still says off, the compositor is missing `wlr-data-control` or
+`ext-data-control`.
+
+## From another machine
+
+The CLI talks to a remote daemon over the same TLS the phone uses:
+
+```bash
+tether -g --host 10.0.0.5
+tether --pair --host 10.0.0.5
+```

--- a/docs/man/man1/tether.1.in
+++ b/docs/man/man1/tether.1.in
@@ -94,8 +94,8 @@ Each of these is the option named beside it, so nothing behaves differently for
 having been typed as a word. A first argument that is not one of these, or that
 starts with a dash, is left for the option parser.
 .TP
-\fBdevices\fR
-\fB\-\-list-devices\fR
+\fBstatus\fR, \fBdevices\fR, \fBpending\fR
+\fB\-\-status\fR, \fB\-\-list-devices\fR, \fB\-\-pending\fR
 .TP
 \fBaccept\fR \fIFINGERPRINT\fR, \fBforget\fR \fIFINGERPRINT\fR, \fBpair\fR
 \fB\-\-accept\fR, \fB\-\-forget\fR, \fB\-\-pair\fR
@@ -103,8 +103,8 @@ starts with a dash, is left for the option parser.
 \fBdiscover\fR, \fBsend\fR \fIFILE\fR, \fBcopy\fR [\fISTRING\fR], \fBpaste\fR
 \fB\-\-discover\fR, \fB\-\-send-file\fR, \fB\-\-set-clipboard\fR, \fB\-\-get-clipboard\fR
 .TP
-\fBversion\fR, \fBhelp\fR
-\fB\-\-version\fR, \fB\-\-help\fR
+\fBservice\fR, \fBversion\fR, \fBhelp\fR
+\fB\-\-install-service\fR, \fB\-\-version\fR, \fB\-\-help\fR
 .TP
 \fBbt\fR \fINAME\fR [\fIARGUMENTS\fR]
 The \fB\-\-bt-\fR\fINAME\fR option, so \fBtether bt pair AA:BB:CC:DD:EE:FF\fR is

--- a/docs/man/man1/tether.1.in
+++ b/docs/man/man1/tether.1.in
@@ -44,6 +44,16 @@ Discovery scan duration in milliseconds (default: 3000).
 \fB\-\-list-devices\fR
 List all paired connection devices and their fingerprints.
 .TP
+\fB\-\-status\fR
+Print what the daemon is doing: version, clipboard and mDNS state, how many
+devices are paired, how many pairing requests wait, which peers are connected,
+and the files most recently received.
+.TP
+\fB\-\-pending\fR
+List the Wi\-Fi pairing requests waiting to be accepted, with the fingerprint
+\fB\-\-accept\fR takes. On a machine with no GTK app to show the prompt, this
+is how a request is seen.
+.TP
 \fB\-\-accept\fR \fIFINGERPRINT\fR
 Accept a pending pairing request locally for the specified device fingerprint.
 .TP
@@ -65,6 +75,14 @@ distro packages install the manifests system\-wide.
 Write \fBtether-btclass@.service\fR to \fB/etc/systemd/system\fR. Needs root, and
 never enables it. Needed only for a portable build such as the AppImage; the distro
 packages install the unit themselves. See \fB\-\-bt-setup\fR.
+.TP
+\fB\-\-install-service\fR
+Write \fBtetherd.service\fR into \fB~/.config/systemd/user\fR and print the
+commands that enable it. Never enables or starts anything. Needed only for a
+portable build; the distro packages install the unit system\-wide.
+.TP
+\fB\-\-uninstall-service\fR
+Remove the \fBtetherd.service\fR unit this user installed.
 .SH BLUETOOTH OPTIONS
 Bluetooth carries iPhone messages (MAP), contacts (PBAP), and notification
 mirroring (ANCS). It is independent of the Wi-Fi pairing above.
@@ -203,6 +221,12 @@ See what Bluetooth still needs before pairing an iPhone:
 tether \-\-bt-setup
 .SH FILES
 .TP
+\fB/usr/lib/systemd/user/tetherd.service\fR
+Starts \fBtetherd\fR for one user. Installed by the distro packages but never
+enabled; a portable build writes its own copy to
+\fB~/.config/systemd/user\fR with \fB\-\-install-service\fR. The daemon does
+not need a Wayland session: without one it runs with clipboard sync off.
+.TP
 \fB/usr/lib/systemd/system/tether\-btclass@.service\fR
 Sets the Bluetooth adapter's Class of Device to A/V Hands\-Free, which iOS
 requires before it will offer its Messages and Contacts permissions. Installed
@@ -210,4 +234,5 @@ by the distro packages but never enabled; a portable build writes it to
 \fB/etc/systemd/system\fR instead. See \fB\-\-bt-setup\fR.
 .SH SEE ALSO
 .BR tetherd (8),
-.BR tether-gtk (1)
+.BR tether-gtk (1),
+.BR systemd.unit (5)

--- a/packaging/systemd/tetherd.service.in
+++ b/packaging/systemd/tetherd.service.in
@@ -5,17 +5,19 @@ Documentation=https://github.com/zackb/tether
 # Wayland session, it just does not sync the clipboard when there is none.
 After=dbus.socket network.target bluetooth.target
 Wants=network.target
-# A tetherd a client spawned on its own still holds the TCP listener, so this
-# unit cannot bind it. Give up and say so rather than restarting into it forever.
+# A tetherd a client spawned on its own holds the runtime lock, so this unit's
+# tetherd exits. Give up and say so rather than restarting into it forever.
 StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
 Type=simple
 # A client spawns tetherd on its own when one is not already running, so there
-# may be one from before this unit was enabled. It holds the TCP listener, which
-# this unit would then fail to bind, so take it over rather than start into it.
-ExecStartPre=-/usr/bin/pkill -x tetherd
+# may be one from before this unit was enabled. It holds the runtime lock, which
+# makes this unit's tetherd exit, so take it over rather than start into it.
+# Matched on the command line, not the process name: a client spawns the daemon
+# as argv[0] "tetherd", but an AppImage's name is what lands in comm.
+ExecStartPre=-/usr/bin/pkill -f ^tetherd
 ExecStart=@TETHERD_EXEC@
 Restart=on-failure
 RestartSec=3

--- a/packaging/systemd/tetherd.service.in
+++ b/packaging/systemd/tetherd.service.in
@@ -1,0 +1,27 @@
+[Unit]
+Description=Tether daemon, bridging an iPhone to this computer
+Documentation=https://github.com/zackb/tether
+# Deliberately not tied to graphical-session.target: tetherd runs without a
+# Wayland session, it just does not sync the clipboard when there is none.
+After=dbus.socket network.target bluetooth.target
+Wants=network.target
+# A tetherd a client spawned on its own still holds the TCP listener, so this
+# unit cannot bind it. Give up and say so rather than restarting into it forever.
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+Type=simple
+# A client spawns tetherd on its own when one is not already running, so there
+# may be one from before this unit was enabled. It holds the TCP listener, which
+# this unit would then fail to bind, so take it over rather than start into it.
+ExecStartPre=-/usr/bin/pkill -x tetherd
+ExecStart=@TETHERD_EXEC@
+Restart=on-failure
+RestartSec=3
+# The daemon writes its own log into $XDG_STATE_HOME/tether.
+StandardOutput=null
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -243,11 +243,16 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Zapíše uživatelskou službu systemd tetherd pro tohoto uživatele a vypíše, jak ji povolit. Potřeba jen u přenosných sestavení; distribuční balíčky ji instalují samy."
+msgstr ""
+"Zapíše uživatelskou službu systemd tetherd pro tohoto uživatele a vypíše, "
+"jak ji povolit. Potřeba jen u přenosných sestavení; distribuční balíčky ji "
+"instalují samy."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Odebere uživatelskou službu systemd tetherd, kterou tento uživatel nainstaloval."
+msgstr ""
+"Odebere uživatelskou službu systemd tetherd, kterou tento uživatel "
+"nainstaloval."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
@@ -292,8 +297,7 @@ msgstr "Příklady:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"Nainstalováno %s\n"
+msgstr "Nainstalováno %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -752,8 +756,7 @@ msgstr "Zpráva nebyla odeslána."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Nepodařilo se přečíst stav démona.\n"
+msgstr "Nepodařilo se přečíst stav démona.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -831,8 +834,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Nečekají žádné žádosti o spárování.\n"
+msgstr "Nečekají žádné žádosti o spárování.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -842,6 +844,17 @@ msgid ""
 msgstr ""
 "\n"
 "Přijměte některou pomocí: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"V tomto počítači není systemd, takže není žádná uživatelská služba ke správě. "
+"Spusťte tetherd tím, co tento systém používá pro služby, nebo jej nechte "
+"spustit klientem na vyžádání.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -858,12 +871,14 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether ji za vás nepovolí. Chcete-li démona spustit nyní a při každém přihlášení:\n"
+"Tether ji za vás nepovolí. Chcete-li démona spustit nyní a při každém "
+"přihlášení:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
 "\n"
-"Na serveru, ze kterého se odhlašujete, udržujte také uživatelskou relaci naživu:\n"
+"Na serveru, ze kterého se odhlašujete, udržujte také uživatelskou relaci "
+"naživu:\n"
 "\n"
 "loginctl enable-linger $USER\n"
 
@@ -876,8 +891,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"Odebráno %s\n"
+msgstr "Odebráno %s\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Czech\n"
@@ -240,6 +240,24 @@ msgstr ""
 "Potřebné pouze pro přenosná sestavení; balíčky distribuce ji instalují samy."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Zapíše uživatelskou službu systemd tetherd pro tohoto uživatele a vypíše, jak ji povolit. Potřeba jen u přenosných sestavení; distribuční balíčky ji instalují samy."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Odebere uživatelskou službu systemd tetherd, kterou tento uživatel nainstaloval."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Zobrazí, co démon dělá: zařízení, spojení a nedávné přenosy."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Vypíše žádosti o spárování přes Wi-Fi, které čekají na přijetí."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Přijmout čekající žádost o spárování místně."
 
@@ -266,7 +284,8 @@ msgstr "Příklady:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Nainstalováno %s\n"
+msgstr ""
+"Nainstalováno %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -465,12 +484,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Nepodařilo se načíst baterii AirPods z démona.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Nejsou připojena žádná AirPods.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Správa AirPods je vypnutá.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nejsou připojena žádná AirPods.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -722,6 +741,144 @@ msgstr "Odesláno na %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Zpráva nebyla odeslána."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Nepodařilo se přečíst stav démona.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Verze"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Démon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "běží"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Schránka"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synchronizuje se"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "vypnuto, na tomto počítači není relace Wayland"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "oznamuje se"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "nedostupné"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Spárovaná zařízení"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Čekající žádosti"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Právě připojeno"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "spárováno"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "nespárováno"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Nedávno přijaté:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Spusťte 'tether --pending' a zobrazte, co čeká na přijetí.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Nečekají žádné žádosti o spárování.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Přijměte některou pomocí: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether ji za vás nepovolí. Chcete-li démona spustit nyní a při každém přihlášení:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Na serveru, ze kterého se odhlašujete, udržujte také uživatelskou relaci naživu:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Pro tohoto uživatele nebyla nainstalována žádná uživatelská služba tetherd.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"Odebráno %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Spusťte 'systemctl --user daemon-reload', aby na ni systemd zapomněl.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -244,6 +244,24 @@ msgstr ""
 "portable Builds nötig; die Distributionspakete installieren sie selbst."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Schreibt den systemd-Benutzerdienst tetherd für diesen Benutzer und gibt aus, wie er aktiviert wird. Nur für portable Builds nötig; die Distributionspakete installieren ihn selbst."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Entfernt den systemd-Benutzerdienst tetherd, den dieser Benutzer installiert hat."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Zeigt, was der Daemon tut: Geräte, Verbindungen und letzte Übertragungen."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Listet die Wi-Fi-Kopplungsanfragen auf, die auf Annahme warten."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Eine ausstehende Kopplungsanfrage lokal annehmen."
 
@@ -270,7 +288,8 @@ msgstr "Beispiele:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Installiert: %s\n"
+msgstr ""
+"%s installiert\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -464,12 +483,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Der Akkustand der AirPods konnte nicht vom Daemon gelesen werden.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Keine AirPods verbunden.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Die AirPods-Verwaltung ist ausgeschaltet.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Keine AirPods verbunden.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -728,6 +747,144 @@ msgstr "Gesendet an %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Die Nachricht wurde nicht gesendet."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Der Zustand des Daemons konnte nicht gelesen werden.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Version"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Daemon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "läuft"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Zwischenablage"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "wird synchronisiert"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "aus, auf diesem Rechner läuft keine Wayland-Sitzung"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "wird angekündigt"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "nicht verfügbar"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Gekoppelte Geräte"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Ausstehende Anfragen"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Jetzt verbunden"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "gekoppelt"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "nicht gekoppelt"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Zuletzt empfangen:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Führen Sie 'tether --pending' aus, um zu sehen, was auf Annahme wartet.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Es warten keine Kopplungsanfragen.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Eine annehmen mit: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether aktiviert ihn nicht für Sie. Um den Daemon jetzt und bei jeder Anmeldung zu starten:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Auf einem Server, von dem Sie sich abmelden, halten Sie auch die Benutzersitzung am Leben:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Für diesen Benutzer wurde kein tetherd-Benutzerdienst installiert.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"%s entfernt\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Führen Sie 'systemctl --user daemon-reload' aus, damit systemd sie vergisst.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: German\n"
@@ -247,15 +247,21 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Schreibt den systemd-Benutzerdienst tetherd für diesen Benutzer und gibt aus, wie er aktiviert wird. Nur für portable Builds nötig; die Distributionspakete installieren ihn selbst."
+msgstr ""
+"Schreibt den systemd-Benutzerdienst tetherd für diesen Benutzer und gibt "
+"aus, wie er aktiviert wird. Nur für portable Builds nötig; die "
+"Distributionspakete installieren ihn selbst."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Entfernt den systemd-Benutzerdienst tetherd, den dieser Benutzer installiert hat."
+msgstr ""
+"Entfernt den systemd-Benutzerdienst tetherd, den dieser Benutzer installiert "
+"hat."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Zeigt, was der Daemon tut: Geräte, Verbindungen und letzte Übertragungen."
+msgstr ""
+"Zeigt, was der Daemon tut: Geräte, Verbindungen und letzte Übertragungen."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
@@ -296,8 +302,7 @@ msgstr "Beispiele:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"%s installiert\n"
+msgstr "%s installiert\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -758,8 +763,7 @@ msgstr "Die Nachricht wurde nicht gesendet."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Der Zustand des Daemons konnte nicht gelesen werden.\n"
+msgstr "Der Zustand des Daemons konnte nicht gelesen werden.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -837,8 +841,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Es warten keine Kopplungsanfragen.\n"
+msgstr "Es warten keine Kopplungsanfragen.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -848,6 +851,17 @@ msgid ""
 msgstr ""
 "\n"
 "Eine annehmen mit: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"Auf diesem Rechner läuft kein systemd, es gibt also keinen Benutzerdienst zu "
+"verwalten. Starten Sie tetherd über das, was dieses System für Dienste nutzt, "
+"oder lassen Sie ihn von einem Client bei Bedarf starten.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -864,26 +878,26 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether aktiviert ihn nicht für Sie. Um den Daemon jetzt und bei jeder Anmeldung zu starten:\n"
+"Tether aktiviert ihn nicht für Sie. Um den Daemon jetzt und bei jeder "
+"Anmeldung zu starten:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
 "\n"
-"Auf einem Server, von dem Sie sich abmelden, halten Sie auch die Benutzersitzung am Leben:\n"
+"Auf einem Server, von dem Sie sich abmelden, halten Sie auch die "
+"Benutzersitzung am Leben:\n"
 "\n"
 "loginctl enable-linger $USER\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"Für diesen Benutzer wurde kein tetherd-Benutzerdienst installiert.\n"
+msgstr "Für diesen Benutzer wurde kein tetherd-Benutzerdienst installiert.\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"%s entfernt\n"
+msgstr "%s entfernt\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -892,7 +906,8 @@ msgid ""
 "Run 'systemctl --user daemon-reload' to forget it.\n"
 msgstr ""
 "\n"
-"Führen Sie 'systemctl --user daemon-reload' aus, damit systemd sie vergisst.\n"
+"Führen Sie 'systemctl --user daemon-reload' aus, damit systemd sie "
+"vergisst.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -246,6 +246,24 @@ msgstr ""
 "la instalan."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Escribe el servicio de usuario de systemd tetherd para este usuario e imprime cómo habilitarlo. Solo es necesario para compilaciones portables; los paquetes de la distribución lo instalan."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Elimina el servicio de usuario de systemd tetherd que instaló este usuario."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Muestra qué está haciendo el demonio: dispositivos, conexiones y transferencias recientes."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Lista las solicitudes de emparejamiento por Wi-Fi que esperan ser aceptadas."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Aceptar localmente una solicitud de emparejamiento pendiente."
 
@@ -272,7 +290,8 @@ msgstr "Ejemplos:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Instalado %s\n"
+msgstr ""
+"Instalado %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -467,12 +486,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "No se pudo leer la batería de los AirPods desde el demonio.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "No hay AirPods conectados.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "La gestión de los AirPods está desactivada.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "No hay AirPods conectados.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -727,6 +746,144 @@ msgstr "Enviado a %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "El mensaje no se envió."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"No se pudo leer el estado del demonio.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Versión"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Demonio"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "en ejecución"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Portapapeles"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "sincronizando"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "desactivado, no hay sesión de Wayland en esta máquina"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "anunciando"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "no disponible"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Cortafuegos"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Dispositivos emparejados"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Solicitudes pendientes"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Conectados ahora"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "emparejado"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "sin emparejar"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Recibidos recientemente:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Ejecute 'tether --pending' para ver qué está esperando ser aceptado.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"No hay solicitudes de emparejamiento esperando.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Acepte una con: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether no lo habilita por usted. Para iniciar el demonio ahora y en cada inicio de sesión:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"En un servidor del que cierra sesión, mantenga también viva la sesión de usuario:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"No se instaló ningún servicio de usuario tetherd para este usuario.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"Eliminado %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Ejecute 'systemctl --user daemon-reload' para que se olvide de él.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Spanish\n"
@@ -249,19 +249,26 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Escribe el servicio de usuario de systemd tetherd para este usuario e imprime cómo habilitarlo. Solo es necesario para compilaciones portables; los paquetes de la distribución lo instalan."
+msgstr ""
+"Escribe el servicio de usuario de systemd tetherd para este usuario e "
+"imprime cómo habilitarlo. Solo es necesario para compilaciones portables; "
+"los paquetes de la distribución lo instalan."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Elimina el servicio de usuario de systemd tetherd que instaló este usuario."
+msgstr ""
+"Elimina el servicio de usuario de systemd tetherd que instaló este usuario."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Muestra qué está haciendo el demonio: dispositivos, conexiones y transferencias recientes."
+msgstr ""
+"Muestra qué está haciendo el demonio: dispositivos, conexiones y "
+"transferencias recientes."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
-msgstr "Lista las solicitudes de emparejamiento por Wi-Fi que esperan ser aceptadas."
+msgstr ""
+"Lista las solicitudes de emparejamiento por Wi-Fi que esperan ser aceptadas."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -298,8 +305,7 @@ msgstr "Ejemplos:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"Instalado %s\n"
+msgstr "Instalado %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -757,8 +763,7 @@ msgstr "El mensaje no se envió."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"No se pudo leer el estado del demonio.\n"
+msgstr "No se pudo leer el estado del demonio.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -836,8 +841,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"No hay solicitudes de emparejamiento esperando.\n"
+msgstr "No hay solicitudes de emparejamiento esperando.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -847,6 +851,17 @@ msgid ""
 msgstr ""
 "\n"
 "Acepte una con: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"Esta máquina no tiene systemd, así que no hay ningún servicio de usuario que "
+"gestionar. Inicia tetherd con lo que este sistema use para servicios, o deja "
+"que un cliente lo inicie cuando haga falta.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -863,26 +878,26 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether no lo habilita por usted. Para iniciar el demonio ahora y en cada inicio de sesión:\n"
+"Tether no lo habilita por usted. Para iniciar el demonio ahora y en cada "
+"inicio de sesión:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
 "\n"
-"En un servidor del que cierra sesión, mantenga también viva la sesión de usuario:\n"
+"En un servidor del que cierra sesión, mantenga también viva la sesión de "
+"usuario:\n"
 "\n"
 "loginctl enable-linger $USER\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"No se instaló ningún servicio de usuario tetherd para este usuario.\n"
+msgstr "No se instaló ningún servicio de usuario tetherd para este usuario.\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"Eliminado %s\n"
+msgstr "Eliminado %s\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -249,6 +249,24 @@ msgstr ""
 "l'installent."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Écrit le service utilisateur systemd tetherd pour cet utilisateur et affiche comment l'activer. Nécessaire uniquement pour les builds portables ; les paquets de la distribution l'installent."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Supprime le service utilisateur systemd tetherd installé par cet utilisateur."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Affiche ce que fait le démon : appareils, connexions et transferts récents."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Liste les demandes d'appairage Wi-Fi en attente d'acceptation."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Accepter localement une demande d'appairage en attente."
 
@@ -275,7 +293,8 @@ msgstr "Exemples :"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Installé %s\n"
+msgstr ""
+"%s installé\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -470,12 +489,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Impossible de lire la batterie des AirPods depuis le démon.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Aucun AirPods connecté.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "La gestion des AirPods est désactivée.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Aucun AirPods connecté.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -732,6 +751,144 @@ msgstr "Envoyé à %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Le message n'a pas été envoyé."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Impossible de lire l'état du démon.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Version"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Démon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "en cours d'exécution"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Presse-papiers"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synchronisation"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "désactivé, aucune session Wayland sur cette machine"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "diffusion"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "indisponible"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Pare-feu"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Appareils appairés"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Demandes en attente"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Connectés actuellement"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "appairé"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "non appairé"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Reçus récemment :"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Exécutez 'tether --pending' pour voir ce qui attend d'être accepté.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Aucune demande d'appairage en attente.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Acceptez-en une avec : tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether ne l'active pas pour vous. Pour démarrer le démon maintenant et à chaque connexion :\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Sur un serveur dont vous vous déconnectez, gardez aussi la session utilisateur active :\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Aucun service utilisateur tetherd n'a été installé pour cet utilisateur.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"%s supprimé\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Exécutez 'systemctl --user daemon-reload' pour qu'il l'oublie.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-22\n"
 "Last-Translator: Tether project\n"
 "Language-Team: French\n"
@@ -252,15 +252,20 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Écrit le service utilisateur systemd tetherd pour cet utilisateur et affiche comment l'activer. Nécessaire uniquement pour les builds portables ; les paquets de la distribution l'installent."
+msgstr ""
+"Écrit le service utilisateur systemd tetherd pour cet utilisateur et affiche "
+"comment l'activer. Nécessaire uniquement pour les builds portables ; les "
+"paquets de la distribution l'installent."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Supprime le service utilisateur systemd tetherd installé par cet utilisateur."
+msgstr ""
+"Supprime le service utilisateur systemd tetherd installé par cet utilisateur."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Affiche ce que fait le démon : appareils, connexions et transferts récents."
+msgstr ""
+"Affiche ce que fait le démon : appareils, connexions et transferts récents."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
@@ -301,8 +306,7 @@ msgstr "Exemples :"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"%s installé\n"
+msgstr "%s installé\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -762,8 +766,7 @@ msgstr "Le message n'a pas été envoyé."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Impossible de lire l'état du démon.\n"
+msgstr "Impossible de lire l'état du démon.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -841,8 +844,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Aucune demande d'appairage en attente.\n"
+msgstr "Aucune demande d'appairage en attente.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -852,6 +854,17 @@ msgid ""
 msgstr ""
 "\n"
 "Acceptez-en une avec : tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"Pas de systemd sur cette machine, il n'y a donc aucun service utilisateur à "
+"gérer. Lancez tetherd avec ce que ce système utilise pour ses services, ou "
+"laissez un client le démarrer à la demande.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -868,12 +881,14 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether ne l'active pas pour vous. Pour démarrer le démon maintenant et à chaque connexion :\n"
+"Tether ne l'active pas pour vous. Pour démarrer le démon maintenant et à "
+"chaque connexion :\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
 "\n"
-"Sur un serveur dont vous vous déconnectez, gardez aussi la session utilisateur active :\n"
+"Sur un serveur dont vous vous déconnectez, gardez aussi la session "
+"utilisateur active :\n"
 "\n"
 "loginctl enable-linger $USER\n"
 
@@ -886,8 +901,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"%s supprimé\n"
+msgstr "%s supprimé\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -247,6 +247,24 @@ msgstr ""
 "installano."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Scrive il servizio utente systemd tetherd per questo utente e stampa come abilitarlo. Necessario solo per build portabili; i pacchetti della distribuzione lo installano."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Rimuove il servizio utente systemd tetherd installato da questo utente."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Mostra cosa sta facendo il demone: dispositivi, connessioni e trasferimenti recenti."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Elenca le richieste di accoppiamento Wi-Fi in attesa di essere accettate."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Accetta localmente una richiesta di accoppiamento in sospeso."
 
@@ -273,7 +291,8 @@ msgstr "Esempi:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Installato %s\n"
+msgstr ""
+"Installato %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -467,12 +486,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Impossibile leggere la batteria degli AirPods dal demone.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Nessun AirPods connesso.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "La gestione degli AirPods è disattivata.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nessun AirPods connesso.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -727,6 +746,144 @@ msgstr "Inviato a %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Il messaggio non è stato inviato."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Impossibile leggere lo stato del demone.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Versione"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Demone"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "in esecuzione"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Appunti"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "sincronizzazione"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "disattivato, nessuna sessione Wayland su questa macchina"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "in annuncio"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "non disponibile"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Dispositivi accoppiati"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Richieste in sospeso"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Connessi ora"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "accoppiato"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "non accoppiato"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Ricevuti di recente:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Esegui 'tether --pending' per vedere cosa attende di essere accettato.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Nessuna richiesta di accoppiamento in attesa.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Accettane una con: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether non lo abilita per te. Per avviare il demone ora e a ogni accesso:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Su un server da cui esci, mantieni attiva anche la sessione utente:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Nessun servizio utente tetherd è stato installato per questo utente.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"Rimosso %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Esegui 'systemctl --user daemon-reload' per dimenticarlo.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Italian\n"
@@ -250,19 +250,26 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Scrive il servizio utente systemd tetherd per questo utente e stampa come abilitarlo. Necessario solo per build portabili; i pacchetti della distribuzione lo installano."
+msgstr ""
+"Scrive il servizio utente systemd tetherd per questo utente e stampa come "
+"abilitarlo. Necessario solo per build portabili; i pacchetti della "
+"distribuzione lo installano."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Rimuove il servizio utente systemd tetherd installato da questo utente."
+msgstr ""
+"Rimuove il servizio utente systemd tetherd installato da questo utente."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Mostra cosa sta facendo il demone: dispositivi, connessioni e trasferimenti recenti."
+msgstr ""
+"Mostra cosa sta facendo il demone: dispositivi, connessioni e trasferimenti "
+"recenti."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
-msgstr "Elenca le richieste di accoppiamento Wi-Fi in attesa di essere accettate."
+msgstr ""
+"Elenca le richieste di accoppiamento Wi-Fi in attesa di essere accettate."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -299,8 +306,7 @@ msgstr "Esempi:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"Installato %s\n"
+msgstr "Installato %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -757,8 +763,7 @@ msgstr "Il messaggio non è stato inviato."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Impossibile leggere lo stato del demone.\n"
+msgstr "Impossibile leggere lo stato del demone.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -836,8 +841,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Nessuna richiesta di accoppiamento in attesa.\n"
+msgstr "Nessuna richiesta di accoppiamento in attesa.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -847,6 +851,17 @@ msgid ""
 msgstr ""
 "\n"
 "Accettane una con: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"Su questa macchina non c'è systemd, quindi non c'è alcun servizio utente da "
+"gestire. Avvia tetherd con ciò che questo sistema usa per i servizi, oppure "
+"lascia che sia un client ad avviarlo quando serve.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -875,14 +890,12 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"Nessun servizio utente tetherd è stato installato per questo utente.\n"
+msgstr "Nessun servizio utente tetherd è stato installato per questo utente.\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"Rimosso %s\n"
+msgstr "Rimosso %s\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -246,11 +246,16 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "このユーザー向けの tetherd systemd ユーザーサービスを書き込み、有効化の方法を表示します。ポータブルビルドでのみ必要です。ディストリビューションのパッケージは自分でインストールします。"
+msgstr ""
+"このユーザー向けの tetherd systemd ユーザーサービスを書き込み、有効化の方法を"
+"表示します。ポータブルビルドでのみ必要です。ディストリビューションのパッケー"
+"ジは自分でインストールします。"
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "このユーザーがインストールした tetherd の systemd ユーザーサービスを削除します。"
+msgstr ""
+"このユーザーがインストールした tetherd の systemd ユーザーサービスを削除しま"
+"す。"
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
@@ -295,8 +300,7 @@ msgstr "例:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"%s をインストールしました\n"
+msgstr "%s をインストールしました\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -743,8 +747,7 @@ msgstr "メッセージは送信されませんでした。"
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"デーモンの状態を読み取れませんでした。\n"
+msgstr "デーモンの状態を読み取れませんでした。\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -822,8 +825,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"待機中のペアリングリクエストはありません。\n"
+msgstr "待機中のペアリングリクエストはありません。\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -833,6 +835,17 @@ msgid ""
 msgstr ""
 "\n"
 "次のコマンドで承認します: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"このマシンには systemd がないため、管理するユーザーサービスはありません。この"
+"システムがサービスに使っているもので tetherd を起動するか、クライアントが必要"
+"に応じて起動するのに任せてください。\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -849,7 +862,8 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether が代わりに有効化することはありません。デーモンを今すぐ、そしてログインのたびに起動するには:\n"
+"Tether が代わりに有効化することはありません。デーモンを今すぐ、そしてログイン"
+"のたびに起動するには:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
@@ -867,8 +881,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"%s を削除しました\n"
+msgstr "%s を削除しました\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Japanese\n"
@@ -243,6 +243,24 @@ msgstr ""
 "ンストールします。"
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "このユーザー向けの tetherd systemd ユーザーサービスを書き込み、有効化の方法を表示します。ポータブルビルドでのみ必要です。ディストリビューションのパッケージは自分でインストールします。"
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "このユーザーがインストールした tetherd の systemd ユーザーサービスを削除します。"
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "デーモンの動作状況を表示します: デバイス、接続、最近の転送。"
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "承認待ちの Wi-Fi ペアリングリクエストを一覧表示します。"
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "保留中のペアリング要求をローカルで承認します。"
 
@@ -269,7 +287,8 @@ msgstr "例:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "インストールしました: %s\n"
+msgstr ""
+"%s をインストールしました\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -456,12 +475,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "デーモンから AirPods のバッテリーを読み取れませんでした。\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "AirPods は接続されていません。\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods の管理はオフです。\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "AirPods は接続されていません。\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -713,6 +732,144 @@ msgstr "%s に送信しました\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "メッセージは送信されませんでした。"
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"デーモンの状態を読み取れませんでした。\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "バージョン"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "デーモン"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "実行中"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "クリップボード"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "同期中"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "オフ、このマシンには Wayland セッションがありません"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "アドバタイズ中"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "利用不可"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "ファイアウォール"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "ペアリング済みデバイス"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "保留中のリクエスト"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "現在の接続"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "ペアリング済み"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "未ペアリング"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "最近受信したファイル:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"承認待ちのものを見るには 'tether --pending' を実行してください。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"待機中のペアリングリクエストはありません。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"次のコマンドで承認します: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether が代わりに有効化することはありません。デーモンを今すぐ、そしてログインのたびに起動するには:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"ログアウトするサーバーでは、ユーザーセッションも維持してください:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"このユーザー向けの tetherd ユーザーサービスはインストールされていません。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"%s を削除しました\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"'systemctl --user daemon-reload' を実行して忘れさせてください。\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -240,6 +240,24 @@ msgstr ""
 "다. 배포판 패키지는 직접 설치합니다."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "이 사용자를 위한 tetherd systemd 사용자 서비스를 작성하고 활성화 방법을 출력합니다. 포터블 빌드에만 필요하며, 배포판 패키지는 직접 설치합니다."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "이 사용자가 설치한 tetherd systemd 사용자 서비스를 제거합니다."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "데몬의 상태를 표시합니다: 기기, 연결, 최근 전송."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "수락을 기다리는 Wi-Fi 페어링 요청을 나열합니다."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "대기 중인 페어링 요청을 로컬에서 수락합니다."
 
@@ -266,7 +284,8 @@ msgstr "예제:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "설치함: %s\n"
+msgstr ""
+"%s 설치됨\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -453,12 +472,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "데몬에서 AirPods 배터리를 읽을 수 없습니다.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "연결된 AirPods가 없습니다.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods 관리가 꺼져 있습니다.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "연결된 AirPods가 없습니다.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -709,6 +728,144 @@ msgstr "%s(으)로 보냈습니다\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "메시지가 전송되지 않았습니다."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"데몬의 상태를 읽을 수 없습니다.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "버전"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "데몬"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "실행 중"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "클립보드"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "동기화 중"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "꺼짐, 이 컴퓨터에 Wayland 세션이 없습니다"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "브로드캐스트 중"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "사용 불가"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "방화벽"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "페어링된 기기"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "대기 중인 요청"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "현재 연결됨"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "페어링됨"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "페어링되지 않음"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "최근에 받은 항목:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"수락을 기다리는 항목을 보려면 'tether --pending'을 실행하세요.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"대기 중인 페어링 요청이 없습니다.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"다음 명령으로 수락하세요: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether가 대신 활성화하지 않습니다. 데몬을 지금 그리고 로그인할 때마다 시작하려면:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"로그아웃하는 서버에서는 사용자 세션도 유지하세요:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"이 사용자를 위해 설치된 tetherd 사용자 서비스가 없습니다.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"%s 제거됨\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"'systemctl --user daemon-reload'을 실행하여 잊게 하세요.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Korean\n"
@@ -243,7 +243,9 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "이 사용자를 위한 tetherd systemd 사용자 서비스를 작성하고 활성화 방법을 출력합니다. 포터블 빌드에만 필요하며, 배포판 패키지는 직접 설치합니다."
+msgstr ""
+"이 사용자를 위한 tetherd systemd 사용자 서비스를 작성하고 활성화 방법을 출력"
+"합니다. 포터블 빌드에만 필요하며, 배포판 패키지는 직접 설치합니다."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
@@ -292,8 +294,7 @@ msgstr "예제:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"%s 설치됨\n"
+msgstr "%s 설치됨\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -739,8 +740,7 @@ msgstr "메시지가 전송되지 않았습니다."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"데몬의 상태를 읽을 수 없습니다.\n"
+msgstr "데몬의 상태를 읽을 수 없습니다.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -818,8 +818,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"대기 중인 페어링 요청이 없습니다.\n"
+msgstr "대기 중인 페어링 요청이 없습니다.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -829,6 +828,17 @@ msgid ""
 msgstr ""
 "\n"
 "다음 명령으로 수락하세요: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"이 컴퓨터에는 systemd가 없으므로 관리할 사용자 서비스가 없습니다. 이 시스템이 "
+"서비스에 사용하는 방법으로 tetherd를 시작하거나, 클라이언트가 필요할 때 "
+"시작하도록 두십시오.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -845,7 +855,8 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether가 대신 활성화하지 않습니다. 데몬을 지금 그리고 로그인할 때마다 시작하려면:\n"
+"Tether가 대신 활성화하지 않습니다. 데몬을 지금 그리고 로그인할 때마다 시작하"
+"려면:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
@@ -857,14 +868,12 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"이 사용자를 위해 설치된 tetherd 사용자 서비스가 없습니다.\n"
+msgstr "이 사용자를 위해 설치된 tetherd 사용자 서비스가 없습니다.\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"%s 제거됨\n"
+msgstr "%s 제거됨\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -247,15 +247,21 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Schrijft de systemd-gebruikersservice tetherd voor deze gebruiker en toont hoe je hem inschakelt. Alleen nodig voor draagbare builds; de distributiepakketten installeren hem zelf."
+msgstr ""
+"Schrijft de systemd-gebruikersservice tetherd voor deze gebruiker en toont "
+"hoe je hem inschakelt. Alleen nodig voor draagbare builds; de "
+"distributiepakketten installeren hem zelf."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Verwijdert de systemd-gebruikersservice tetherd die deze gebruiker heeft geïnstalleerd."
+msgstr ""
+"Verwijdert de systemd-gebruikersservice tetherd die deze gebruiker heeft "
+"geïnstalleerd."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Toont wat de daemon doet: apparaten, verbindingen en recente overdrachten."
+msgstr ""
+"Toont wat de daemon doet: apparaten, verbindingen en recente overdrachten."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
@@ -296,8 +302,7 @@ msgstr "Voorbeelden:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"%s geïnstalleerd\n"
+msgstr "%s geïnstalleerd\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -754,8 +759,7 @@ msgstr "Het bericht is niet verstuurd."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Kon de status van de daemon niet lezen.\n"
+msgstr "Kon de status van de daemon niet lezen.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -833,8 +837,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Er wachten geen koppelingsverzoeken.\n"
+msgstr "Er wachten geen koppelingsverzoeken.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -844,6 +847,17 @@ msgid ""
 msgstr ""
 "\n"
 "Accepteer er een met: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"Op deze machine draait geen systemd, dus er is geen gebruikersservice om te "
+"beheren. Start tetherd met wat dit systeem voor services gebruikt, of laat een "
+"client hem starten wanneer dat nodig is.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -860,7 +874,8 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether schakelt hem niet voor je in. Om de daemon nu en bij elke aanmelding te starten:\n"
+"Tether schakelt hem niet voor je in. Om de daemon nu en bij elke aanmelding "
+"te starten:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
@@ -878,8 +893,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"%s verwijderd\n"
+msgstr "%s verwijderd\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Dutch\n"
@@ -244,6 +244,24 @@ msgstr ""
 "voor draagbare builds; de distributiepakketten installeren hem zelf."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Schrijft de systemd-gebruikersservice tetherd voor deze gebruiker en toont hoe je hem inschakelt. Alleen nodig voor draagbare builds; de distributiepakketten installeren hem zelf."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Verwijdert de systemd-gebruikersservice tetherd die deze gebruiker heeft geïnstalleerd."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Toont wat de daemon doet: apparaten, verbindingen en recente overdrachten."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Toont de Wi-Fi-koppelingsverzoeken die op acceptatie wachten."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Een openstaand koppelverzoek lokaal accepteren."
 
@@ -270,7 +288,8 @@ msgstr "Voorbeelden:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Geïnstalleerd: %s\n"
+msgstr ""
+"%s geïnstalleerd\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -465,12 +484,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Kon de accu van de AirPods niet uitlezen via de daemon.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Geen AirPods verbonden.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods-beheer staat uit.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Geen AirPods verbonden.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -724,6 +743,144 @@ msgstr "Verstuurd naar %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Het bericht is niet verstuurd."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Kon de status van de daemon niet lezen.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Versie"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Daemon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "actief"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Klembord"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synchroniseert"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "uit, geen Wayland-sessie op deze machine"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "adverteert"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "niet beschikbaar"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Gekoppelde apparaten"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Openstaande verzoeken"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Nu verbonden"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "gekoppeld"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "niet gekoppeld"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Onlangs ontvangen:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Voer 'tether --pending' uit om te zien wat op acceptatie wacht.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Er wachten geen koppelingsverzoeken.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Accepteer er een met: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether schakelt hem niet voor je in. Om de daemon nu en bij elke aanmelding te starten:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Op een server waar je uitlogt, houd je ook de gebruikerssessie in leven:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Er is geen tetherd-gebruikersservice voor deze gebruiker geïnstalleerd.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"%s verwijderd\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Voer 'systemctl --user daemon-reload' uit om hem te vergeten.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -243,6 +243,24 @@ msgstr ""
 "tylko dla wersji przenośnych; pakiety dystrybucji instalują ją same."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Zapisuje usługę użytkownika systemd tetherd dla tego użytkownika i wypisuje, jak ją włączyć. Potrzebne tylko dla przenośnych kompilacji; pakiety dystrybucji instalują ją same."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Usuwa usługę użytkownika systemd tetherd zainstalowaną przez tego użytkownika."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Pokazuje, co robi demon: urządzenia, połączenia i ostatnie transfery."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Wyświetla żądania parowania przez Wi-Fi oczekujące na zaakceptowanie."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Zaakceptuj lokalnie oczekujące żądanie parowania."
 
@@ -269,7 +287,8 @@ msgstr "Przykłady:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Zainstalowano %s\n"
+msgstr ""
+"Zainstalowano %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -468,12 +487,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Nie można odczytać poziomu baterii AirPods z demona.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Nie podłączono żadnych AirPods.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Zarządzanie AirPods jest wyłączone.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nie podłączono żadnych AirPods.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -728,6 +747,144 @@ msgstr "Wysłano do %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Wiadomość nie została wysłana."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Nie udało się odczytać stanu demona.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Wersja"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Demon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "działa"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Schowek"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synchronizuje"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "wyłączone, brak sesji Wayland na tym komputerze"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "rozgłasza"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "niedostępne"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Zapora sieciowa"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Sparowane urządzenia"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Oczekujące żądania"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Połączone teraz"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "sparowane"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "niesparowane"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Ostatnio odebrane:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Uruchom 'tether --pending', aby zobaczyć, co czeka na zaakceptowanie.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Brak oczekujących żądań parowania.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Zaakceptuj jedno poleceniem: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether nie włączy jej za Ciebie. Aby uruchomić demona teraz i przy każdym logowaniu:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Na serwerze, z którego się wylogowujesz, utrzymaj też sesję użytkownika przy życiu:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Dla tego użytkownika nie zainstalowano usługi użytkownika tetherd.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"Usunięto %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Uruchom 'systemctl --user daemon-reload', aby o niej zapomniał.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Polish\n"
@@ -246,11 +246,16 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Zapisuje usługę użytkownika systemd tetherd dla tego użytkownika i wypisuje, jak ją włączyć. Potrzebne tylko dla przenośnych kompilacji; pakiety dystrybucji instalują ją same."
+msgstr ""
+"Zapisuje usługę użytkownika systemd tetherd dla tego użytkownika i wypisuje, "
+"jak ją włączyć. Potrzebne tylko dla przenośnych kompilacji; pakiety "
+"dystrybucji instalują ją same."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Usuwa usługę użytkownika systemd tetherd zainstalowaną przez tego użytkownika."
+msgstr ""
+"Usuwa usługę użytkownika systemd tetherd zainstalowaną przez tego "
+"użytkownika."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
@@ -295,8 +300,7 @@ msgstr "Przykłady:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"Zainstalowano %s\n"
+msgstr "Zainstalowano %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -758,8 +762,7 @@ msgstr "Wiadomość nie została wysłana."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Nie udało się odczytać stanu demona.\n"
+msgstr "Nie udało się odczytać stanu demona.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -837,8 +840,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Brak oczekujących żądań parowania.\n"
+msgstr "Brak oczekujących żądań parowania.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -848,6 +850,17 @@ msgid ""
 msgstr ""
 "\n"
 "Zaakceptuj jedno poleceniem: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"Na tym komputerze nie ma systemd, więc nie ma usługi użytkownika do "
+"zarządzania. Uruchom tetherd tym, czego ten system używa do usług, albo "
+"pozwól, by klient uruchomił go na żądanie.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -864,26 +877,26 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether nie włączy jej za Ciebie. Aby uruchomić demona teraz i przy każdym logowaniu:\n"
+"Tether nie włączy jej za Ciebie. Aby uruchomić demona teraz i przy każdym "
+"logowaniu:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
 "\n"
-"Na serwerze, z którego się wylogowujesz, utrzymaj też sesję użytkownika przy życiu:\n"
+"Na serwerze, z którego się wylogowujesz, utrzymaj też sesję użytkownika przy "
+"życiu:\n"
 "\n"
 "loginctl enable-linger $USER\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"Dla tego użytkownika nie zainstalowano usługi użytkownika tetherd.\n"
+msgstr "Dla tego użytkownika nie zainstalowano usługi użytkownika tetherd.\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"Usunięto %s\n"
+msgstr "Usunięto %s\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -244,6 +244,24 @@ msgstr ""
 "apenas para builds portáteis; os pacotes da distribuição a instalam."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Escreve o serviço de usuário systemd tetherd para este usuário e imprime como habilitá-lo. Necessário apenas para builds portáteis; os pacotes da distribuição o instalam."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Remove o serviço de usuário systemd tetherd que este usuário instalou."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Mostra o que o daemon está fazendo: dispositivos, conexões e transferências recentes."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Lista as solicitações de pareamento por Wi-Fi aguardando aceitação."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Aceitar localmente uma solicitação de pareamento pendente."
 
@@ -270,7 +288,8 @@ msgstr "Exemplos:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Instalado %s\n"
+msgstr ""
+"Instalado %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -464,12 +483,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Não foi possível ler a bateria dos AirPods do daemon.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Nenhum AirPods conectado.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "O gerenciamento dos AirPods está desativado.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Nenhum AirPods conectado.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -723,6 +742,144 @@ msgstr "Enviado para %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "A mensagem não foi enviada."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Não foi possível ler o estado do daemon.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Versão"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Daemon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "em execução"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Área de transferência"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "sincronizando"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "desativado, sem sessão Wayland nesta máquina"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "anunciando"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "indisponível"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Firewall"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Dispositivos pareados"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Solicitações pendentes"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Conectados agora"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "pareado"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "não pareado"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Recebidos recentemente:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Execute 'tether --pending' para ver o que aguarda aceitação.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Nenhuma solicitação de pareamento aguardando.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Aceite uma com: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"O Tether não o habilita para você. Para iniciar o daemon agora e a cada login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Em um servidor do qual você faz logout, mantenha a sessão de usuário viva também:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Nenhum serviço de usuário tetherd foi instalado para este usuário.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"Removido %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Execute 'systemctl --user daemon-reload' para esquecê-lo.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -247,7 +247,10 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Escreve o serviço de usuário systemd tetherd para este usuário e imprime como habilitá-lo. Necessário apenas para builds portáteis; os pacotes da distribuição o instalam."
+msgstr ""
+"Escreve o serviço de usuário systemd tetherd para este usuário e imprime "
+"como habilitá-lo. Necessário apenas para builds portáteis; os pacotes da "
+"distribuição o instalam."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
@@ -255,7 +258,9 @@ msgstr "Remove o serviço de usuário systemd tetherd que este usuário instalou
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Mostra o que o daemon está fazendo: dispositivos, conexões e transferências recentes."
+msgstr ""
+"Mostra o que o daemon está fazendo: dispositivos, conexões e transferências "
+"recentes."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
@@ -296,8 +301,7 @@ msgstr "Exemplos:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"Instalado %s\n"
+msgstr "Instalado %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -753,8 +757,7 @@ msgstr "A mensagem não foi enviada."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Não foi possível ler o estado do daemon.\n"
+msgstr "Não foi possível ler o estado do daemon.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -832,8 +835,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Nenhuma solicitação de pareamento aguardando.\n"
+msgstr "Nenhuma solicitação de pareamento aguardando.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -843,6 +845,17 @@ msgid ""
 msgstr ""
 "\n"
 "Aceite uma com: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"Esta máquina não tem systemd, então não há serviço de usuário a gerenciar. "
+"Inicie o tetherd com o que este sistema usa para serviços, ou deixe um "
+"cliente iniciá-lo quando for preciso.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -859,26 +872,26 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"O Tether não o habilita para você. Para iniciar o daemon agora e a cada login:\n"
+"O Tether não o habilita para você. Para iniciar o daemon agora e a cada "
+"login:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
 "\n"
-"Em um servidor do qual você faz logout, mantenha a sessão de usuário viva também:\n"
+"Em um servidor do qual você faz logout, mantenha a sessão de usuário viva "
+"também:\n"
 "\n"
 "loginctl enable-linger $USER\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"Nenhum serviço de usuário tetherd foi instalado para este usuário.\n"
+msgstr "Nenhum serviço de usuário tetherd foi instalado para este usuário.\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"Removido %s\n"
+msgstr "Removido %s\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -246,15 +246,21 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Записывает пользовательскую службу systemd tetherd для этого пользователя и выводит, как её включить. Нужно только для переносимых сборок; пакеты дистрибутива устанавливают её сами."
+msgstr ""
+"Записывает пользовательскую службу systemd tetherd для этого пользователя и "
+"выводит, как её включить. Нужно только для переносимых сборок; пакеты "
+"дистрибутива устанавливают её сами."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Удаляет пользовательскую службу systemd tetherd, установленную этим пользователем."
+msgstr ""
+"Удаляет пользовательскую службу systemd tetherd, установленную этим "
+"пользователем."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Показывает, чем занят демон: устройства, соединения и недавние передачи."
+msgstr ""
+"Показывает, чем занят демон: устройства, соединения и недавние передачи."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
@@ -295,8 +301,7 @@ msgstr "Примеры:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"Установлено %s\n"
+msgstr "Установлено %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -757,8 +762,7 @@ msgstr "Сообщение не отправлено."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Не удалось прочитать состояние демона.\n"
+msgstr "Не удалось прочитать состояние демона.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -836,8 +840,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Нет ожидающих запросов на сопряжение.\n"
+msgstr "Нет ожидающих запросов на сопряжение.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -847,6 +850,17 @@ msgid ""
 msgstr ""
 "\n"
 "Принять можно так: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"На этой машине нет systemd, поэтому нет пользовательской службы для "
+"управления. Запустите tetherd тем, что эта система использует для служб, или "
+"позвольте клиенту запустить его по требованию.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -863,12 +877,14 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether не включает её за вас. Чтобы запустить демона сейчас и при каждом входе:\n"
+"Tether не включает её за вас. Чтобы запустить демона сейчас и при каждом "
+"входе:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
 "\n"
-"На сервере, с которого вы выходите, также не давайте пользовательскому сеансу закрыться:\n"
+"На сервере, с которого вы выходите, также не давайте пользовательскому "
+"сеансу закрыться:\n"
 "\n"
 "loginctl enable-linger $USER\n"
 
@@ -881,8 +897,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"Удалено %s\n"
+msgstr "Удалено %s\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Russian\n"
@@ -243,6 +243,24 @@ msgstr ""
 "для переносимых сборок; пакеты дистрибутива устанавливают его сами."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Записывает пользовательскую службу systemd tetherd для этого пользователя и выводит, как её включить. Нужно только для переносимых сборок; пакеты дистрибутива устанавливают её сами."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Удаляет пользовательскую службу systemd tetherd, установленную этим пользователем."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Показывает, чем занят демон: устройства, соединения и недавние передачи."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Показывает запросы на сопряжение по Wi-Fi, ожидающие принятия."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Принять ожидающий запрос на сопряжение локально."
 
@@ -269,7 +287,8 @@ msgstr "Примеры:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Установлено: %s\n"
+msgstr ""
+"Установлено %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -468,12 +487,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Не удалось получить заряд AirPods от службы.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "AirPods не подключены.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Управление AirPods отключено.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "AirPods не подключены.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -727,6 +746,144 @@ msgstr "Отправлено в %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Сообщение не отправлено."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Не удалось прочитать состояние демона.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Версия"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Демон"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "работает"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Буфер обмена"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "синхронизируется"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "выключено, на этой машине нет сеанса Wayland"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "объявляет"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "недоступно"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Брандмауэр"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Сопряжённые устройства"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Ожидающие запросы"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Подключено сейчас"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "сопряжено"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "не сопряжено"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Недавно получено:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Выполните 'tether --pending', чтобы увидеть, что ожидает принятия.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Нет ожидающих запросов на сопряжение.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Принять можно так: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether не включает её за вас. Чтобы запустить демона сейчас и при каждом входе:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"На сервере, с которого вы выходите, также не давайте пользовательскому сеансу закрыться:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Для этого пользователя не установлена пользовательская служба tetherd.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"Удалено %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Выполните 'systemctl --user daemon-reload', чтобы systemd забыл о ней.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -242,6 +242,24 @@ msgstr ""
 "bara för portabla byggen; distributionspaketen installerar den själva."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Skriver systemd-användartjänsten tetherd för den här användaren och skriver ut hur den aktiveras. Behövs bara för portabla byggen; distributionspaketen installerar den själva."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Tar bort systemd-användartjänsten tetherd som den här användaren installerade."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Visar vad daemonen gör: enheter, anslutningar och senaste överföringar."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Listar de Wi-Fi-parkopplingsförfrågningar som väntar på att accepteras."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Godkänn en väntande parkopplingsförfrågan lokalt."
 
@@ -268,7 +286,8 @@ msgstr "Exempel:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Installerade %s\n"
+msgstr ""
+"%s installerad\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -461,12 +480,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Kunde inte läsa AirPods batterinivå från demonen.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Inga AirPods anslutna.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Hanteringen av AirPods är avstängd.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Inga AirPods anslutna.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -720,6 +739,144 @@ msgstr "Skickat till %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Meddelandet skickades inte."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Kunde inte läsa daemonens tillstånd.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Version"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Daemon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "körs"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Urklipp"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "synkroniseras"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "av, ingen Wayland-session på den här maskinen"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "annonserar"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "otillgängligt"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Brandvägg"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Parkopplade enheter"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Väntande förfrågningar"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Anslutna nu"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "parkopplad"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "inte parkopplad"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Nyligen mottagna:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Kör 'tether --pending' för att se vad som väntar på att accepteras.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Inga parkopplingsförfrågningar väntar.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Acceptera en med: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether aktiverar den inte åt dig. För att starta daemonen nu och vid varje inloggning:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"På en server du loggar ut från, håll även användarsessionen vid liv:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Ingen tetherd-användartjänst installerades för den här användaren.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"%s borttagen\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Kör 'systemctl --user daemon-reload' för att glömma den.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Swedish\n"
@@ -245,19 +245,26 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Skriver systemd-användartjänsten tetherd för den här användaren och skriver ut hur den aktiveras. Behövs bara för portabla byggen; distributionspaketen installerar den själva."
+msgstr ""
+"Skriver systemd-användartjänsten tetherd för den här användaren och skriver "
+"ut hur den aktiveras. Behövs bara för portabla byggen; distributionspaketen "
+"installerar den själva."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Tar bort systemd-användartjänsten tetherd som den här användaren installerade."
+msgstr ""
+"Tar bort systemd-användartjänsten tetherd som den här användaren "
+"installerade."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Visar vad daemonen gör: enheter, anslutningar och senaste överföringar."
+msgstr ""
+"Visar vad daemonen gör: enheter, anslutningar och senaste överföringar."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
-msgstr "Listar de Wi-Fi-parkopplingsförfrågningar som väntar på att accepteras."
+msgstr ""
+"Listar de Wi-Fi-parkopplingsförfrågningar som väntar på att accepteras."
 
 #: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
@@ -294,8 +301,7 @@ msgstr "Exempel:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"%s installerad\n"
+msgstr "%s installerad\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -750,8 +756,7 @@ msgstr "Meddelandet skickades inte."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Kunde inte läsa daemonens tillstånd.\n"
+msgstr "Kunde inte läsa daemonens tillstånd.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -829,8 +834,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Inga parkopplingsförfrågningar väntar.\n"
+msgstr "Inga parkopplingsförfrågningar väntar.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -840,6 +844,17 @@ msgid ""
 msgstr ""
 "\n"
 "Acceptera en med: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"Den här maskinen har inte systemd, så det finns ingen användartjänst att "
+"hantera. Starta tetherd med det som systemet använder för tjänster, eller låt "
+"en klient starta den vid behov.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -856,7 +871,8 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether aktiverar den inte åt dig. För att starta daemonen nu och vid varje inloggning:\n"
+"Tether aktiverar den inte åt dig. För att starta daemonen nu och vid varje "
+"inloggning:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
@@ -868,14 +884,12 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"Ingen tetherd-användartjänst installerades för den här användaren.\n"
+msgstr "Ingen tetherd-användartjänst installerades för den här användaren.\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"%s borttagen\n"
+msgstr "%s borttagen\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether 0.2.29\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -778,6 +778,14 @@ msgstr ""
 msgid ""
 "\n"
 "Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
 msgstr ""
 
 #: src/cli/main.cpp

--- a/po/tether.pot
+++ b/po/tether.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: tether 0.2.28\n"
+"Project-Id-Version: tether 0.2.29\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -221,6 +221,24 @@ msgid ""
 msgstr ""
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr ""
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr ""
 
@@ -420,11 +438,11 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr ""
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
+msgid "AirPods management is off.\n"
 msgstr ""
 
 #: src/cli/main.cpp
-msgid "AirPods management is off.\n"
+msgid "No AirPods connected.\n"
 msgstr ""
 
 #: src/cli/main.cpp
@@ -665,6 +683,125 @@ msgstr ""
 
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr ""
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
 msgstr ""
 
 #: src/cli/main.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -245,7 +245,10 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Bu kullanıcı için tetherd systemd kullanıcı hizmetini yazar ve nasıl etkinleştirileceğini gösterir. Yalnızca taşınabilir yapılar için gereklidir; dağıtım paketleri bunu kendisi kurar."
+msgstr ""
+"Bu kullanıcı için tetherd systemd kullanıcı hizmetini yazar ve nasıl "
+"etkinleştirileceğini gösterir. Yalnızca taşınabilir yapılar için gereklidir; "
+"dağıtım paketleri bunu kendisi kurar."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
@@ -253,7 +256,9 @@ msgstr "Bu kullanıcının kurduğu tetherd systemd kullanıcı hizmetini kaldı
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Arka plandaki sürecin ne yaptığını gösterir: cihazlar, bağlantılar ve son aktarımlar."
+msgstr ""
+"Arka plandaki sürecin ne yaptığını gösterir: cihazlar, bağlantılar ve son "
+"aktarımlar."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
@@ -294,8 +299,7 @@ msgstr "Örnekler:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"%s kuruldu\n"
+msgstr "%s kuruldu\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -751,8 +755,7 @@ msgstr "Mesaj gönderilmedi."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Arka plandaki tetherd sürecinin durumu okunamadı.\n"
+msgstr "Arka plandaki tetherd sürecinin durumu okunamadı.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -830,8 +833,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Bekleyen eşleştirme isteği yok.\n"
+msgstr "Bekleyen eşleştirme isteği yok.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -841,6 +843,17 @@ msgid ""
 msgstr ""
 "\n"
 "Birini şununla kabul edin: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"Bu makinede systemd yok, dolayısıyla yönetilecek bir kullanıcı servisi de yok. "
+"tetherd'i bu sistemin servisler için kullandığı şeyle başlatın ya da bir "
+"istemcinin gerektiğinde başlatmasına izin verin.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -857,7 +870,8 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether bunu sizin için etkinleştirmez. Süreci şimdi ve her oturum açışta başlatmak için:\n"
+"Tether bunu sizin için etkinleştirmez. Süreci şimdi ve her oturum açışta "
+"başlatmak için:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
@@ -869,14 +883,12 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"Bu kullanıcı için kurulmuş bir tetherd kullanıcı hizmeti yok.\n"
+msgstr "Bu kullanıcı için kurulmuş bir tetherd kullanıcı hizmeti yok.\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"%s kaldırıldı\n"
+msgstr "%s kaldırıldı\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Turkish\n"
@@ -242,6 +242,24 @@ msgstr ""
 "taşınabilir yapılar için gereklidir; dağıtım paketleri onu kendisi kurar."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Bu kullanıcı için tetherd systemd kullanıcı hizmetini yazar ve nasıl etkinleştirileceğini gösterir. Yalnızca taşınabilir yapılar için gereklidir; dağıtım paketleri bunu kendisi kurar."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Bu kullanıcının kurduğu tetherd systemd kullanıcı hizmetini kaldırır."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Arka plandaki sürecin ne yaptığını gösterir: cihazlar, bağlantılar ve son aktarımlar."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Kabul edilmeyi bekleyen Wi-Fi eşleştirme isteklerini listeler."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Bekleyen bir eşleşme isteğini yerel olarak kabul et."
 
@@ -268,7 +286,8 @@ msgstr "Örnekler:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Kuruldu: %s\n"
+msgstr ""
+"%s kuruldu\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -462,12 +481,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "AirPods pil durumu arka plan hizmetinden okunamadı.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "Bağlı AirPods yok.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods yönetimi kapalı.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "Bağlı AirPods yok.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -721,6 +740,144 @@ msgstr "%s adresine gönderildi\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Mesaj gönderilmedi."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Arka plandaki tetherd sürecinin durumu okunamadı.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Sürüm"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Daemon"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "çalışıyor"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Pano"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "eşitleniyor"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "kapalı, bu makinede Wayland oturumu yok"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "yayınlanıyor"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "kullanılamıyor"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Güvenlik duvarı"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Eşleştirilmiş cihazlar"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Bekleyen istekler"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Şu an bağlı"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "eşleştirildi"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "eşleştirilmedi"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Son alınanlar:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Kabul edilmeyi bekleyenleri görmek için 'tether --pending' çalıştırın.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Bekleyen eşleştirme isteği yok.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Birini şununla kabul edin: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether bunu sizin için etkinleştirmez. Süreci şimdi ve her oturum açışta başlatmak için:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"Oturumu kapattığınız bir sunucuda, kullanıcı oturumunu da canlı tutun:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Bu kullanıcı için kurulmuş bir tetherd kullanıcı hizmeti yok.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"%s kaldırıldı\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Unutturmak için 'systemctl --user daemon-reload' çalıştırın.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -247,15 +247,20 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "Записує службу користувача systemd tetherd для цього користувача та виводить, як її увімкнути. Потрібно лише для портативних збірок; пакунки дистрибутива встановлюють її самі."
+msgstr ""
+"Записує службу користувача systemd tetherd для цього користувача та "
+"виводить, як її увімкнути. Потрібно лише для портативних збірок; пакунки "
+"дистрибутива встановлюють її самі."
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
-msgstr "Вилучає службу користувача systemd tetherd, яку встановив цей користувач."
+msgstr ""
+"Вилучає службу користувача systemd tetherd, яку встановив цей користувач."
 
 #: src/cli/main.cpp
 msgid "Show what the daemon is doing: devices, links, and recent transfers."
-msgstr "Показує, що робить демон: пристрої, з'єднання та нещодавні передавання."
+msgstr ""
+"Показує, що робить демон: пристрої, з'єднання та нещодавні передавання."
 
 #: src/cli/main.cpp
 msgid "List Wi-Fi pairing requests waiting to be accepted."
@@ -296,8 +301,7 @@ msgstr "Приклади:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"Встановлено %s\n"
+msgstr "Встановлено %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -758,8 +762,7 @@ msgstr "Повідомлення не надіслано."
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"Не вдалося прочитати стан демона.\n"
+msgstr "Не вдалося прочитати стан демона.\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -837,8 +840,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"Немає запитів на спарення в очікуванні.\n"
+msgstr "Немає запитів на спарення в очікуванні.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -848,6 +850,17 @@ msgid ""
 msgstr ""
 "\n"
 "Прийняти можна так: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"На цій машині немає systemd, тож немає користувацької служби для керування. "
+"Запустіть tetherd тим, що ця система використовує для служб, або дозвольте "
+"клієнту запустити його на вимогу.\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -864,26 +877,26 @@ msgid ""
 "loginctl enable-linger $USER\n"
 msgstr ""
 "\n"
-"Tether не вмикає її за вас. Щоб запустити демона зараз і під час кожного входу:\n"
+"Tether не вмикає її за вас. Щоб запустити демона зараз і під час кожного "
+"входу:\n"
 "\n"
 "systemctl --user daemon-reload\n"
 "systemctl --user enable --now tetherd.service\n"
 "\n"
-"На сервері, з якого ви виходите, також підтримуйте сеанс користувача активним:\n"
+"На сервері, з якого ви виходите, також підтримуйте сеанс користувача "
+"активним:\n"
 "\n"
 "loginctl enable-linger $USER\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"Для цього користувача не встановлено службу користувача tetherd.\n"
+msgstr "Для цього користувача не встановлено службу користувача tetherd.\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"Вилучено %s\n"
+msgstr "Вилучено %s\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Ukrainian\n"
@@ -244,6 +244,24 @@ msgstr ""
 "переносних збірок; пакунки дистрибутива встановлюють його самі."
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "Записує службу користувача systemd tetherd для цього користувача та виводить, як її увімкнути. Потрібно лише для портативних збірок; пакунки дистрибутива встановлюють її самі."
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "Вилучає службу користувача systemd tetherd, яку встановив цей користувач."
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "Показує, що робить демон: пристрої, з'єднання та нещодавні передавання."
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "Показує запити на спарення через Wi-Fi, які очікують на прийняття."
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "Прийняти локально запит на створення пари, що очікує."
 
@@ -270,7 +288,8 @@ msgstr "Приклади:"
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "Встановлено: %s\n"
+msgstr ""
+"Встановлено %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -469,12 +488,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "Не вдалося отримати заряд AirPods від служби.\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "AirPods не під'єднано.\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "Керування AirPods вимкнено.\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "AirPods не під'єднано.\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -728,6 +747,144 @@ msgstr "Надіслано до %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "Повідомлення не надіслано."
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"Не вдалося прочитати стан демона.\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "Версія"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "Демон"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "працює"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "Буфер обміну"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "синхронізується"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "вимкнено, на цій машині немає сеансу Wayland"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "оголошує"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "недоступно"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "Брандмауер"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "Спарені пристрої"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "Запити в очікуванні"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "Підключено зараз"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "спарено"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "не спарено"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "Нещодавно отримано:"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"Виконайте 'tether --pending', щоб побачити, що очікує на прийняття.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"Немає запитів на спарення в очікуванні.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"Прийняти можна так: tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether не вмикає її за вас. Щоб запустити демона зараз і під час кожного входу:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"На сервері, з якого ви виходите, також підтримуйте сеанс користувача активним:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"Для цього користувача не встановлено службу користувача tetherd.\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"Вилучено %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"Виконайте 'systemctl --user daemon-reload', щоб systemd забув про неї.\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-10 07:12+0000\n"
+"POT-Creation-Date: 2026-09-10 09:25-0700\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -234,7 +234,9 @@ msgstr ""
 msgid ""
 "Write the tetherd systemd user service for this user, and print how to "
 "enable it. Needed only for portable builds; the distro packages install it."
-msgstr "为此用户写入 tetherd systemd 用户服务，并打印启用方法。仅便携版构建需要；发行版软件包会自行安装。"
+msgstr ""
+"为此用户写入 tetherd systemd 用户服务，并打印启用方法。仅便携版构建需要；发行"
+"版软件包会自行安装。"
 
 #: src/cli/main.cpp
 msgid "Remove the tetherd systemd user service this user installed."
@@ -283,8 +285,7 @@ msgstr "示例："
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr ""
-"已安装 %s\n"
+msgstr "已安装 %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -727,8 +728,7 @@ msgstr "信息未发送。"
 
 #: src/cli/main.cpp
 msgid "Could not read the daemon's state.\n"
-msgstr ""
-"无法读取守护进程的状态。\n"
+msgstr "无法读取守护进程的状态。\n"
 
 #: src/cli/main.cpp
 msgid "Version"
@@ -806,8 +806,7 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No pairing requests are waiting.\n"
-msgstr ""
-"没有等待中的配对请求。\n"
+msgstr "没有等待中的配对请求。\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -817,6 +816,16 @@ msgid ""
 msgstr ""
 "\n"
 "使用以下命令接受：tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"No systemd on this machine, so there is no user service to manage. Start "
+"tetherd from whatever this system uses for services, or let a client start "
+"it on demand.\n"
+msgstr ""
+"本机没有 systemd，因此没有可管理的用户服务。请用本系统管理服务的方式启动 "
+"tetherd，或者让客户端在需要时启动它。\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -845,14 +854,12 @@ msgstr ""
 #: src/cli/main.cpp
 #, c-format
 msgid "No tetherd user service was installed for this user.\n"
-msgstr ""
-"未为此用户安装 tetherd 用户服务。\n"
+msgstr "未为此用户安装 tetherd 用户服务。\n"
 
 #: src/cli/main.cpp
 #, c-format
 msgid "Removed %s\n"
-msgstr ""
-"已移除 %s\n"
+msgstr "已移除 %s\n"
 
 #: src/cli/main.cpp
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tether\n"
 "Report-Msgid-Bugs-To: zack@bartel.com\n"
-"POT-Creation-Date: 2026-09-09 20:19-0700\n"
+"POT-Creation-Date: 2026-09-10 07:12+0000\n"
 "PO-Revision-Date: 2026-08-23\n"
 "Last-Translator: Tether project\n"
 "Language-Team: Simplified Chinese\n"
@@ -231,6 +231,24 @@ msgstr ""
 "root，且从不启用它。仅便携式构建需要；发行版软件包会自行安装。"
 
 #: src/cli/main.cpp
+msgid ""
+"Write the tetherd systemd user service for this user, and print how to "
+"enable it. Needed only for portable builds; the distro packages install it."
+msgstr "为此用户写入 tetherd systemd 用户服务，并打印启用方法。仅便携版构建需要；发行版软件包会自行安装。"
+
+#: src/cli/main.cpp
+msgid "Remove the tetherd systemd user service this user installed."
+msgstr "移除此用户安装的 tetherd systemd 用户服务。"
+
+#: src/cli/main.cpp
+msgid "Show what the daemon is doing: devices, links, and recent transfers."
+msgstr "显示守护进程正在做什么：设备、连接和最近的传输。"
+
+#: src/cli/main.cpp
+msgid "List Wi-Fi pairing requests waiting to be accepted."
+msgstr "列出等待接受的 Wi-Fi 配对请求。"
+
+#: src/cli/main.cpp
 msgid "Accept a pending pairing request locally."
 msgstr "在本地接受待处理的配对请求。"
 
@@ -257,7 +275,8 @@ msgstr "示例："
 #: src/cli/main.cpp
 #, c-format
 msgid "Installed %s\n"
-msgstr "已安装 %s\n"
+msgstr ""
+"已安装 %s\n"
 
 #: src/cli/main.cpp
 #, c-format
@@ -443,12 +462,12 @@ msgid "Could not read the AirPods battery from the daemon.\n"
 msgstr "无法从守护进程读取 AirPods 电量。\n"
 
 #: src/cli/main.cpp
-msgid "No AirPods connected.\n"
-msgstr "未连接 AirPods。\n"
-
-#: src/cli/main.cpp
 msgid "AirPods management is off.\n"
 msgstr "AirPods 管理已关闭。\n"
+
+#: src/cli/main.cpp
+msgid "No AirPods connected.\n"
+msgstr "未连接 AirPods。\n"
 
 #: src/cli/main.cpp
 msgid "Left"
@@ -697,6 +716,144 @@ msgstr "已发送至 %s\n"
 #: src/cli/main.cpp src/gtk/messages_view.cpp
 msgid "The message was not sent."
 msgstr "信息未发送。"
+
+#: src/cli/main.cpp
+msgid "Could not read the daemon's state.\n"
+msgstr ""
+"无法读取守护进程的状态。\n"
+
+#: src/cli/main.cpp
+msgid "Version"
+msgstr "版本"
+
+#: src/cli/main.cpp
+msgid "Daemon"
+msgstr "守护进程"
+
+#: src/cli/main.cpp
+msgid "running"
+msgstr "运行中"
+
+#: src/cli/main.cpp
+msgid "Clipboard"
+msgstr "剪贴板"
+
+#: src/cli/main.cpp
+msgid "syncing"
+msgstr "同步中"
+
+#: src/cli/main.cpp
+msgid "off, no Wayland session on this machine"
+msgstr "已关闭，此机器上没有 Wayland 会话"
+
+#: src/cli/main.cpp
+msgid "mDNS"
+msgstr "mDNS"
+
+#: src/cli/main.cpp
+msgid "advertising"
+msgstr "正在广播"
+
+#: src/cli/main.cpp
+msgid "unavailable"
+msgstr "不可用"
+
+#: src/cli/main.cpp
+msgid "Firewall"
+msgstr "防火墙"
+
+#: src/cli/main.cpp
+msgid "Paired devices"
+msgstr "已配对设备"
+
+#: src/cli/main.cpp
+msgid "Pending requests"
+msgstr "待处理请求"
+
+#: src/cli/main.cpp
+msgid "Connected now"
+msgstr "当前连接"
+
+#: src/cli/main.cpp
+msgid "paired"
+msgstr "已配对"
+
+#: src/cli/main.cpp
+msgid "unpaired"
+msgstr "未配对"
+
+#: src/cli/main.cpp
+msgid "Recently received:"
+msgstr "最近接收："
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'tether --pending' to see what is waiting to be accepted.\n"
+msgstr ""
+"\n"
+"运行 'tether --pending' 查看有哪些请求正在等待接受。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No pairing requests are waiting.\n"
+msgstr ""
+"没有等待中的配对请求。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Accept one with: tether --accept <fingerprint>\n"
+msgstr ""
+"\n"
+"使用以下命令接受：tether --accept <fingerprint>\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Tether does not enable it for you. To start the daemon now and on every "
+"login:\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"On a server you log out of, keep the user session alive too:\n"
+"\n"
+"loginctl enable-linger $USER\n"
+msgstr ""
+"\n"
+"Tether 不会替你启用它。要立即启动守护进程并在每次登录时启动：\n"
+"\n"
+"systemctl --user daemon-reload\n"
+"systemctl --user enable --now tetherd.service\n"
+"\n"
+"在你会登出的服务器上，也请保持用户会话存活：\n"
+"\n"
+"loginctl enable-linger $USER\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "No tetherd user service was installed for this user.\n"
+msgstr ""
+"未为此用户安装 tetherd 用户服务。\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid "Removed %s\n"
+msgstr ""
+"已移除 %s\n"
+
+#: src/cli/main.cpp
+#, c-format
+msgid ""
+"\n"
+"Run 'systemctl --user daemon-reload' to forget it.\n"
+msgstr ""
+"\n"
+"运行 'systemctl --user daemon-reload' 使其被忘记。\n"
 
 #: src/cli/main.cpp
 msgid "--port expects a number.\n"

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1186,7 +1186,21 @@ static int print_pending(tether::Client& client) {
     return 0;
 }
 
+// systemd is what runs the unit, so writing one where there is no systemd would
+// leave a dead file and instructions that go nowhere.
+static bool has_systemd() {
+    if (!tether::which_program("systemctl").empty())
+        return true;
+    fprintf(stdout,
+            _("No systemd on this machine, so there is no user service to manage. Start tetherd from "
+              "whatever this system uses for services, or let a client start it on demand.\n"));
+    return false;
+}
+
 static int install_service() {
+    if (!has_systemd())
+        return 1;
+
     const auto result = tether::install_tetherd_service();
 
     for (const auto& err : result.errors)
@@ -1205,6 +1219,9 @@ static int install_service() {
 }
 
 static int uninstall_service() {
+    if (!has_systemd())
+        return 1;
+
     const auto result = tether::uninstall_tetherd_service();
 
     for (const auto& err : result.errors)

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -20,6 +20,7 @@
 #include <tether/i18n.hpp>
 #include <tether/log.hpp>
 #include <tether/packaging.hpp>
+#include <tether/service.hpp>
 #include <tether/version.hpp>
 #include <thread>
 #include <unistd.h>
@@ -233,6 +234,12 @@ static const Opt kOptions[] = {
     {"--install-btclass-unit",
      N_("Write the tether-btclass@.service unit, which sets the Bluetooth adapter class iOS requires. Needs "
         "root, and never enables it. Needed only for portable builds; the distro packages install it.")},
+    {"--install-service",
+     N_("Write the tetherd systemd user service for this user, and print how to enable it. Needed only for "
+        "portable builds; the distro packages install it.")},
+    {"--uninstall-service", N_("Remove the tetherd systemd user service this user installed.")},
+    {"--status", N_("Show what the daemon is doing: devices, links, and recent transfers.")},
+    {"--pending", N_("List Wi-Fi pairing requests waiting to be accepted.")},
     {"--accept <fingerprint>", N_("Accept a pending pairing request locally.")},
     {"--forget <fingerprint>", N_("Remove a Wi-Fi pairing and drop its session.")},
     {"--pair", N_("Send a pair_request over TCP to the daemon.")},
@@ -1048,6 +1055,127 @@ static int send_bt_message(tether::Client& client, const std::string& thread, co
     }
 }
 
+// The daemon answers one request at a time here, but be strict about it: parse
+// the first line only, so a stray broadcast cannot turn into a parse error.
+static nlohmann::json parse_first_line(const std::string& response) {
+    const auto newline = response.find('\n');
+    return nlohmann::json::parse(newline == std::string::npos ? response : response.substr(0, newline));
+}
+
+static nlohmann::json state_snapshot(tether::Client& client) {
+    return parse_first_line(client.send_and_wait("{\"command\":\"state_snapshot\"}\n"));
+}
+
+static int print_status(tether::Client& client) {
+    nlohmann::json snap;
+    try {
+        snap = state_snapshot(client);
+    } catch (const std::exception&) {
+        debug::log(ERR, _("Could not read the daemon's state.\n"));
+        return 1;
+    }
+
+    // Defaults rather than lookups: a daemon that predates a field should
+    // still give a readable status.
+    const auto paired = snap.value("paired_devices", nlohmann::json::array());
+    const auto pending = snap.value("pending_pairs", nlohmann::json::array());
+    const auto clients = snap.value("connected_clients", nlohmann::json::array());
+
+    std::vector<Field> fields;
+    fields.emplace_back(_("Version"), tether::get_version());
+    fields.emplace_back(_("Daemon"), _("running"));
+    fields.emplace_back(_("Clipboard"),
+                        snap.value("clipboard_available", false) ? _("syncing")
+                                                                 : _("off, no Wayland session on this machine"));
+    fields.emplace_back(_("mDNS"), snap.value("mdns_available", false) ? _("advertising") : _("unavailable"));
+    fields.emplace_back(_("Firewall"), yn(snap.value("firewall_active", false)));
+    fields.emplace_back(_("Paired devices"), std::to_string(paired.size()));
+    fields.emplace_back(_("Pending requests"), std::to_string(pending.size()));
+    fields.emplace_back(_("Connected now"), std::to_string(clients.size()));
+    print_fields(fields);
+
+    for (const auto& c : clients) {
+        fprintf(stdout,
+                "\n  %s  %s  %s\n",
+                c.value("device_name", "?").c_str(),
+                c.value("address", "?").c_str(),
+                c.value("paired", false) ? _("paired") : _("unpaired"));
+    }
+
+    const auto files = snap.value("recent_received_files", nlohmann::json::array());
+    if (!files.empty()) {
+        fprintf(stdout, "\n%s\n", _("Recently received:"));
+        for (const auto& f : files)
+            fprintf(stdout, "  %s\n", f.value("path", "").c_str());
+    }
+
+    // The count is already a field above, so this only says what to do about it.
+    if (!pending.empty())
+        fprintf(stdout, _("\nRun 'tether --pending' to see what is waiting to be accepted.\n"));
+
+    return 0;
+}
+
+// The headless half of pairing: with no GTK app to show the prompt, this is how
+// a request is seen before 'tether --accept' takes it.
+static int print_pending(tether::Client& client) {
+    nlohmann::json snap;
+    try {
+        snap = state_snapshot(client);
+    } catch (const std::exception&) {
+        debug::log(ERR, _("Could not read the daemon's state.\n"));
+        return 1;
+    }
+
+    const auto pending = snap.value("pending_pairs", nlohmann::json::array());
+    if (pending.empty()) {
+        fprintf(stdout, _("No pairing requests are waiting.\n"));
+        return 0;
+    }
+
+    for (const auto& item : pending)
+        fprintf(stdout, "  %-20s  %s\n", item.value("device_name", "?").c_str(), item.value("fingerprint", "").c_str());
+
+    fprintf(stdout, _("\nAccept one with: tether --accept <fingerprint>\n"));
+    return 0;
+}
+
+static int install_service() {
+    const auto result = tether::install_tetherd_service();
+
+    for (const auto& err : result.errors)
+        debug::log(ERR, "{}\n", err);
+    if (!result.errors.empty())
+        return 1;
+
+    fprintf(stdout, _("Installed %s\n"), result.path.c_str());
+    fprintf(stdout,
+            _("\nTether does not enable it for you. To start the daemon now and on every login:\n\n"
+              "systemctl --user daemon-reload\n"
+              "systemctl --user enable --now tetherd.service\n\n"
+              "On a server you log out of, keep the user session alive too:\n\n"
+              "loginctl enable-linger $USER\n"));
+    return 0;
+}
+
+static int uninstall_service() {
+    const auto result = tether::uninstall_tetherd_service();
+
+    for (const auto& err : result.errors)
+        debug::log(ERR, "{}\n", err);
+    if (!result.errors.empty())
+        return 1;
+
+    if (!result.changed) {
+        fprintf(stdout, _("No tetherd user service was installed for this user.\n"));
+        return 0;
+    }
+
+    fprintf(stdout, _("Removed %s\n"), result.path.c_str());
+    fprintf(stdout, _("\nRun 'systemctl --user daemon-reload' to forget it.\n"));
+    return 0;
+}
+
 int main(int argc, char* argv[]) {
     tether::init_locale();
 
@@ -1079,6 +1207,14 @@ int main(int argc, char* argv[]) {
             action = "install_extension_host";
         } else if (arg == "--install-btclass-unit") {
             action = "install_btclass_unit";
+        } else if (arg == "--install-service") {
+            action = "install_service";
+        } else if (arg == "--uninstall-service") {
+            action = "uninstall_service";
+        } else if (arg == "--status") {
+            action = "status";
+        } else if (arg == "--pending") {
+            action = "pending";
         } else if (arg == "--bt-setup") {
             action = "bt_setup";
         } else if (arg == "--bt-status") {
@@ -1228,6 +1364,12 @@ int main(int argc, char* argv[]) {
     if (action == "install_btclass_unit")
         return install_btclass_unit();
 
+    if (action == "install_service")
+        return install_service();
+
+    if (action == "uninstall_service")
+        return uninstall_service();
+
     tether::Client client;
 
     // Fast-path local operations that don't need active daemon connection fundamentally
@@ -1282,6 +1424,12 @@ int main(int argc, char* argv[]) {
               "broken?\n"));
         return 1;
     }
+
+    if (action == "status")
+        return print_status(client);
+
+    if (action == "pending")
+        return print_pending(client);
 
     std::string err;
     if (action == "accept") {

--- a/src/cli/verbs.cpp
+++ b/src/cli/verbs.cpp
@@ -3,7 +3,9 @@
 namespace tether::cli {
 
     const Verb kVerbs[] = {
+        {"status", "--status", "tether status"},
         {"devices", "--list-devices", "tether devices"},
+        {"pending", "--pending", "tether pending"},
         {"accept", "--accept", "tether accept <fingerprint>"},
         {"forget", "--forget", "tether forget <fingerprint>"},
         {"pair", "--pair", "tether pair --host <ip>"},
@@ -11,6 +13,7 @@ namespace tether::cli {
         {"send", "--send-file", "tether send <path>"},
         {"copy", "--set-clipboard", "tether copy [text]"},
         {"paste", "--get-clipboard", "tether paste"},
+        {"service", "--install-service", "tether service"},
         {"version", "--version", "tether version"},
         {"help", "--help", "tether help"},
     };

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(tether STATIC
     src/secret_store.cpp
     src/client.cpp
     src/extension_host.cpp
+    src/service.cpp
     src/discovery.cpp
     src/mpris.cpp
     src/audio.cpp

--- a/src/core/include/tether/packaging.hpp.in
+++ b/src/core/include/tether/packaging.hpp.in
@@ -4,6 +4,7 @@
 // (AppImage) cannot, so they are embedded here and written out at runtime.
 namespace tether::packaging {
 
+    inline constexpr const char* TETHERD_UNIT = R"TETHER(@TETHERD_UNIT@)TETHER";
     inline constexpr const char* BTCLASS_UNIT = R"TETHER(@BTCLASS_UNIT@)TETHER";
     inline constexpr const char* NATIVE_HOST_MANIFEST_CHROME = R"TETHER(@CHROME_MANIFEST@)TETHER";
     inline constexpr const char* NATIVE_HOST_MANIFEST_MOZILLA = R"TETHER(@MOZILLA_MANIFEST@)TETHER";

--- a/src/core/include/tether/service.hpp
+++ b/src/core/include/tether/service.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace tether {
+
+    // The application id flatpak uses in the running sandbox, empty outside one.
+    std::string flatpak_app_id();
+
+    // Absolute path of a program on PATH, empty when it is not there.
+    std::string which_program(const std::string& name);
+
+    // ExecStart= line for the systemd unit: an absolute program and its
+    // arguments, pointed at the tetherd this build would start. systemd runs no
+    // shell, so this is never quoted for one.
+    std::string tetherd_exec_command();
+
+    // The user unit with its ExecStart filled in.
+    std::string render_tetherd_unit(const std::string& exec_command);
+
+    struct ServiceInstall {
+        std::string path; // unit written, or the one that was removed
+        std::vector<std::string> errors;
+        bool changed = false; // a file was written or removed
+    };
+
+    // Writes the tetherd user unit into $XDG_CONFIG_HOME/systemd/user. Needed by
+    // portable builds, which cannot write the system directory the distro
+    // packages install into. Never enables or starts anything: that is the
+    // user's call, and 'tether --install-service' prints the commands.
+    ServiceInstall install_tetherd_service(const std::filesystem::path& config_dir);
+    ServiceInstall install_tetherd_service();
+
+    // Removes the unit this user's install wrote, if it is there.
+    ServiceInstall uninstall_tetherd_service(const std::filesystem::path& config_dir);
+    ServiceInstall uninstall_tetherd_service();
+
+} // namespace tether

--- a/src/core/src/client.cpp
+++ b/src/core/src/client.cpp
@@ -6,6 +6,7 @@
 #include <arpa/inet.h>
 #include <atomic>
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -58,7 +59,28 @@ namespace tether {
         return Crypto::get_peer_fingerprint(ssl_);
     }
 
+    // systemd owns the daemon once its user unit is enabled, and the wants
+    // symlink is what 'systemctl --user enable' writes. Spawning our own tetherd
+    // alongside it leaves an orphan holding the TCP listener, which the unit then
+    // cannot bind, so it would restart into the failure until systemd gives up.
+    static bool systemd_owns_tetherd() {
+        std::filesystem::path config;
+        if (const char* config_home = std::getenv("XDG_CONFIG_HOME"); config_home && *config_home == '/')
+            config = config_home;
+        else if (const char* home = std::getenv("HOME"); home && *home)
+            config = std::filesystem::path(home) / ".config";
+        else
+            return false;
+
+        std::error_code ec;
+        return std::filesystem::exists(config / "systemd/user/default.target.wants/tetherd.service", ec);
+    }
+
     void spawn_daemon() {
+        // Let systemd start it, and stay out of the way when it already does.
+        if (systemd_owns_tetherd())
+            return;
+
         // everything the child needs is resolved before the fork
         std::filesystem::path self_path = std::filesystem::read_symlink("/proc/self/exe");
         const std::string sibling = (self_path.parent_path() / "tetherd").string();

--- a/src/core/src/service.cpp
+++ b/src/core/src/service.cpp
@@ -1,0 +1,171 @@
+#include "tether/service.hpp"
+#include "tether/packaging.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <unistd.h>
+
+namespace tether {
+
+    namespace {
+
+        namespace fs = std::filesystem;
+
+        // The token render_tetherd_unit() replaces. CMake leaves it in the
+        // embedded copy of the unit; the copy the distro packages install has
+        // the real path already.
+        constexpr const char* EXEC_TOKEN = "__TETHERD_EXEC__";
+
+        bool write_file(const fs::path& path, const std::string& content, std::string& err) {
+            std::error_code ec;
+            fs::create_directories(path.parent_path(), ec);
+            if (ec) {
+                err = path.parent_path().string() + ": " + ec.message();
+                return false;
+            }
+
+            std::ofstream out(path, std::ios::trunc);
+            if (!out.is_open()) {
+                err = path.string() + ": cannot open for writing";
+                return false;
+            }
+            out << content;
+            if (!out) {
+                err = path.string() + ": write failed";
+                return false;
+            }
+            return true;
+        }
+
+        fs::path user_config_dir() {
+            const char* config_home = std::getenv("XDG_CONFIG_HOME");
+            if (config_home && *config_home == '/')
+                return fs::path(config_home);
+
+            const char* home = std::getenv("HOME");
+            if (!home || !*home)
+                return {};
+            return fs::path(home) / ".config";
+        }
+
+    } // namespace
+
+    std::string flatpak_app_id() {
+        std::ifstream in("/.flatpak-info");
+        if (!in.is_open())
+            return {};
+        for (std::string line; std::getline(in, line);) {
+            if (line.rfind("name=", 0) == 0)
+                return line.substr(5);
+        }
+        return {};
+    }
+
+    std::string which_program(const std::string& name) {
+        const char* path = std::getenv("PATH");
+        if (!path || !*path)
+            path = "/usr/local/bin:/usr/bin:/bin";
+
+        std::istringstream parts(path);
+        std::string dir;
+        std::error_code ec;
+        while (std::getline(parts, dir, ':')) {
+            if (dir.empty())
+                continue;
+            const fs::path candidate = fs::path(dir) / name;
+            if (fs::is_regular_file(candidate, ec) && ::access(candidate.c_str(), X_OK) == 0)
+                return candidate.string();
+        }
+        return {};
+    }
+
+    std::string tetherd_exec_command() {
+        if (const char* appimage = std::getenv("APPIMAGE"); appimage && *appimage)
+            return std::string(appimage) + " --daemon";
+
+        if (const std::string app_id = flatpak_app_id(); !app_id.empty()) {
+            const std::string flatpak = which_program("flatpak");
+            return (flatpak.empty() ? "/usr/bin/flatpak" : flatpak) + " run --command=tetherd " + app_id;
+        }
+
+        std::error_code ec;
+        const fs::path self = fs::read_symlink("/proc/self/exe", ec);
+        if (!ec) {
+            const fs::path sibling = self.parent_path() / "tetherd";
+            if (fs::is_regular_file(sibling, ec))
+                return sibling.string();
+        }
+
+        const std::string found = which_program("tetherd");
+        return found.empty() ? "/usr/bin/tetherd" : found;
+    }
+
+    std::string render_tetherd_unit(const std::string& exec_command) {
+        std::string unit = packaging::TETHERD_UNIT;
+        const auto at = unit.find(EXEC_TOKEN);
+        if (at != std::string::npos)
+            unit.replace(at, std::strlen(EXEC_TOKEN), exec_command);
+        return unit;
+    }
+
+    ServiceInstall install_tetherd_service(const fs::path& config_dir) {
+        ServiceInstall result;
+        if (config_dir.empty()) {
+            result.errors.push_back("No config directory to write the unit into.");
+            return result;
+        }
+
+        const fs::path unit = config_dir / "systemd" / "user" / "tetherd.service";
+        result.path = unit.string();
+
+        std::string err;
+        if (!write_file(unit, render_tetherd_unit(tetherd_exec_command()), err)) {
+            result.errors.push_back(err);
+            return result;
+        }
+
+        result.changed = true;
+        return result;
+    }
+
+    ServiceInstall install_tetherd_service() {
+        const fs::path config = user_config_dir();
+        if (config.empty()) {
+            ServiceInstall result;
+            result.errors.push_back("No $HOME, so there is nowhere to write the unit.");
+            return result;
+        }
+        return install_tetherd_service(config);
+    }
+
+    ServiceInstall uninstall_tetherd_service(const fs::path& config_dir) {
+        ServiceInstall result;
+        if (config_dir.empty())
+            return result;
+
+        const fs::path unit = config_dir / "systemd" / "user" / "tetherd.service";
+        result.path = unit.string();
+
+        std::error_code ec;
+        if (!fs::exists(unit, ec))
+            return result;
+
+        if (!fs::remove(unit, ec)) {
+            result.errors.push_back(unit.string() + ": " + ec.message());
+            return result;
+        }
+
+        result.changed = true;
+        return result;
+    }
+
+    ServiceInstall uninstall_tetherd_service() {
+        const fs::path config = user_config_dir();
+        if (config.empty())
+            return {};
+        return uninstall_tetherd_service(config);
+    }
+
+} // namespace tether

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(tether_test
     test_otp.cpp
     test_paths.cpp
     test_message_format.cpp
+    test_service.cpp
     ../src/gtk/message_format.cpp
 )
 

--- a/test/test_service.cpp
+++ b/test/test_service.cpp
@@ -1,0 +1,83 @@
+#include "scoped_env.hpp"
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <tether/service.hpp>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+    class ServiceTest : public ::testing::Test {
+    protected:
+        void SetUp() override { fs::create_directories(config_); }
+
+        void TearDown() override {
+            std::error_code ec;
+            fs::remove_all(root_, ec);
+        }
+
+        const fs::path root_ =
+            fs::temp_directory_path() / ("tether-service-" + std::to_string(::getpid()) + "-" +
+                                         ::testing::UnitTest::GetInstance()->current_test_info()->name());
+        const fs::path config_ = root_ / "config";
+        const fs::path unit_ = config_ / "systemd/user/tetherd.service";
+    };
+
+    std::string read(const fs::path& path) {
+        std::ifstream in(path);
+        return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+    }
+
+} // namespace
+
+TEST_F(ServiceTest, RenderTetherdUnitFillsInExecStart) {
+    const std::string unit = tether::render_tetherd_unit("/usr/bin/tetherd");
+
+    EXPECT_NE(unit.find("ExecStart=/usr/bin/tetherd"), std::string::npos) << unit;
+    EXPECT_EQ(unit.find("__TETHERD_EXEC__"), std::string::npos) << unit;
+    EXPECT_NE(unit.find("WantedBy=default.target"), std::string::npos) << unit;
+}
+
+TEST_F(ServiceTest, InstallWritesTheUnitAndUninstallTakesItBack) {
+    const auto installed = tether::install_tetherd_service(config_);
+
+    ASSERT_TRUE(installed.errors.empty()) << installed.errors.front();
+    EXPECT_TRUE(installed.changed);
+    EXPECT_EQ(installed.path, unit_.string());
+    ASSERT_TRUE(fs::exists(unit_));
+    EXPECT_NE(read(unit_).find("ExecStart="), std::string::npos);
+
+    const auto removed = tether::uninstall_tetherd_service(config_);
+    EXPECT_TRUE(removed.errors.empty());
+    EXPECT_TRUE(removed.changed);
+    EXPECT_FALSE(fs::exists(unit_));
+}
+
+TEST_F(ServiceTest, UninstallingWhatWasNeverInstalledIsNotAnError) {
+    const auto removed = tether::uninstall_tetherd_service(config_);
+
+    EXPECT_TRUE(removed.errors.empty());
+    EXPECT_FALSE(removed.changed);
+}
+
+TEST_F(ServiceTest, ExecStartPointsAtTheAppImageWhenRunningFromOne) {
+    const tether::testing::ScopedEnv appimage("APPIMAGE", std::string("/opt/tether.AppImage"));
+
+    EXPECT_EQ(tether::tetherd_exec_command(), "/opt/tether.AppImage --daemon");
+}
+
+TEST_F(ServiceTest, WhichProgramFindsOnlyWhatIsExecutable) {
+    const fs::path bin = root_ / "bin";
+    fs::create_directories(bin);
+    std::ofstream(bin / "tether-fake") << "#!/bin/sh\n";
+    std::ofstream(bin / "tether-data") << "not a program\n";
+    fs::permissions(bin / "tether-fake", fs::perms::owner_all);
+
+    const tether::testing::ScopedEnv path("PATH", bin.string());
+
+    EXPECT_EQ(tether::which_program("tether-fake"), (bin / "tether-fake").string());
+    EXPECT_TRUE(tether::which_program("tether-data").empty());
+    EXPECT_TRUE(tether::which_program("tether-missing").empty());
+}


### PR DESCRIPTION
Second half of #157, split as you asked. Independent of #160 — either can merge first, in either order.

No installer, no `curl | sh`, no auto-update, no `--self-update`/`--uninstall`. `scripts/install.sh` is gone, along with the `update_plan`/`remove_plan`/`installer_path`/`running_flavor`/`detect_package_manager` half of `service.cpp` that only existed to serve it.

### What is here

```
--status   what the daemon is doing: devices, links, recent transfers
--pending  the Wi-Fi pairing requests waiting, with their fingerprints
```

Both read the `state_snapshot` the GTK app already uses. They parse only the first line of the reply, so a broadcast arriving mid-request cannot turn into a parse error.

A `tetherd.service` user unit comes with them. The distro packages install it into `/usr/lib/systemd/user`; a portable build has no package to do that, so `tether --install-service` writes a copy into `~/.config/systemd/user/tetherd.service` with `ExecStart` pointed at wherever that build actually lives (AppImage, flatpak, sibling binary, or `$PATH`). Neither path enables or starts anything: the unit is written, the commands are printed, the choice stays with the user. `--uninstall-service` takes it back.

**The wrong-path bug you hit was `install.sh`, not this.** It was writing to `~/.config/tether/systemd/user/...`. `install_tetherd_service()` has always written `<config>/systemd/user/tetherd.service`, and there is now a test asserting exactly that path.

### The spawn_daemon() bug

You were right, and the mechanism is slightly worse than an orphan. `UnixServer::start()` unlinks the socket before binding, so systemd's tetherd takes the unix socket happily — but `TcpServer::start()` then cannot bind 5134, which the spawned daemon still holds, and `src/daemon/main.cpp` returns 1. With `Restart=on-failure` and `RestartSec=3` that is the restart loop, with two daemons running and the older one still serving.

Three changes, smallest first:

1. **Clients stop spawning once the unit is enabled.** `spawn_daemon()` returns early if `~/.config/systemd/user/default.target.wants/tetherd.service` exists — the symlink `systemctl --user enable` writes. Filesystem check, no subprocess. This is the durable half: after enabling, no client can create a competitor.
2. **The unit takes over a daemon spawned before it.** `ExecStartPre=-/usr/bin/pkill -x tetherd`, leading `-` so a missing pkill is not fatal. This covers the exact order you described: `tether status` first, enable second.
3. **The loop is bounded.** `StartLimitIntervalSec=60` / `StartLimitBurst=3`, so any remaining way into that state fails visibly instead of spinning.

(2) is the one I would expect you to push back on — killing by process name from a unit is blunt. If you would rather the daemon itself refuse to start when another holds the port, or exit 0 so systemd does not treat it as a failure, say which and I will do that instead; it is a small change either way.

### Checked

- `test/test_service.cpp` covers unit rendering, the install/uninstall round trip through an explicit config dir, uninstalling what was never installed, the AppImage `ExecStart`, and `which_program`.
- I ran those assertions locally against a CMake-equivalent generated `packaging.hpp` (14/14), since the full tree needs wayland/avahi/libsecret dev packages this box does not have. CI is the first full compile.
- `po/update-pot.sh --check` and `po/check-catalogs.sh` both pass. 28 new strings, translated in all 15 catalogs, with the `systemctl`/`loginctl` command lines left verbatim inside the translated blocks and `%s` preserved.
- `docs/HEADLESS.md` is rewritten around the package/portable split rather than an installer. It uses the flag spellings so it stays correct whether or not #160 lands; if it does, I will sweeten it to subcommands in the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)